### PR TITLE
feat: add app entry and placeholder view

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+// MARK: - 仮のコンテンツビュー
+// 開発初期段階の動作確認用としてテキストのみを表示する
+struct ContentView: View {
+    var body: some View {
+        // 画面中央に簡単なメッセージを配置
+        Text("KnightCards 開発中…")
+            .font(.title)
+            .padding()
+    }
+}
+
+// MARK: - プレビュー
+#Preview {
+    // Xcode の Canvas 上で ContentView を表示するためのプレビュー
+    ContentView()
+}
+

--- a/KnightCardsApp.swift
+++ b/KnightCardsApp.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+// MARK: - アプリのエントリーポイント
+// `@main` 属性を付与した構造体からアプリが開始される
+@main
+struct KnightCardsApp: App {
+    var body: some Scene {
+        WindowGroup {
+            // アプリ起動時に最初に表示するビュー
+            // 現在は仮の画面である `ContentView` を表示
+            ContentView()
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add app entry `KnightCardsApp` using SwiftUI
- add placeholder `ContentView` for development testing

## Testing
- `swiftc KnightCardsApp.swift ContentView.swift Game/Models.swift 2>&1 | head -n 20` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68be46610c28832c8a58ef1c65500a7b