### PR TITLE
Add audio and haptic settings with contact info

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -170,6 +170,8 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol {
             let vc = UIHostingController(rootView: DummyInterstitialView())
             vc.modalPresentationStyle = .fullScreen
             root.present(vc, animated: true)
+            // 広告表示のタイミングで軽いハプティクスを発生
+            HapticService.shared.notify(.warning)
             // 表示後にタイムスタンプとフラグを更新
             lastInterstitialDate = Date()
             hasShownInCurrentPlay = true
@@ -180,6 +182,8 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol {
         guard let ad = interstitial else { return }
         // 現在のルートビューから広告を表示
         ad.present(fromRootViewController: root)
+        // 広告表示のタイミングで軽いハプティクスを発生
+        HapticService.shared.notify(.warning)
         // 表示後にタイムスタンプとフラグを更新し、次回に備えて再読み込み
         lastInterstitialDate = Date()
         hasShownInCurrentPlay = true

--- a/Services/HapticService.swift
+++ b/Services/HapticService.swift
@@ -1,0 +1,46 @@
+import Foundation
+#if canImport(UIKit)
+import UIKit
+import SwiftUI
+#endif
+
+#if canImport(UIKit)
+typealias HapticType = UINotificationFeedbackGenerator.FeedbackType
+#else
+/// UIKit が利用できない環境向けのダミー列挙
+enum HapticType {
+    case success, warning, error
+}
+#endif
+
+/// ハプティクスの発生を一元管理するサービス
+/// - NOTE: 設定のオン/オフを `@AppStorage` で保持する
+final class HapticService {
+    /// シングルトンインスタンス
+    static let shared = HapticService()
+
+    #if canImport(UIKit)
+    /// ハプティクスのオン/オフ設定（UserDefaults と連携）
+    @AppStorage("enable_haptics") private var enableHaptics: Bool = true
+    #else
+    /// 非 iOS 環境では単純なプロパティで代替
+    private var enableHaptics: Bool = true
+    #endif
+
+    /// 外部からのインスタンス生成を禁止
+    private init() {}
+
+    /// 指定したタイプのハプティクスを再生
+    /// - Parameter type: 成功/警告/エラーなどのハプティクスタイプ
+    func notify(_ type: HapticType) {
+        #if canImport(UIKit)
+        // ユーザー設定がオンのときのみ実行
+        guard enableHaptics else { return }
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(type)
+        #else
+        // 非 iOS 環境では何もしない
+        #endif
+    }
+}
+

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -74,10 +74,15 @@ struct GameView: View {
                                     // 盤外に出るカードは薄く表示し、タップを無効化
                                     .opacity(isCardUsable(card) ? 1.0 : 0.4)
                                     .onTapGesture {
-                                        // 列挙型 MoveCard の使用可否を確認してから GameCore へ伝達
-                                        guard isCardUsable(card) else { return }
-                                        // 選択されたカードで GameCore を更新（index は手札位置）
-                                        core.playCard(at: index)
+                                        // カードが盤内に移動可能かチェック
+                                        if isCardUsable(card) {
+                                            // 有効カードなら GameCore を更新し、成功ハプティクスを再生
+                                            core.playCard(at: index)
+                                            HapticService.shared.notify(.success)
+                                        } else {
+                                            // 無効カードをタップした場合は警告ハプティクスを再生
+                                            HapticService.shared.notify(.error)
+                                        }
                                     }
                             }
                         }

--- a/UI/SettingsView.swift
+++ b/UI/SettingsView.swift
@@ -7,10 +7,26 @@ import UserMessagingPlatform
 struct SettingsView: View {
     /// 課金処理を扱う `StoreService` を参照
     @StateObject private var store = StoreService.shared
+    /// BGM のオン/オフ設定を保持
+    @AppStorage("bgm_enabled") private var bgmEnabled: Bool = true
+    /// 効果音のオン/オフ設定を保持
+    @AppStorage("se_enabled") private var seEnabled: Bool = true
+    /// ハプティクスのオン/オフ設定を保持
+    @AppStorage("enable_haptics") private var enableHaptics: Bool = true
 
     var body: some View {
         NavigationStack {
             List {
+                // MARK: - サウンド設定セクション
+                Section("サウンド") {
+                    // BGM の再生を切り替えるトグル
+                    Toggle("BGM", isOn: $bgmEnabled)
+                    // 効果音の再生を切り替えるトグル
+                    Toggle("効果音", isOn: $seEnabled)
+                    // ハプティクスの発生を切り替えるトグル
+                    Toggle("ハプティクス", isOn: $enableHaptics)
+                }
+
                 // MARK: - 課金関連セクション
                 Section("課金") {
                     // 広告除去を購入するボタン
@@ -58,6 +74,13 @@ struct SettingsView: View {
                         Text("プライバシー設定")
                             .frame(maxWidth: .infinity, alignment: .center)
                     }
+                }
+
+                // MARK: - 開発者連絡セクション
+                Section("開発者へ連絡") {
+                    // メールアプリを起動して問い合わせ
+                    Link("メールで問い合わせ", destination: URL(string: "mailto:developer@example.com")!)
+                        .frame(maxWidth: .infinity, alignment: .center)
                 }
             }
             // 画面タイトルをナビゲーションバーに表示


### PR DESCRIPTION
## Summary
- add BGM/SE/haptic toggles in SettingsView
- wire haptic toggle through new HapticService for game actions and ads
- include developer contact link

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be69037798832ca195965d4f60b436