### PR TITLE
feat: add protocol-based service injection

### DIFF
--- a/KnightCardsApp.swift
+++ b/KnightCardsApp.swift
@@ -4,13 +4,29 @@ import SwiftUI
 // `@main` 属性を付与した構造体からアプリが開始される
 @main
 struct KnightCardsApp: App {
-    // Game Center 認証は `RootView` の表示後に実行されるため
-    // ここでは特別な初期化処理を行わない
+    /// Game Center と広告サービスのインスタンス
+    /// - NOTE: UI テスト時はモックを使用する
+    private let gameCenterService: GameCenterServiceProtocol
+    private let adsService: AdsServiceProtocol
+
+    /// 初期化時に環境変数を確認してモックの使用有無を決定する
+    init() {
+        if ProcessInfo.processInfo.environment["UITEST_MODE"] != nil {
+            // UI テストではモックを利用して即時認証・ダミー広告を表示
+            self.gameCenterService = MockGameCenterService()
+            self.adsService = MockAdsService()
+        } else {
+            // 通常起動時はシングルトンを利用
+            self.gameCenterService = GameCenterService.shared
+            self.adsService = AdsService.shared
+        }
+    }
+
     var body: some Scene {
         WindowGroup {
             // MARK: 起動直後に表示するルートビュー
             // TabView でゲームと設定を切り替える `RootView` を表示
-            RootView()
+            RootView(gameCenterService: gameCenterService, adsService: adsService)
         }
     }
 }

--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -5,9 +5,21 @@ import SwiftUI
 import AppTrackingTransparency
 import UserMessagingPlatform
 
+/// 広告表示に必要なインターフェースを定義するプロトコル
+/// - NOTE: テストではこのプロトコルに準拠したモックを注入する
+protocol AdsServiceProtocol: AnyObject {
+    /// インタースティシャル広告を表示する
+    func showInterstitial()
+    /// 1 プレイにつき 1 回のみ表示するためのフラグをリセットする
+    func resetPlayFlag()
+    /// 広告除去購入時に広告の読み込みを停止する
+    func disableAds()
+}
+
 /// インタースティシャル広告を管理するサービス
 /// ゲーム終了時に ResultView から呼び出される
