### PR TITLE
Add SpriteKit GameScene with grid and tap handling

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -1,0 +1,145 @@
+import SpriteKit
+
+/// GameCore とのやり取りのためのプロトコル
+/// - ゲームロジック側で実装し、タップされたマスに対する移動処理を担当する
+protocol GameCoreProtocol: AnyObject {
+    /// 指定されたマスをタップした際に呼び出される
+    /// - Parameter point: タップされたマスの座標
+    func handleTap(at point: GridPoint)
+}
+
+/// 盤面と駒を描画し、タップ入力を GameCore に渡すシーン
+class GameScene: SKScene {
+    /// ゲームロジックを保持する参照
+    weak var gameCore: GameCoreProtocol?
+
+    /// 現在の盤面状態
+    private var board = Board()
+
+    /// 1 マスのサイズ
+    private var tileSize: CGFloat = 0
+
+    /// グリッドの左下原点
+    private var gridOrigin: CGPoint = .zero
+
+    /// 各マスに対応するノードを保持
+    private var tileNodes: [GridPoint: SKShapeNode] = [:]
+
+    /// 駒を表すノード
+    private var knightNode: SKShapeNode?
+
+    // MARK: - シーン初期化
+
+    override func didMove(to view: SKView) {
+        super.didMove(to: view)
+
+        /// 背景色を黒に統一
+        backgroundColor = .black
+
+        /// マスのサイズと原点を計算
+        calculateLayout()
+
+        /// グリッドと駒を生成
+        setupGrid()
+        setupKnight()
+
+        /// 初期状態として中央を踏破済みに表示
+        updateTileColors()
+    }
+
+    /// 画面サイズからマスのサイズと原点を算出する
+    private func calculateLayout() {
+        let length = min(size.width, size.height)
+        tileSize = length / CGFloat(Board.size)
+        let offsetX = (size.width - tileSize * CGFloat(Board.size)) / 2
+        let offsetY = (size.height - tileSize * CGFloat(Board.size)) / 2
+        gridOrigin = CGPoint(x: offsetX, y: offsetY)
+    }
+
+    /// 5×5 のグリッドを描画
+    private func setupGrid() {
+        for y in 0..<Board.size {
+            for x in 0..<Board.size {
+                let rect = CGRect(
+                    x: gridOrigin.x + CGFloat(x) * tileSize,
+                    y: gridOrigin.y + CGFloat(y) * tileSize,
+                    width: tileSize,
+                    height: tileSize
+                )
+                let node = SKShapeNode(rect: rect)
+                node.strokeColor = .white
+                node.lineWidth = 1
+                node.fillColor = .clear
+                addChild(node)
+                let point = GridPoint(x: x, y: y)
+                tileNodes[point] = node
+            }
+        }
+    }
+
+    /// 駒を生成して中央に配置
+    private func setupKnight() {
+        let radius = tileSize * 0.4
+        let node = SKShapeNode(circleOfRadius: radius)
+        node.fillColor = .white
+        node.strokeColor = .clear
+        node.position = position(for: GridPoint.center)
+        addChild(node)
+        knightNode = node
+    }
+
+    /// 指定座標に対応するシーン上の位置を返す
+    /// - Parameter point: グリッド座標
+    /// - Returns: シーン上の中心座標
+    private func position(for point: GridPoint) -> CGPoint {
+        let x = gridOrigin.x + CGFloat(point.x) * tileSize + tileSize / 2
+        let y = gridOrigin.y + CGFloat(point.y) * tileSize + tileSize / 2
+        return CGPoint(x: x, y: y)
+    }
+
+    /// 盤面の状態を更新し、踏破済みマスの色を反映する
+    /// - Parameter board: 新しい盤面
+    func updateBoard(_ board: Board) {
+        self.board = board
+        updateTileColors()
+    }
+
+    /// 各マスの色を踏破状態に合わせて更新する
+    private func updateTileColors() {
+        for (point, node) in tileNodes {
+            if board.isVisited(point) {
+                node.fillColor = .gray
+            } else {
+                node.fillColor = .clear
+            }
+        }
+    }
+
+    /// 駒を指定座標へ移動する
+    /// - Parameter point: 移動先の座標
+    func moveKnight(to point: GridPoint) {
+        let destination = position(for: point)
+        let move = SKAction.move(to: destination, duration: 0.2)
+        knightNode?.run(move)
+    }
+
+    // MARK: - タップ処理
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+        let location = touch.location(in: self)
+        guard let point = gridPoint(from: location) else { return }
+        gameCore?.handleTap(at: point)
+    }
+
+    /// シーン上の座標からグリッド座標を算出する
+    /// - Parameter location: シーン上のタッチ位置
+    /// - Returns: 対応するマスの座標。盤外なら nil。
+    private func gridPoint(from location: CGPoint) -> GridPoint? {
+        let x = Int((location.x - gridOrigin.x) / tileSize)
+        let y = Int((location.y - gridOrigin.y) / tileSize)
+        let point = GridPoint(x: x, y: y)
+        return board.contains(point) ? point : nil
+    }
+}
+


### PR DESCRIPTION
## Summary
- draw a 5×5 grid and knight piece using SpriteKit
- mark visited tiles in gray and center start
- forward tap input to GameCore via protocol hook

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftc Game/GameScene.swift Game/Models.swift -o /tmp/app` *(fails: no such module 'SpriteKit')*


------
https://chatgpt.com/codex/tasks/task_e_68be47949634832cb9c7ac6df9486328