### PR TITLE
設定画面で UMP プライバシーオプションフォームを表示

### DIFF
--- a/UI/SettingsView.swift
+++ b/UI/SettingsView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import UIKit
+import UserMessagingPlatform
 
 /// アプリ全体の設定をまとめたビュー
 /// 課金やプライバシー設定への導線を提供する
@@ -35,10 +37,23 @@ struct SettingsView: View {
 
                 // MARK: - プライバシー設定セクション
                 Section("プライバシー") {
-                    // UMP のプライバシー設定を再表示するボタン
+                    // UMP のプライバシー設定フォームを再表示するボタン
                     Button(action: {
-                        // 実際の UMP SDK 呼び出しは未実装のためログ出力のみ
-                        print("プライバシー設定を表示")
+                        // 現在表示中のルートビューコントローラを取得
+                        if let root = UIApplication.shared.connectedScenes
+                            .compactMap({ $0 as? UIWindowScene })
+                            .first?.windows.first?.rootViewController {
+                            // 取得したコントローラからプライバシー設定フォームを表示
+                            UMPConsentForm.presentPrivacyOptionsForm(from: root) { error in
+                                if let error {
+                                    // フォーム表示に失敗した場合の処理
+                                    // TODO: ユーザーへのエラー表示などを実装
+                                } else {
+                                    // フォーム表示に成功した場合の処理
+                                    // TODO: 必要に応じて同意状況の再評価を実装
+                                }
+                            }
+                        }
                     }) {
                         Text("プライバシー設定")
                             .frame(maxWidth: .infinity, alignment: .center)


### PR DESCRIPTION
## 概要
- 設定画面の「プライバシー設定」ボタンで `UMPConsentForm.presentPrivacyOptionsForm` を呼び出すように変更
- フォーム表示成功/失敗時のコメントを追加し、デバッグログを削除

## テスト
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be5cab7080832ca4d38039767cb1c1