### PR TITLE
テスト用デッキ生成関数追加と再構築テスト整理

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -111,3 +111,20 @@ struct Deck {
         return (newHand, newNext)
     }
 }
+
+#if DEBUG
+/// テストコードから利用するための拡張
+/// - Note: 既存の初期化子 `init(seed:)` を基に、任意のカード列を山札として設定する。
+///         本体コードへの影響を避けるため `DEBUG` ビルド時のみ有効。
+extension Deck {
+    /// 任意のカード配列を山札として持つテスト用デッキを生成する
+    /// - Parameter cards: 山札にしたいカード配列（末尾がトップ）
+    /// - Returns: 指定したカードのみを含むデッキ
+    static func makeTestDeck(cards: [MoveCard]) -> Deck {
+        var deck = Deck(seed: 0) // 乱数シードを固定して初期化
+        deck.drawPile = cards    // ファイル内拡張のため private にアクセス可能
+        deck.discardPile = []    // 捨札は空で開始
+        return deck
+    }
+}
+#endif

--- a/Tests/GameTests/DeckTests.swift
+++ b/Tests/GameTests/DeckTests.swift
@@ -5,20 +5,21 @@ import XCTest
 final class DeckTests: XCTestCase {
     /// 山札が尽きた際に捨札から再構築されるか
     func testDeckRebuild() {
-        // 乱数シードを固定してデッキを生成
-        var deck = Deck(seed: 0)
+        // テスト専用の小規模デッキを 1 枚だけ用意
+        // 末尾が山札のトップになる点に注意
+        var deck = Deck.makeTestDeck(cards: [.knightUp2Right1])
 
-        // 80 枚すべてのカードを引いて捨札に送る
-        // MoveCard は 16 種 × 5 枚 = 80 枚
-        for _ in 0..<(MoveCard.allCases.count * 5) {
-            let card = deck.draw()!
-            deck.discard(card)
-        }
+        // --- 1 回目のドロー ---
+        // 山札から 1 枚引き、同じカードを捨札へ送る
+        let firstDraw = deck.draw()!
+        deck.discard(firstDraw)
 
-        // 山札が空になった状態で draw すると捨札から再構築される
+        // --- 2 回目のドロー ---
+        // 山札が空になったため、捨札から自動的に再構築される
+        // この時点で捨札には 1 枚だけ存在するため、同じカードが戻るはず
         let rebuilt = deck.draw()
 
-        // 再構築後は何らかのカードが返るはず（nil でないことを確認）
-        XCTAssertNotNil(rebuilt)
+        // 再構築後に引いたカードが最初に引いたものと一致するかを検証
+        XCTAssertEqual(rebuilt, firstDraw)
     }
 }


### PR DESCRIPTION
## 概要
- デバッグ専用のデッキ生成関数を追加
- デッキ再構築テストを小規模デッキで整理

## テスト
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be4dab2188832c89b9fc80a6cb5461