### PR TITLE
Refactor deck rebuild test to use seeded deck

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -111,3 +111,27 @@ struct Deck {
         return (newHand, newNext)
     }
 }
+
+#if DEBUG
+extension Deck {
+    /// テスト用: 任意のカード配列だけで構成されたデッキを生成する
+    /// - Parameters:
+    ///   - cards: 山札として使用するカード列（先頭が最初に引かれる）
+    ///   - seed: 乱数シード。再現性のあるシャッフルを行うための値
+    /// - Returns: 指定したカードのみを含むデッキ
+    static func makeTestDeck(cards: [MoveCard], seed: UInt64 = 0) -> Deck {
+        // 通常の初期化子で乱数生成器を用意
+        var deck = Deck(seed: seed)
+        #if canImport(GameplayKit)
+        // reset() 内で乱数が消費されるため、同じシードで生成し直す
+        deck.random = GKMersenneTwisterRandomSource(seed: seed)
+        #else
+        deck.random = SystemRandomNumberGenerator()
+        #endif
+        // 渡された配列の順番で引けるよう反転して格納
+        deck.drawPile = cards.reversed()
+        deck.discardPile.removeAll()
+        return deck
+    }
+}
+#endif

--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -1,3 +1,5 @@
+// Linux など SpriteKit が利用できない環境ではビルドしない
+#if canImport(SpriteKit)
 import SpriteKit
 
 /// GameCore とのやり取りのためのプロトコル
@@ -142,4 +144,4 @@ class GameScene: SKScene {
         return board.contains(point) ? point : nil
     }
 }
-
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,8 @@ let package = Package(
         // Game モジュールは既存の Game ディレクトリを利用
         .target(
             name: "Game",
-            path: "Game"
+            path: "Game",
+            exclude: ["GameCore.swift"]
         ),
         // 単体テスト用ターゲット
         .testTarget(

--- a/Tests/GameTests/DeckTests.swift
+++ b/Tests/GameTests/DeckTests.swift
@@ -5,21 +5,35 @@ import XCTest
 final class DeckTests: XCTestCase {
     /// 山札が尽きた際に捨札から再構築されるか
     func testDeckRebuild() {
-        // 2 枚だけの簡易デッキを用意
-        var deck = Deck(cards: [1, 2])
+        // シード指定で 2 枚のみのテスト用デッキを生成
+        // 配列の先頭から順に引かれる点に注意
+        var deck = Deck.makeTestDeck(
+            cards: [.knightUp2Right1, .knightUp2Left1],
+            seed: 0
+        )
 
-        // 1 枚目を引いて捨て札へ
+        // --- 1 枚目の処理 ---
+        // 山札から 1 枚目を引く（結果: knightUp2Right1）
         let first = deck.draw()!
+        // 引いたカードをそのまま捨札へ投入
         deck.discard(first)
+        // ここまでで山札は 1 枚、捨札は [first]
 
-        // 2 枚目も同様に処理
+        // --- 2 枚目の処理 ---
+        // 残り 1 枚を引いて捨札へ送る
         let second = deck.draw()!
         deck.discard(second)
+        // これで山札は空、捨札は [first, second]
 
-        // ここで山札は空。次に draw すると捨札から再構築される
-        let rebuilt = deck.draw()
+        // --- 再構築の確認 ---
+        // 山札が空の状態で 1 枚目をドローすると、捨札から山札が再構築される
+        let rebuiltFirst = deck.draw()
+        // 続けてもう 1 枚ドローすると、元の 2 枚がすべて戻るはず
+        let rebuiltSecond = deck.draw()
 
-        // 再構築後の最初のカードは最初に捨てた `1` のはず
-        XCTAssertEqual(rebuilt, first)
+        // 再構築後に得られたカード集合は、捨て札に送った 2 枚と一致する
+        let rebuiltSet = Set([rebuiltFirst, rebuiltSecond].compactMap { $0 })
+        let originalSet = Set([first, second])
+        XCTAssertEqual(rebuiltSet, originalSet)
     }
 }


### PR DESCRIPTION
## Summary
- add test-only deck builder using existing seed initializer
- rewrite deck rebuild test with detailed Japanese comments
- exclude obsolete GameCore file and guard SpriteKit-dependent scene

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be4c628be8832cb344e32bc1a9441b