### PR TITLE
RootView表示後にGame Center認証を実行

### DIFF
--- a/KnightCardsApp.swift
+++ b/KnightCardsApp.swift
@@ -4,13 +4,8 @@ import SwiftUI
 // `@main` 属性を付与した構造体からアプリが開始される
 @main
 struct KnightCardsApp: App {
-    /// イニシャライザで Game Center 認証を実行
-    /// - Note: アプリ起動時に一度だけ呼び出される
-    init() {
-        // Game Center のローカルプレイヤー認証を開始
-        GameCenterService.shared.authenticateLocalPlayer()
-    }
-
+    // Game Center 認証は `RootView` の表示後に実行されるため
+    // ここでは特別な初期化処理を行わない
     var body: some Scene {
         WindowGroup {
             // MARK: 起動直後に表示するルートビュー

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -3,6 +3,10 @@ import SwiftUI
 /// ゲーム画面と設定画面を切り替えるルートビュー
 /// `TabView` を用いて 2 つのタブを提供する
 struct RootView: View {
+    /// Game Center 認証済みかどうかを追跡するフラグ
+    /// - Note: `onAppear` が複数回呼ばれても二重認証を避ける
+    @State private var didAuthenticate = false
+
     var body: some View {
         TabView {
             // MARK: - ゲームタブ
@@ -17,6 +21,13 @@ struct RootView: View {
                 .tabItem {
                     Label("設定", systemImage: "gearshape")
                 }
+        }
+        .onAppear {
+            // ルート ViewController が取得できるタイミングで認証を実施
+            // Game Center のログイン UI を安全に表示できる
+            guard !didAuthenticate else { return } // 二重呼び出しを防止
+            GameCenterService.shared.authenticateLocalPlayer()
+            didAuthenticate = true
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove early Game Center authentication from app initializer
- authenticate Game Center in RootView.onAppear so root VC is ready
- document timing in Japanese comments

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be5cb0efb8832c96d6c2e259c30738