### PR TITLE
ゲームクリア時に結果画面とスコア送信を追加

### DIFF
--- a/Services/GameCenterService.swift
+++ b/Services/GameCenterService.swift
@@ -6,9 +6,25 @@ import UIKit
 final class GameCenterService: NSObject, GKGameCenterControllerDelegate {
     /// シングルトンインスタンス
     static let shared = GameCenterService()
-    
+
     private override init() {}
-    
+
+    /// スコアを Game Center のリーダーボードへ送信する
+    /// - Parameter score: 送信する手数（少ないほど高評価）
+    func submitScore(_ score: Int) {
+        GKLeaderboard.submitScore(
+            score,
+            context: 0,
+            player: GKLocalPlayer.local,
+            leaderboardIDs: ["kc_moves_5x5"]
+        ) { error in
+            // エラーが発生した場合はログ出力のみ行う
+            if let error {
+                print("Game Center スコア送信失敗: \(error.localizedDescription)")
+            }
+        }
+    }
+
     /// ランキング画面を表示する
     func showLeaderboard() {
         guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -8,6 +8,9 @@ import Game
 struct GameView: View {
     /// ゲームロジックを保持する ObservableObject
     @StateObject private var core = GameCore()
+    /// 結果画面を表示するかどうかのフラグ
+    /// - NOTE: クリア時に true となり ResultView をシート表示する
+    @State private var showingResult = false
     /// SpriteKit のシーン。初期化時に一度だけ生成して再利用する
     private let scene: GameScene
 
@@ -72,6 +75,23 @@ struct GameView: View {
             // 画面全体を黒背景に統一
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.black)
+        }
+        // progress が .cleared へ変化したタイミングで結果画面を表示
+        .onChange(of: core.progress) { newValue in
+            guard newValue == .cleared else { return }
+            // Game Center へスコア送信
+            GameCenterService.shared.submitScore(core.score)
+            // 結果画面を開く
+            showingResult = true
+        }
+        // シートで結果画面を表示
+        .sheet(isPresented: $showingResult) {
+            ResultView(moves: core.score) {
+                // リトライ時はゲームを初期化して再開
+                core.reset()
+                // シートを閉じる
+                showingResult = false
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- ゲームクリアを監視して結果画面をモーダル表示
- Game Centerへ手数を送信するAPIを実装
- リトライでGameCoreをリセットしてゲーム再開

## Testing
- `swift test` *(fails: no such module 'SpriteKit')*

------
https://chatgpt.com/codex/tasks/task_e_68be4c67dedc832ca1d3948213b9c4e0