### PR TITLE
Add StoreService and integrate ad removal

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import GoogleMobileAds
 import UIKit
+import SwiftUI
 
 /// インタースティシャル広告を管理するサービス
 /// ゲーム終了時に ResultView から呼び出される
@@ -10,15 +11,23 @@ final class AdsService: NSObject, ObservableObject {
     
     /// ロード済みのインタースティシャル広告
     private var interstitial: GADInterstitialAd?
+
+    /// 広告除去購入済みフラグ（UserDefaults と連携）
+    @AppStorage("remove_ads") private var removeAds: Bool = false
     
     private override init() {
         super.init()
-        // アプリ起動直後に広告をプリロードしておく
-        loadInterstitial()
+        // 購入済みでなければアプリ起動直後に広告をプリロードしておく
+        if !removeAds {
+            loadInterstitial()
+        }
     }
     
     /// インタースティシャル広告を読み込む
     private func loadInterstitial() {
+        // 広告除去購入済みであれば何もしない
+        guard !removeAds else { return }
+
         let request = GADRequest()
         // テスト用広告ユニット ID（実装時に差し替え）
         GADInterstitialAd.load(withAdUnitID: "ca-app-pub-3940256099942544/4411468910", request: request) { [weak self] ad, error in
@@ -34,14 +43,21 @@ final class AdsService: NSObject, ObservableObject {
     
     /// 準備済みの広告があれば表示する
     func showInterstitial() {
-        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+        // 購入済みなら広告を表示しない
+        guard !removeAds,
+              let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let root = scene.windows.first?.rootViewController,
               let ad = interstitial else { return }
-        
+
         // 現在のルートビューから広告を表示
         ad.present(fromRootViewController: root)
-        // 表示後は破棄して次回に備えて再読み込み
+        // 表示後は破棄して次回に備えて再読み込み（未購入時のみ）
         interstitial = nil
         loadInterstitial()
+    }
+
+    /// 購入済みのときに既存広告を破棄し、以降読み込まないようにする
+    func disableAds() {
+        interstitial = nil
     }
 }

--- a/Services/StoreService.swift
+++ b/Services/StoreService.swift
@@ -1,0 +1,123 @@
+import Foundation
+import StoreKit
+import SwiftUI
+
+/// StoreKit2 を用いた課金処理をまとめたサービス
+/// `remove_ads` 商品の購入・復元・状態保持を担当する
+@MainActor
+final class StoreService: ObservableObject {
+    /// シングルトンインスタンス
+    static let shared = StoreService()
+
+    /// 取得済みのプロダクト一覧（現在は広告除去のみ）
+    @Published var products: [Product] = []
+
+    /// 広告除去購入済みフラグ
+    /// - `true` の場合は AdsService が広告を読み込まない
+    @AppStorage("remove_ads") private var removeAds: Bool = false
+
+    private init() {
+        // 初期化と同時に商品情報の取得とトランザクション監視を開始
+        Task {
+            await fetchProducts()
+            await updatePurchasedStatus()
+            await observeTransactions()
+        }
+    }
+
+    // MARK: - Product
+
+    /// `remove_ads` 商品の情報を取得する
+    func fetchProducts() async {
+        do {
+            // App Store Connect で登録した Product ID を指定
+            products = try await Product.products(for: ["remove_ads"])
+        } catch {
+            // 失敗時はログ出力のみ（ユーザーには表示しない）
+            print("商品情報の取得に失敗: \(error)")
+        }
+    }
+
+    // MARK: - Purchase
+
+    /// 広告除去を購入する
+    func purchaseRemoveAds() async {
+        // 事前に取得したプロダクトを検索
+        guard let product = products.first(where: { $0.id == "remove_ads" }) else { return }
+
+        do {
+            // 購入フローを開始
+            let result = try await product.purchase()
+            switch result {
+            case .success(let verification):
+                // トランザクションの検証
+                if let transaction = checkVerified(verification), transaction.productID == "remove_ads" {
+                    // フラグ反映と広告停止
+                    applyRemoveAds()
+                    // 消費型ではないので明示的に finish
+                    await transaction.finish()
+                }
+            default:
+                // キャンセルや待機中の場合は特に何もしない
+                break
+            }
+        } catch {
+            print("購入処理でエラー: \(error)")
+        }
+    }
+
+    /// 外部から呼び出して購入済み情報を更新する
+    private func applyRemoveAds() {
+        removeAds = true
+        // 広告サービスに通知して表示を停止させる
+        AdsService.shared.disableAds()
+    }
+
+    // MARK: - Transaction
+
+    /// 購入済みトランザクションを確認しフラグを反映する
+    private func updatePurchasedStatus() async {
+        // 現在有効なトランザクションをすべてチェック
+        for await result in Transaction.currentEntitlements {
+            if let transaction = checkVerified(result), transaction.productID == "remove_ads" {
+                applyRemoveAds()
+            }
+        }
+    }
+
+    /// トランザクション更新の監視を開始する
+    private func observeTransactions() async {
+        // 非同期シーケンスとして更新を受け取る
+        for await result in Transaction.updates {
+            if let transaction = checkVerified(result), transaction.productID == "remove_ads" {
+                applyRemoveAds()
+                await transaction.finish()
+            }
+        }
+    }
+
+    /// StoreKit2 の検証結果を確認する汎用メソッド
+    private func checkVerified<T>(_ result: VerificationResult<T>) -> T? {
+        switch result {
+        case .unverified:
+            // 署名が正しくない場合は無視
+            return nil
+        case .verified(let safe):
+            return safe
+        }
+    }
+
+    // MARK: - Restore
+
+    /// 「購入を復元」ボタンなどから呼び出される処理
+    /// App Store と同期して過去の購入を再評価する
+    func restorePurchases() async {
+        do {
+            try await AppStore.sync()
+            // `AppStore.sync()` 実行後は `Transaction.updates` が再度流れるため
+            // `updatePurchasedStatus()` を明示的に呼ぶ必要はない
+        } catch {
+            print("購入の復元に失敗: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add StoreService using StoreKit2 to purchase and restore the `remove_ads` product
- wire AdsService to @AppStorage `remove_ads` and stop loading/ showing ads when purchased

## Testing
- `swift test` *(fails: no such module 'SpriteKit')*

------
https://chatgpt.com/codex/tasks/task_e_68be4c65ed54832c883662dd199554af