### PR TITLE
Add haptic feedback to game actions

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import SpriteKit
 import Game
+import UIKit // ハプティクス用のフレームワークを追加
 
 /// SwiftUI から SpriteKit の盤面を表示するビュー
 /// 画面下部に手札 3 枚と次に引かれるカードを表示し、
@@ -74,10 +75,17 @@ struct GameView: View {
                                     // 盤外に出るカードは薄く表示し、タップを無効化
                                     .opacity(isCardUsable(card) ? 1.0 : 0.4)
                                     .onTapGesture {
-                                        // 列挙型 MoveCard の使用可否を確認してから GameCore へ伝達
-                                        guard isCardUsable(card) else { return }
-                                        // 選択されたカードで GameCore を更新（index は手札位置）
-                                        core.playCard(at: index)
+                                        // ハプティクス生成器を都度生成
+                                        let generator = UINotificationFeedbackGenerator()
+                                        // 列挙型 MoveCard の使用可否を判定
+                                        if isCardUsable(card) {
+                                            // 使用可能 ⇒ ゲーム状態を更新し、成功フィードバックを発火
+                                            core.playCard(at: index)
+                                            generator.notificationOccurred(.success)
+                                        } else {
+                                            // 使用不可 ⇒ 警告フィードバックのみを発火
+                                            generator.notificationOccurred(.warning)
+                                        }
                                     }
                             }
                         }

--- a/UI/ResultView.swift
+++ b/UI/ResultView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit // ハプティクス用フレームワーク
 
 /// ゲーム終了時の結果を表示するビュー
 /// 手数・ベスト記録・各種ボタンをまとめて配置する
@@ -30,6 +31,8 @@ struct ResultView: View {
             
             // MARK: - リトライボタン
             Button(action: {
+                // 成功フィードバックを発火させてからリトライ処理を呼び出す
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
                 onRetry()
             }) {
                 Text("リトライ")
@@ -39,6 +42,8 @@ struct ResultView: View {
             
             // MARK: - Game Center ランキングボタン
             Button(action: {
+                // ランキング表示時も軽い成功フィードバックを挿入
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
                 gameCenterService.showLeaderboard()
             }) {
                 Text("ランキング")


### PR DESCRIPTION
## Summary
- add success/warning haptic feedback for card taps in GameView
- trigger haptic feedback on retry and leaderboard buttons

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be690056dc832c92b7d41afa29b477