### PR TITLE
初回起動時の同意フローを追加

### DIFF
--- a/KnightCardsApp.swift
+++ b/KnightCardsApp.swift
@@ -9,6 +9,10 @@ struct KnightCardsApp: App {
     private let gameCenterService: GameCenterServiceProtocol
     private let adsService: AdsServiceProtocol
 
+    /// 同意フローが完了したかどうかを保持するフラグ
+    /// - NOTE: `UserDefaults` と連携し、次回以降はスキップする
+    @AppStorage("has_completed_consent_flow") private var hasCompletedConsentFlow: Bool = false
+
     /// 初期化時に環境変数を確認してモックの使用有無を決定する
     init() {
         if ProcessInfo.processInfo.environment["UITEST_MODE"] != nil {
@@ -24,9 +28,15 @@ struct KnightCardsApp: App {
 
     var body: some Scene {
         WindowGroup {
-            // MARK: 起動直後に表示するルートビュー
-            // TabView でゲームと設定を切り替える `RootView` を表示
-            RootView(gameCenterService: gameCenterService, adsService: adsService)
+            // MARK: 起動直後の表示切り替え
+            // 初回のみ同意フローを表示し、完了後に `RootView` へ遷移する
+            if hasCompletedConsentFlow {
+                // 通常時はタブビューを提供するルート画面を表示
+                RootView(gameCenterService: gameCenterService, adsService: adsService)
+            } else {
+                // 同意取得前はオンボーディング画面を表示
+                ConsentFlowView(adsService: adsService)
+            }
         }
     }
 }

--- a/Services/ServiceMocks.swift
+++ b/Services/ServiceMocks.swift
@@ -38,6 +38,12 @@ final class MockAdsService: AdsServiceProtocol {
     /// 広告読み込み停止も不要なので空実装
     func disableAds() {}
 
+    /// ATT 許可ダイアログは表示しないダミー実装
+    func requestTrackingAuthorization() async {}
+
+    /// UMP 同意フォームも表示しないダミー実装
+    func requestConsentIfNeeded() async {}
+
     /// ダミー広告ビュー
     private struct MockAdView: View {
         @Environment(\.dismiss) private var dismiss

--- a/UI/ConsentFlowView.swift
+++ b/UI/ConsentFlowView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// 初回起動時に表示するオンボーディングビュー
+/// 広告・トラッキングに関する説明と同意取得を行う
+struct ConsentFlowView: View {
+    /// 広告サービス。ATT/UMP の許諾処理を呼び出す
+    private let adsService: AdsServiceProtocol
+    /// 同意フローが完了したかどうかを UserDefaults と連携して保持
+    @AppStorage("has_completed_consent_flow") private var hasCompletedConsentFlow: Bool = false
+    /// 処理中でボタンを無効化するためのフラグ
+    @State private var isRequesting: Bool = false
+
+    /// サービスを外部から注入可能にする初期化処理
+    /// - Parameter adsService: 広告処理を担うサービス（デフォルトはシングルトン）
+    init(adsService: AdsServiceProtocol = AdsService.shared) {
+        self.adsService = adsService
+    }
+
+    var body: some View {
+        VStack(spacing: 24) {
+            // MARK: - 説明テキスト
+            // 同意内容を簡潔にユーザーへ伝える
+            Text("本アプリでは広告表示のために\nトラッキングとプライバシーに関する\n許諾をお願いしています。")
+                .multilineTextAlignment(.center)
+                .padding()
+
+            // MARK: - 続行ボタン
+            Button(action: {
+                // 非同期で同意フローを開始
+                Task { await startFlow() }
+            }) {
+                Text("続行")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isRequesting)
+        }
+        .padding()
+    }
+
+    /// ATT → UMP の順に同意ダイアログを表示する
+    private func startFlow() async {
+        isRequesting = true
+        // まずはトラッキング許諾を求める
+        await adsService.requestTrackingAuthorization()
+        // 続いて Google UMP の同意フォームを表示
+        await adsService.requestConsentIfNeeded()
+        // フロー完了フラグを保存し、次回以降は表示しない
+        hasCompletedConsentFlow = true
+        isRequesting = false
+    }
+}
+
+#Preview {
+    ConsentFlowView(adsService: MockAdsService())
+}


### PR DESCRIPTION
## Summary
- 初回起動時に表示する `ConsentFlowView` を新規作成
- `ATTrackingManager` → `UMPConsentForm` の順に許諾を取得し、完了後は `RootView` へ遷移
- `AdsService` を同意フロー対応にリファクタリングし、モックも更新

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be69018b40832cb3c528bf449aa211