### PR TITLE
ゲーム画面にSpriteKitと手札UIを追加

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,13 +1,11 @@
 import SwiftUI
 
-// MARK: - 仮のコンテンツビュー
-// 開発初期段階の動作確認用としてテキストのみを表示する
+// MARK: - ゲーム画面へのエントリービュー
+// 現時点では `GameView` を直接表示し、後にナビゲーション構造を追加する想定
 struct ContentView: View {
     var body: some View {
-        // 画面中央に簡単なメッセージを配置
-        Text("KnightCards 開発中…")
-            .font(.title)
-            .padding()
+        // SpriteKit を埋め込んだゲーム画面を表示
+        GameView()
     }
 }
 

--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Combine
+
+/// ゲーム全体の進行と状態を管理するクラス
+/// - 備考: SwiftUI から監視するため `ObservableObject` に準拠
+final class GameCore: ObservableObject {
+    // MARK: - 公開プロパティ
+    /// プレイヤーの現在位置
+    @Published private(set) var position: GridPoint = .center
+    /// 盤面情報（踏破状態など）
+    @Published private(set) var board = Board()
+    /// 手札3枚
+    @Published private(set) var hand: [MoveCard] = []
+    /// 先読み1枚
+    @Published private(set) var nextCard: MoveCard = MoveCard.all.first!
+
+    // MARK: - 内部プロパティ
+    /// 残りの山札
+    private var deck: [MoveCard] = []
+
+    // MARK: - 初期化
+    init() {
+        // 山札を初期化して手札・先読みを配る
+        resetDeck()
+        hand = (0..<3).map { _ in drawCard() }
+        nextCard = drawCard()
+    }
+
+    // MARK: - 山札管理
+    /// 山札が空になったら全カードをシャッフルし直す
+    private func resetDeck() {
+        deck = MoveCard.all.shuffled()
+    }
+
+    /// 山札から1枚引く
+    private func drawCard() -> MoveCard {
+        if deck.isEmpty { resetDeck() }
+        return deck.removeFirst()
+    }
+
+    // MARK: - カード選択処理
+    /// 手札からカードを選んだ際の処理
+    /// - Parameter index: 選択したカードの手札インデックス
+    func playCard(at index: Int) {
+        guard hand.indices.contains(index) else { return }
+        let card = hand[index]
+
+        // 移動後の座標を計算
+        let target = position.offset(dx: card.dx, dy: card.dy)
+
+        // 盤面内であれば移動を反映
+        if board.contains(target) {
+            position = target
+            board.markVisited(target)
+        }
+
+        // 使用したスロットを先読みカードで埋める
+        hand[index] = nextCard
+        // 次の先読みカードを引く
+        nextCard = drawCard()
+    }
+}

--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -1,0 +1,20 @@
+import SpriteKit
+
+/// 盤面や駒を描画する `SKScene`
+/// - 備考: 現時点ではレイアウトのみ。今後の拡張で盤面描画やタップ処理を実装予定
+final class GameScene: SKScene {
+    /// ゲームロジックへの参照
+    private let core: GameCore
+
+    /// 初期化時にゲームロジックを受け取り、シーンサイズを設定する
+    init(size: CGSize, core: GameCore) {
+        self.core = core
+        super.init(size: size)
+        scaleMode = .resizeFill
+        backgroundColor = .black
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Game/MoveCard.swift
+++ b/Game/MoveCard.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// 駒をどの方向に何マス動かすかを表すカード
+/// - 仕様: ナイト移動8種 + 直線/斜めの2マス移動8種の計16種
+struct MoveCard: Identifiable {
+    /// 一意な識別子（デバッグやリスト表示用）
+    let id = UUID()
+    /// x方向の移動量（右が正）
+    let dx: Int
+    /// y方向の移動量（上が正）
+    let dy: Int
+
+    /// 表示用ラベル
+    /// - 備考: 現状はシンプルに "dx,dy" 形式で返す
+    var label: String {
+        "\(dx),\(dy)"
+    }
+}
+
+extension MoveCard {
+    /// 16種類のカードをあらかじめ定義した配列
+    /// 山札の初期化や再構築で利用する
+    static let all: [MoveCard] = [
+        // MARK: - ナイト移動 8種
+        MoveCard(dx: 1, dy: 2),
+        MoveCard(dx: 2, dy: 1),
+        MoveCard(dx: -1, dy: 2),
+        MoveCard(dx: -2, dy: 1),
+        MoveCard(dx: 1, dy: -2),
+        MoveCard(dx: 2, dy: -1),
+        MoveCard(dx: -1, dy: -2),
+        MoveCard(dx: -2, dy: -1),
+        // MARK: - 直線/斜めの2マス移動 8種
+        MoveCard(dx: 2, dy: 0),
+        MoveCard(dx: -2, dy: 0),
+        MoveCard(dx: 0, dy: 2),
+        MoveCard(dx: 0, dy: -2),
+        MoveCard(dx: 2, dy: 2),
+        MoveCard(dx: -2, dy: 2),
+        MoveCard(dx: 2, dy: -2),
+        MoveCard(dx: -2, dy: -2)
+    ]
+}

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import SpriteKit
+
+/// SpriteKit の `GameScene` を SwiftUI に埋め込み、
+/// 画面下に手札3枚と先読み1枚を表示するビュー
+struct GameView: View {
+    // MARK: - 状態
+    /// ゲームロジックのインスタンス
+    @StateObject private var core = GameCore()
+
+    /// SpriteKit のシーンを生成
+    /// - 備考: サイズは仮の 300×300。実装が進んだら端末サイズに応じて調整する
+    private var scene: SKScene {
+        GameScene(size: CGSize(width: 300, height: 300), core: core)
+    }
+
+    // MARK: - ビュー本体
+    var body: some View {
+        VStack(spacing: 0) {
+            // ゲーム盤面（SpriteKit）
+            SpriteView(scene: scene)
+                .ignoresSafeArea()
+                .frame(minHeight: 300)
+
+            // 手札表示エリア
+            cardArea
+                .padding()
+                .background(Color(white: 0.2))
+        }
+    }
+
+    /// 手札3枚と先読み1枚を並べるエリア
+    private var cardArea: some View {
+        HStack(alignment: .center, spacing: 16) {
+            // 手札3枚をボタンとして表示
+            ForEach(core.hand.indices, id: \.self) { index in
+                let card = core.hand[index]
+                Button {
+                    // カードを選択したら GameCore に処理を依頼
+                    core.playCard(at: index)
+                } label: {
+                    cardView(card)
+                }
+            }
+
+            // 手札との間に適度なスペースを挟む
+            Spacer(minLength: 24)
+
+            // 先読みカードは押下不可のプレースホルダーとして表示
+            cardView(core.nextCard)
+                .opacity(0.5)
+        }
+    }
+
+    /// 共通のカード表示ビュー
+    /// - Parameter card: 表示したいカード
+    /// - Returns: 60x90pt の角丸矩形にラベルを載せたビュー
+    private func cardView(_ card: MoveCard) -> some View {
+        Text(card.label)
+            .frame(width: 60, height: 90)
+            .background(Color.white)
+            .foregroundColor(.black)
+            .cornerRadius(8)
+    }
+}
+
+// MARK: - プレビュー
+#Preview {
+    GameView()
+}


### PR DESCRIPTION
## Summary
- MoveCardとGameCoreを実装し、手札と先読みカードを管理
- SpriteKitのGameSceneをSwiftUIへ埋め込むGameViewを追加
- ContentViewからGameViewを表示するように変更

## Testing
- `swift build` *(Package.swiftが無いため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68be47973750832cb144c34b618af41f