### PR TITLE
Introduce service protocols and UI test mocks

### DIFF
--- a/KnightCardsApp.swift
+++ b/KnightCardsApp.swift
@@ -1,16 +1,38 @@
 import SwiftUI
+import Foundation
 
 // MARK: - アプリのエントリーポイント
 // `@main` 属性を付与した構造体からアプリが開始される
 @main
 struct KnightCardsApp: App {
-    // Game Center 認証は `RootView` の表示後に実行されるため
-    // ここでは特別な初期化処理を行わない
+    /// Game Center サービス（本番またはテスト用）
+    private let gameCenterService: GameCenterServiceProtocol
+    /// 広告サービス（本番またはテスト用）
+    private let adsService: AdsServiceProtocol
+
+    /// イニシャライザで環境に応じたサービスを選択
+    init() {
+        // UI テスト実行時は Xcode が設定する環境変数を利用
+        let isTesting = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+        if isTesting {
+            // テスト用のダミーサービスを使用
+            self.gameCenterService = GameCenterServiceMock()
+            self.adsService = AdsServiceMock()
+        } else {
+            // 通常はシングルトンを使用
+            self.gameCenterService = GameCenterService.shared
+            self.adsService = AdsService.shared
+        }
+    }
+
     var body: some Scene {
         WindowGroup {
             // MARK: 起動直後に表示するルートビュー
             // TabView でゲームと設定を切り替える `RootView` を表示
-            RootView()
+            RootView(
+                gameCenterService: gameCenterService,
+                adsService: adsService
+            )
         }
     }
 }

--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -7,7 +7,8 @@ import UserMessagingPlatform
 
 /// インタースティシャル広告を管理するサービス
 /// ゲーム終了時に ResultView から呼び出される
