### PR TITLE
Add result view with leaderboard and ads

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -1,0 +1,47 @@
+import Foundation
+import GoogleMobileAds
+import UIKit
+
+/// インタースティシャル広告を管理するサービス
+/// ゲーム終了時に ResultView から呼び出される
+final class AdsService: NSObject, ObservableObject {
+    /// シングルトンインスタンス
+    static let shared = AdsService()
+    
+    /// ロード済みのインタースティシャル広告
+    private var interstitial: GADInterstitialAd?
+    
+    private override init() {
+        super.init()
+        // アプリ起動直後に広告をプリロードしておく
+        loadInterstitial()
+    }
+    
+    /// インタースティシャル広告を読み込む
+    private func loadInterstitial() {
+        let request = GADRequest()
+        // テスト用広告ユニット ID（実装時に差し替え）
+        GADInterstitialAd.load(withAdUnitID: "ca-app-pub-3940256099942544/4411468910", request: request) { [weak self] ad, error in
+            if let error = error {
+                // 読み込み失敗時はログを出力
+                print("広告の読み込み失敗: \(error.localizedDescription)")
+                return
+            }
+            // 正常に取得できたら保持
+            self?.interstitial = ad
+        }
+    }
+    
+    /// 準備済みの広告があれば表示する
+    func showInterstitial() {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let root = scene.windows.first?.rootViewController,
+              let ad = interstitial else { return }
+        
+        // 現在のルートビューから広告を表示
+        ad.present(fromRootViewController: root)
+        // 表示後は破棄して次回に備えて再読み込み
+        interstitial = nil
+        loadInterstitial()
+    }
+}

--- a/Services/GameCenterService.swift
+++ b/Services/GameCenterService.swift
@@ -1,0 +1,30 @@
+import Foundation
+import GameKit
+import UIKit
+
+/// Game Center 関連の操作をまとめたサービス
+final class GameCenterService: NSObject, GKGameCenterControllerDelegate {
+    /// シングルトンインスタンス
+    static let shared = GameCenterService()
+    
+    private override init() {}
+    
+    /// ランキング画面を表示する
+    func showLeaderboard() {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let root = scene.windows.first?.rootViewController else { return }
+        
+        // リーダーボード用のコントローラを生成
+        let vc = GKGameCenterViewController()
+        vc.gameCenterDelegate = self
+        vc.viewState = .leaderboards
+        
+        // ルートビューからモーダル表示
+        root.present(vc, animated: true)
+    }
+    
+    /// Game Center コントローラの閉じるボタンが押された際に呼ばれる
+    func gameCenterViewControllerDidFinish(_ gameCenterViewController: GKGameCenterViewController) {
+        gameCenterViewController.dismiss(animated: true)
+    }
+}

--- a/UI/ResultView.swift
+++ b/UI/ResultView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+/// ゲーム終了時の結果を表示するビュー
+/// 手数・ベスト記録・各種ボタンをまとめて配置する
+struct ResultView: View {
+    /// 今回のプレイで消費した手数
+    let moves: Int
+    
+    /// 再戦処理を外部から受け取るクロージャ
+    let onRetry: () -> Void
+    
+    /// ベスト手数を `UserDefaults` に保存する
+    @AppStorage("best_moves_5x5") private var bestMoves: Int = .max
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            // MARK: - 手数表示
+            Text("手数: \(moves)")
+                .font(.title)
+                .padding(.top, 32)
+            
+            // MARK: - ベスト記録表示（未記録の場合は '-'）
+            Text("ベスト: \(bestMovesText)")
+                .font(.headline)
+            
+            // MARK: - リトライボタン
+            Button(action: {
+                onRetry()
+            }) {
+                Text("リトライ")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            
+            // MARK: - Game Center ランキングボタン
+            Button(action: {
+                GameCenterService.shared.showLeaderboard()
+            }) {
+                Text("ランキング")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding()
+        .onAppear {
+            // ビュー表示時に広告表示をトリガー
+            AdsService.shared.showInterstitial()
+            // ベスト記録の更新を判定
+            updateBest()
+        }
+    }
+    
+    /// ベスト記録を表示用の文字列に変換
+    private var bestMovesText: String {
+        bestMoves == .max ? "-" : String(bestMoves)
+    }
+    
+    /// ベスト記録を更新する
+    private func updateBest() {
+        if moves < bestMoves {
+            bestMoves = moves
+        }
+    }
+}
+
+struct ResultView_Previews: PreviewProvider {
+    static var previews: some View {
+        ResultView(moves: 30, onRetry: {})
+    }
+}


### PR DESCRIPTION
## Summary
- Add SwiftUI ResultView showing moves, best record, retry, and Game Center ranking buttons
- Integrate interstitial ads trigger via AdsService
- Provide GameCenterService for leaderboard presentation

## Testing
- `swiftc UI/ResultView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68be47993ea4832cbc73ef634f80324f