### PR TITLE
盤面タップ処理をGameCoreに実装

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -120,3 +120,26 @@ final class GameCore: ObservableObject {
     }
 }
 
+#if canImport(SpriteKit)
+// MARK: - GameScene からのタップ入力に対応
+extension GameCore: GameCoreProtocol {
+    /// 盤面上のマスがタップされた際に呼び出される
+    /// - Parameter point: タップされたマスの座標
+    func handleTap(at point: GridPoint) {
+        // ゲーム進行中でなければ入力を無視
+        guard progress == .playing else { return }
+
+        // タップされたマスと現在位置の差分を計算
+        let dx = point.x - current.x
+        let dy = point.y - current.y
+
+        // 差分に一致するカードを手札から検索
+        if let index = hand.firstIndex(where: { $0.dx == dx && $0.dy == dy }) {
+            // 該当カードがあればそのカードで移動処理を実行
+            playCard(at: index)
+        }
+        // 該当カードが無い場合は何もしない（無効タップ）
+    }
+}
+#endif
+

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -7,18 +7,25 @@ import Game
 /// タップで GameCore を更新する
 struct GameView: View {
     /// ゲームロジックを保持する ObservableObject
-    @StateObject private var core = GameCore()
+    /// - NOTE: `StateObject` は init 内で明示的に生成し、GameScene に渡す
+    @StateObject private var core: GameCore
     /// 結果画面を表示するかどうかのフラグ
     /// - NOTE: クリア時に true となり ResultView をシート表示する
     @State private var showingResult = false
     /// SpriteKit のシーン。初期化時に一度だけ生成して再利用する
     private let scene: GameScene
 
-    /// 初期化で GameScene を設定
+    /// 初期化で GameCore と GameScene を連結する
     init() {
+        // GameCore の生成。StateObject へ包んで保持する
+        let core = GameCore()
+        _core = StateObject(wrappedValue: core)
+
         // GameScene はインスタンス生成後にサイズとスケールを指定
         let scene = GameScene()
         scene.scaleMode = .resizeFill
+        // GameScene から GameCore へタップイベントを伝えるため参照を渡す
+        scene.gameCore = core
         self.scene = scene
     }
 


### PR DESCRIPTION
## Summary
- GameCoreをGameCoreProtocolに適合させ、タップ座標に応じてカードを使用
- GameView初期化時にGameSceneへGameCoreを接続し、タップイベントを伝達

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be4f29863c832c9921fac01b611d66