### PR TITLE
Add Game Center authentication flow

### DIFF
--- a/KnightCardsApp.swift
+++ b/KnightCardsApp.swift
@@ -4,6 +4,13 @@ import SwiftUI
 // `@main` 属性を付与した構造体からアプリが開始される
 @main
 struct KnightCardsApp: App {
+    /// イニシャライザで Game Center 認証を実行
+    /// - Note: アプリ起動時に一度だけ呼び出される
+    init() {
+        // Game Center のローカルプレイヤー認証を開始
+        GameCenterService.shared.authenticateLocalPlayer()
+    }
+
     var body: some Scene {
         WindowGroup {
             // MARK: 起動直後に表示するルートビュー

--- a/Services/GameCenterService.swift
+++ b/Services/GameCenterService.swift
@@ -9,9 +9,50 @@ final class GameCenterService: NSObject, GKGameCenterControllerDelegate {
 
     private override init() {}
 
+    /// Game Center へログイン済みかどうかを保持するフラグ
+    /// - Note: 認証に失敗した場合は `false` のままとなる
+    private(set) var isAuthenticated = false
+
+    /// ローカルプレイヤーを Game Center で認証する
+    /// - Note: アプリ起動時に一度だけ呼び出すことを想定
+    func authenticateLocalPlayer() {
+        // ローカルプレイヤーの取得
+        let player = GKLocalPlayer.local
+
+        // 認証ハンドラを設定
+        player.authenticateHandler = { [weak self] vc, error in
+            // 認証のための ViewController が渡された場合は表示を行う
+            if let vc {
+                // 最前面の ViewController を取得してモーダル表示
+                guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                      let root = scene.windows.first?.rootViewController else { return }
+                root.present(vc, animated: true)
+                return
+            }
+
+            // 認証結果を判定
+            if player.isAuthenticated {
+                // 認証成功
+                self?.isAuthenticated = true
+                print("Game Center 認証成功")
+            } else {
+                // 認証失敗: エラーメッセージをログ出力
+                self?.isAuthenticated = false
+                let message = error?.localizedDescription ?? "不明なエラー"
+                print("Game Center 認証失敗: \(message)")
+            }
+        }
+    }
+
     /// スコアを Game Center のリーダーボードへ送信する
     /// - Parameter score: 送信する手数（少ないほど高評価）
     func submitScore(_ score: Int) {
+        // 未認証の場合はスコア送信を行わない
+        guard isAuthenticated else {
+            print("Game Center 未認証のためスコア送信を中止")
+            return
+        }
+
         GKLeaderboard.submitScore(
             score,
             context: 0,
@@ -21,12 +62,20 @@ final class GameCenterService: NSObject, GKGameCenterControllerDelegate {
             // エラーが発生した場合はログ出力のみ行う
             if let error {
                 print("Game Center スコア送信失敗: \(error.localizedDescription)")
+            } else {
+                print("Game Center スコア送信成功: \(score)")
             }
         }
     }
 
     /// ランキング画面を表示する
     func showLeaderboard() {
+        // 未認証の場合はランキングを表示しない
+        guard isAuthenticated else {
+            print("Game Center 未認証のためランキング表示不可")
+            return
+        }
+
         guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let root = scene.windows.first?.rootViewController else { return }
         


### PR DESCRIPTION
## Summary
- 認証状態を保持する `GameCenterService.authenticateLocalPlayer` を実装し、成功／失敗をログ化
- Game Center 認証が未完了の場合はスコア送信・ランキング表示を抑制
- アプリ起動時に `KnightCardsApp` から認証処理を開始

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be4f17707c832c87165170d862d0f5