### PR TITLE
リトライ時に広告表示フラグをリセット

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -96,9 +96,11 @@ struct GameView: View {
         // シートで結果画面を表示
         .sheet(isPresented: $showingResult) {
             ResultView(moves: core.score) {
-                // リトライ時はゲームを初期化して再開
+                // リトライ時はゲームを初期状態に戻して再開する
                 core.reset()
-                // シートを閉じる
+                // 新しいプレイで広告を再度表示できるようにフラグをリセット
+                AdsService.shared.resetPlayFlag()
+                // 結果画面のシートを閉じてゲーム画面へ戻る
                 showingResult = false
             }
         }


### PR DESCRIPTION
## Summary
- reset play flag after retry to allow interstitial ads on new games

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be5cb0d3f0832ca31eacceabb58624