-final class AdsService: NSObject, ObservableObject {
+/// 実際に AdMob を利用して広告を管理する実装
+final class AdsService: NSObject, ObservableObject, AdsServiceProtocol {
     /// シングルトンインスタンス
     static let shared = AdsService()
 

--- a/Services/GameCenterService.swift
+++ b/Services/GameCenterService.swift
@@ -2,8 +2,24 @@ import Foundation
 import GameKit
 import UIKit
 
+/// Game Center 操作に必要なインターフェースを定義するプロトコル
+/// - NOTE: 認証やスコア送信をテストしやすくするために利用する
+protocol GameCenterServiceProtocol: AnyObject {
+    /// 現在認証済みであるかどうか
+    var isAuthenticated: Bool { get }
+    /// ローカルプレイヤーの認証を行う
+    /// - Parameter completion: 認証結果を受け取るクロージャ
+    func authenticateLocalPlayer(completion: ((Bool) -> Void)?)
+    /// リーダーボードへスコアを送信する
+    /// - Parameter score: 送信する手数
+    func submitScore(_ score: Int)
+    /// ランキング画面を表示する
+    func showLeaderboard()
+}
+
 /// Game Center 関連の操作をまとめたサービス
-final class GameCenterService: NSObject, GKGameCenterControllerDelegate {
+/// 実際に Game Center と連携する実装
+final class GameCenterService: NSObject, GKGameCenterControllerDelegate, GameCenterServiceProtocol {
     /// シングルトンインスタンス
     static let shared = GameCenterService()
 

--- a/Services/ServiceMocks.swift
+++ b/Services/ServiceMocks.swift
@@ -1,0 +1,56 @@
+#if canImport(UIKit)
+import UIKit
+import SwiftUI
+
+/// Game Center の動作を即時成功させる UI テスト用モック
+final class MockGameCenterService: GameCenterServiceProtocol {
+    /// 認証状態を保持するプロパティ
+    var isAuthenticated: Bool = false
+
+    /// 即座に認証成功とし、コールバックを呼び出す
+    func authenticateLocalPlayer(completion: ((Bool) -> Void)?) {
+        isAuthenticated = true
+        completion?(true)
+    }
+
+    /// スコア送信は行わないダミー実装
+    func submitScore(_ score: Int) {}
+
+    /// ランキング表示も行わないダミー実装
+    func showLeaderboard() {}
+}
+
+/// インタースティシャル広告をダミー表示する UI テスト用モック
+final class MockAdsService: AdsServiceProtocol {
+    /// ダミー広告を全画面で表示する
+    func showInterstitial() {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let root = scene.windows.first?.rootViewController else { return }
+        // モック用の簡易ビューを作成して表示
+        let vc = UIHostingController(rootView: MockAdView())
+        vc.modalPresentationStyle = .fullScreen
+        root.present(vc, animated: true)
+    }
+
+    /// フラグ操作は不要なので空実装
+    func resetPlayFlag() {}
+
+    /// 広告読み込み停止も不要なので空実装
+    func disableAds() {}
+
+    /// ダミー広告ビュー
+    private struct MockAdView: View {
+        @Environment(\.dismiss) private var dismiss
+        var body: some View {
+            ZStack {
+                Color.black
+                Text("Test Ad")
+                    .foregroundColor(.white)
+            }
+            .ignoresSafeArea()
+            .accessibilityIdentifier("dummy_interstitial_ad")
+            .onTapGesture { dismiss() }
+        }
+    }
+}
+#endif

--- a/Tests/GameUITests/GameCenterAdsUITests.swift
+++ b/Tests/GameUITests/GameCenterAdsUITests.swift
@@ -2,26 +2,16 @@
 import XCTest
 
 /// Game Center 認証フローとインタースティシャル広告表示を確認する UI テスト
-/// 
+///
 /// - 注意: iOS シミュレーター上でのみ動作を想定し、
-///         ダミーアカウントとテスト用広告ユニット ID を利用する。
+///         モックサービスを利用して動作を簡略化する。
 final class GameCenterAdsUITests: XCTestCase {
-    /// テスト用 Game Center アカウント名
-    private let dummyGameCenterAccount = "GCTestUser1"
-    
-    /// Google 提供のテスト用インタースティシャル広告ユニット ID
-    /// 実機配信では必ず差し替えること
-    private let dummyInterstitialID = "ca-app-pub-3940256099942544/4411468910"
-    
     /// Game Center へのサインインと広告表示の流れを検証
     func testGameCenterAuthAndInterstitialAd() {
         // テスト対象アプリを生成
         let app = XCUIApplication()
-        
-        // --- 環境変数の設定 ---
-        // ダミー Game Center アカウントとダミー広告ユニット ID を渡す
-        app.launchEnvironment["GC_TEST_ACCOUNT"] = dummyGameCenterAccount
-        app.launchEnvironment["GAD_INTERSTITIAL_ID"] = dummyInterstitialID
+        // UI テスト用モックを利用するためのフラグを設定
+        app.launchEnvironment["UITEST_MODE"] = "1"
         
         // アプリを起動
         app.launch()

--- a/UI/ResultView.swift
+++ b/UI/ResultView.swift
@@ -5,10 +5,15 @@ import SwiftUI
 struct ResultView: View {
     /// 今回のプレイで消費した手数
     let moves: Int
-    
+
     /// 再戦処理を外部から受け取るクロージャ
     let onRetry: () -> Void
-    
+
+    /// Game Center 連携を扱うサービス（プロトコル型で受け取る）
+    private let gameCenterService: GameCenterServiceProtocol
+    /// 広告表示を扱うサービス（プロトコル型で受け取る）
+    private let adsService: AdsServiceProtocol
+
     /// ベスト手数を `UserDefaults` に保存する
     @AppStorage("best_moves_5x5") private var bestMoves: Int = .max
     
@@ -34,7 +39,7 @@ struct ResultView: View {
             
             // MARK: - Game Center ランキングボタン
             Button(action: {
-                GameCenterService.shared.showLeaderboard()
+                gameCenterService.showLeaderboard()
             }) {
                 Text("ランキング")
                     .frame(maxWidth: .infinity)
@@ -48,7 +53,7 @@ struct ResultView: View {
         .padding()
         .onAppear {
             // ビュー表示時に広告表示をトリガー
-            AdsService.shared.showInterstitial()
+            adsService.showInterstitial()
             // ベスト記録の更新を判定
             updateBest()
         }
@@ -69,6 +74,11 @@ struct ResultView: View {
 
 struct ResultView_Previews: PreviewProvider {
     static var previews: some View {
-        ResultView(moves: 30, onRetry: {})
+        ResultView(
+            moves: 30,
+            onRetry: {},
+            gameCenterService: GameCenterService.shared,
+            adsService: AdsService.shared
+        )
     }
 }

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -3,9 +3,24 @@ import SwiftUI
 /// ゲーム画面と設定画面を切り替えるルートビュー
 /// `TabView` を用いて 2 つのタブを提供する
 struct RootView: View {
+    /// Game Center 連携を扱うサービス（プロトコル型で受け取る）
+    private let gameCenterService: GameCenterServiceProtocol
+    /// 広告表示を扱うサービス（GameView へ受け渡す）
+    private let adsService: AdsServiceProtocol
     /// Game Center 認証済みかどうかを保持する状態
     /// - Note: 認証後はラベル表示に切り替える
-    @State private var isAuthenticated = GameCenterService.shared.isAuthenticated
+    @State private var isAuthenticated: Bool
+
+    /// 依存サービスを外部から注入可能にする初期化処理
+    /// - Parameters:
+    ///   - gameCenterService: Game Center 連携用サービス（デフォルトはシングルトン）
+    ///   - adsService: 広告表示用サービス（デフォルトはシングルトン）
+    init(gameCenterService: GameCenterServiceProtocol = GameCenterService.shared,
+         adsService: AdsServiceProtocol = AdsService.shared) {
+        self.gameCenterService = gameCenterService
+        self.adsService = adsService
+        _isAuthenticated = State(initialValue: gameCenterService.isAuthenticated)
+    }
 
     var body: some View {
         VStack(spacing: 12) {
@@ -18,7 +33,7 @@ struct RootView: View {
             } else {
                 // サインインボタンをタップで認証を開始
                 Button(action: {
-                    GameCenterService.shared.authenticateLocalPlayer { success in
+                    gameCenterService.authenticateLocalPlayer { success in
                         // 成否に応じて状態を更新し、ラベル表示を切り替える
                         isAuthenticated = success
                     }
@@ -33,7 +48,7 @@ struct RootView: View {
             // MARK: - タブビュー本体
             TabView {
                 // MARK: - ゲームタブ
-                GameView()
+                GameView(gameCenterService: gameCenterService, adsService: adsService)
                     .tabItem {
                         // システムアイコンとラベルを組み合わせてタブを定義
                         Label("ゲーム", systemImage: "gamecontroller")


### PR DESCRIPTION
## Summary
- define AdsServiceProtocol and GameCenterServiceProtocol and update services to conform
- inject protocol-based services into views and app entry for easy mocking
- add UI-test mocks for instant Game Center auth and dummy ad display

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68be631621a4832c81115f56f10836e1