-final class AdsService: NSObject, ObservableObject {
+/// - Note: `AdsServiceProtocol` を実装し、テスト時はモックへ差し替え可能
+final class AdsService: NSObject, ObservableObject, AdsServiceProtocol {
     /// シングルトンインスタンス
     static let shared = AdsService()
 

--- a/Services/GameCenterService.swift
+++ b/Services/GameCenterService.swift
@@ -3,7 +3,8 @@ import GameKit
 import UIKit
 
 /// Game Center 関連の操作をまとめたサービス
-final class GameCenterService: NSObject, GKGameCenterControllerDelegate {
+/// - Note: `GameCenterServiceProtocol` を実装し、テスト用モックとの差し替えを容易にする
+final class GameCenterService: NSObject, GKGameCenterControllerDelegate, GameCenterServiceProtocol {
     /// シングルトンインスタンス
     static let shared = GameCenterService()
 

--- a/Services/Mocks/AdsServiceMock.swift
+++ b/Services/Mocks/AdsServiceMock.swift
@@ -1,0 +1,26 @@
+import UIKit
+
+/// UI テストで利用するダミー広告サービス
+/// 実際の広告 SDK を使わず、簡易ビューを表示する
+final class AdsServiceMock: AdsServiceProtocol {
+    /// 準備済みの広告を表示する
+    func showInterstitial() {
+        // ルート VC を取得して半透明のダミービューをモーダル表示
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let root = scene.windows.first?.rootViewController else { return }
+        let vc = UIViewController()
+        vc.view.backgroundColor = UIColor.black.withAlphaComponent(0.8)
+        // UI テストが識別できるようアクセシビリティ ID を付与
+        vc.view.accessibilityIdentifier = "dummy_interstitial_ad"
+        root.present(vc, animated: false) {
+            // 少し待ってから自動的に閉じる
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                vc.dismiss(animated: false)
+            }
+        }
+    }
+    /// テストではフラグリセットの必要がないため空実装
+    func resetPlayFlag() {}
+    /// 広告をそもそも読み込まないため空実装
+    func disableAds() {}
+}

--- a/Services/Mocks/GameCenterServiceMock.swift
+++ b/Services/Mocks/GameCenterServiceMock.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// UI テストで利用する Game Center のダミーサービス
+/// 認証を即時成功扱いとし、UI 表示は行わない
+final class GameCenterServiceMock: GameCenterServiceProtocol {
+    /// 認証状態を保持するフラグ
+    private(set) var isAuthenticated: Bool = false
+    /// ローカルプレイヤーを即時認証済みにする
+    func authenticateLocalPlayer() {
+        isAuthenticated = true
+    }
+    /// スコア送信はテストでは不要なので空実装
+    func submitScore(_ score: Int) {}
+    /// ランキング画面も表示しない
+    func showLeaderboard() {}
+}

--- a/Services/Protocols/AdsServiceProtocol.swift
+++ b/Services/Protocols/AdsServiceProtocol.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// インタースティシャル広告サービスの共通インターフェース
+/// これにより本番用サービスとテスト用モックを切り替えられる
+protocol AdsServiceProtocol {
+    /// 準備済みの広告を表示する
+    func showInterstitial()
+    /// 新しいプレイ開始時に 1 プレイ 1 回制限フラグをリセットする
+    func resetPlayFlag()
+    /// 広告除去購入時に広告を無効化する
+    func disableAds()
+}

--- a/Services/Protocols/GameCenterServiceProtocol.swift
+++ b/Services/Protocols/GameCenterServiceProtocol.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Game Center 関連機能の共通インターフェース
+/// 認証・スコア送信・ランキング表示を抽象化する
+protocol GameCenterServiceProtocol {
+    /// 認証済みかどうかの状態
+    var isAuthenticated: Bool { get }
+    /// ローカルプレイヤーを認証する
+    func authenticateLocalPlayer()
+    /// スコアをリーダーボードへ送信する
+    func submitScore(_ score: Int)
+    /// ランキング画面を表示する
+    func showLeaderboard()
+}

--- a/Services/StoreService.swift
+++ b/Services/StoreService.swift
@@ -9,6 +9,9 @@ final class StoreService: ObservableObject {
     /// シングルトンインスタンス
     static let shared = StoreService()
 
+    /// 広告サービス（広告除去時に通知するため保持）
+    private let adsService: AdsServiceProtocol
+
     /// 取得済みのプロダクト一覧（現在は広告除去のみ）
     @Published var products: [Product] = []
 
@@ -16,7 +19,8 @@ final class StoreService: ObservableObject {
     /// - `true` の場合は AdsService が広告を読み込まない
     @AppStorage("remove_ads") private var removeAds: Bool = false
 
-    private init() {
+    private init(adsService: AdsServiceProtocol = AdsService.shared) {
+        self.adsService = adsService
         // 初期化と同時に商品情報の取得とトランザクション監視を開始
         Task {
             await fetchProducts()
@@ -70,7 +74,7 @@ final class StoreService: ObservableObject {
     private func applyRemoveAds() {
         removeAds = true
         // 広告サービスに通知して表示を停止させる
-        AdsService.shared.disableAds()
+        adsService.disableAds()
     }
 
     // MARK: - Transaction

--- a/UI/ResultView.swift
+++ b/UI/ResultView.swift
@@ -5,13 +5,35 @@ import SwiftUI
 struct ResultView: View {
     /// 今回のプレイで消費した手数
     let moves: Int
-    
+    /// Game Center サービス（ランキング表示に利用）
+    let gameCenterService: GameCenterServiceProtocol
+    /// 広告サービス（結果表示時に広告表示）
+    let adsService: AdsServiceProtocol
+
     /// 再戦処理を外部から受け取るクロージャ
     let onRetry: () -> Void
-    
+
     /// ベスト手数を `UserDefaults` に保存する
     @AppStorage("best_moves_5x5") private var bestMoves: Int = .max
-    
+
+    /// 依存性を注入するための初期化子
+    /// - Parameters:
+    ///   - moves: 今回の手数
+    ///   - gameCenterService: Game Center サービス
+    ///   - adsService: 広告サービス
+    ///   - onRetry: リトライ時に呼び出す処理
+    init(
+        moves: Int,
+        gameCenterService: GameCenterServiceProtocol = GameCenterService.shared,
+        adsService: AdsServiceProtocol = AdsService.shared,
+        onRetry: @escaping () -> Void
+    ) {
+        self.moves = moves
+        self.gameCenterService = gameCenterService
+        self.adsService = adsService
+        self.onRetry = onRetry
+    }
+
     var body: some View {
         VStack(spacing: 24) {
             // MARK: - 手数表示
@@ -34,7 +56,7 @@ struct ResultView: View {
             
             // MARK: - Game Center ランキングボタン
             Button(action: {
-                GameCenterService.shared.showLeaderboard()
+                gameCenterService.showLeaderboard()
             }) {
                 Text("ランキング")
                     .frame(maxWidth: .infinity)
@@ -44,7 +66,7 @@ struct ResultView: View {
         .padding()
         .onAppear {
             // ビュー表示時に広告表示をトリガー
-            AdsService.shared.showInterstitial()
+            adsService.showInterstitial()
             // ベスト記録の更新を判定
             updateBest()
         }

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -3,14 +3,31 @@ import SwiftUI
 /// ゲーム画面と設定画面を切り替えるルートビュー
 /// `TabView` を用いて 2 つのタブを提供する
 struct RootView: View {
+    /// Game Center サービス（本番/モックで差し替え可能）
+    let gameCenterService: GameCenterServiceProtocol
+    /// 広告サービス（GameView へ伝搬するため保持）
+    let adsService: AdsServiceProtocol
+
     /// Game Center 認証済みかどうかを追跡するフラグ
     /// - Note: `onAppear` が複数回呼ばれても二重認証を避ける
     @State private var didAuthenticate = false
 
+    /// 依存性を注入するための初期化子
+    /// - Parameters:
+    ///   - gameCenterService: Game Center のサービス
+    ///   - adsService: 広告サービス
+    init(
+        gameCenterService: GameCenterServiceProtocol = GameCenterService.shared,
+        adsService: AdsServiceProtocol = AdsService.shared
+    ) {
+        self.gameCenterService = gameCenterService
+        self.adsService = adsService
+    }
+
     var body: some View {
         TabView {
             // MARK: - ゲームタブ
-            GameView()
+            GameView(gameCenterService: gameCenterService, adsService: adsService)
                 .tabItem {
                     // システムアイコンとラベルを組み合わせてタブを定義
                     Label("ゲーム", systemImage: "gamecontroller")
@@ -26,7 +43,7 @@ struct RootView: View {
             // ルート ViewController が取得できるタイミングで認証を実施
             // Game Center のログイン UI を安全に表示できる
             guard !didAuthenticate else { return } // 二重呼び出しを防止
-            GameCenterService.shared.authenticateLocalPlayer()
+            gameCenterService.authenticateLocalPlayer()
             didAuthenticate = true
         }
     }


### PR DESCRIPTION
## Summary
- define AdsServiceProtocol and GameCenterServiceProtocol and conform existing services
- add mock implementations for ads and Game Center to support UI testing
- inject services via protocols into views and app entry point

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be619a35cc832c824524b1f0a307ac