### PR TITLE
設定画面にサウンド・ハプティクス設定と連絡先を追加

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -39,6 +39,8 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol {
 
     /// 広告除去購入済みフラグ（UserDefaults と連携）
     @AppStorage("remove_ads") private var removeAds: Bool = false
+    /// ハプティクスを有効にするかどうかの設定値
+    @AppStorage("haptics_enabled") private var hapticsEnabled: Bool = true
 
     /// ATT と UMP の同意状況に基づくパーソナライズ可否
     private var isPersonalized: Bool = false
@@ -170,6 +172,10 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol {
             let vc = UIHostingController(rootView: DummyInterstitialView())
             vc.modalPresentationStyle = .fullScreen
             root.present(vc, animated: true)
+            // 広告表示時に警告ハプティクスを発生させる
+            if hapticsEnabled {
+                UINotificationFeedbackGenerator().notificationOccurred(.warning)
+            }
             // 表示後にタイムスタンプとフラグを更新
             lastInterstitialDate = Date()
             hasShownInCurrentPlay = true
@@ -180,6 +186,10 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol {
         guard let ad = interstitial else { return }
         // 現在のルートビューから広告を表示
         ad.present(fromRootViewController: root)
+        // 広告表示時に警告ハプティクスを発生させる
+        if hapticsEnabled {
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+        }
         // 表示後にタイムスタンプとフラグを更新し、次回に備えて再読み込み
         lastInterstitialDate = Date()
         hasShownInCurrentPlay = true

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -19,6 +19,8 @@ struct GameView: View {
     private let gameCenterService: GameCenterServiceProtocol
     /// 広告表示を扱うサービス（プロトコル型で受け取る）
     private let adsService: AdsServiceProtocol
+    /// ハプティクスを有効にするかどうかの設定値
+    @AppStorage("haptics_enabled") private var hapticsEnabled: Bool = true
 
     /// 初期化で GameCore と GameScene を連結する
     /// 依存するサービスを外部から注入できるようにする初期化処理
@@ -75,16 +77,19 @@ struct GameView: View {
                                     // 盤外に出るカードは薄く表示し、タップを無効化
                                     .opacity(isCardUsable(card) ? 1.0 : 0.4)
                                     .onTapGesture {
-                                        // ハプティクス生成器を都度生成
-                                        let generator = UINotificationFeedbackGenerator()
                                         // 列挙型 MoveCard の使用可否を判定
                                         if isCardUsable(card) {
-                                            // 使用可能 ⇒ ゲーム状態を更新し、成功フィードバックを発火
+                                            // 使用可能 ⇒ ゲーム状態を更新
                                             core.playCard(at: index)
-                                            generator.notificationOccurred(.success)
+                                            // 設定で許可されていれば成功ハプティクスを発火
+                                            if hapticsEnabled {
+                                                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                                            }
                                         } else {
-                                            // 使用不可 ⇒ 警告フィードバックのみを発火
-                                            generator.notificationOccurred(.warning)
+                                            // 使用不可の場合、警告ハプティクスのみ発火
+                                            if hapticsEnabled {
+                                                UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                                            }
                                         }
                                     }
                             }

--- a/UI/ResultView.swift
+++ b/UI/ResultView.swift
@@ -17,6 +17,8 @@ struct ResultView: View {
 
     /// ベスト手数を `UserDefaults` に保存する
     @AppStorage("best_moves_5x5") private var bestMoves: Int = .max
+    /// ハプティクスを有効にするかどうかの設定値
+    @AppStorage("haptics_enabled") private var hapticsEnabled: Bool = true
     
     var body: some View {
         VStack(spacing: 24) {
@@ -31,8 +33,10 @@ struct ResultView: View {
             
             // MARK: - リトライボタン
             Button(action: {
-                // 成功フィードバックを発火させてからリトライ処理を呼び出す
-                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                // 設定が有効なら成功フィードバックを発火
+                if hapticsEnabled {
+                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                }
                 onRetry()
             }) {
                 Text("リトライ")
@@ -42,8 +46,10 @@ struct ResultView: View {
             
             // MARK: - Game Center ランキングボタン
             Button(action: {
-                // ランキング表示時も軽い成功フィードバックを挿入
-                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                // 設定が有効なら成功フィードバックを発火
+                if hapticsEnabled {
+                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                }
                 gameCenterService.showLeaderboard()
             }) {
                 Text("ランキング")

--- a/UI/SettingsView.swift
+++ b/UI/SettingsView.swift
@@ -7,10 +7,30 @@ import UserMessagingPlatform
 struct SettingsView: View {
     /// 課金処理を扱う `StoreService` を参照
     @StateObject private var store = StoreService.shared
+    /// BGM を再生するかどうかの設定値
+    @AppStorage("bgm_enabled") private var bgmEnabled: Bool = true
+    /// 効果音を再生するかどうかの設定値
+    @AppStorage("se_enabled") private var seEnabled: Bool = true
+    /// ハプティクスを有効にするかどうかの設定値
+    @AppStorage("haptics_enabled") private var hapticsEnabled: Bool = true
 
     var body: some View {
         NavigationStack {
             List {
+                // MARK: - サウンド設定セクション
+                Section("サウンド") {
+                    // BGM のオン・オフを切り替えるトグル
+                    Toggle("BGMを再生", isOn: $bgmEnabled)
+                    // 効果音のオン・オフを切り替えるトグル
+                    Toggle("効果音を再生", isOn: $seEnabled)
+                }
+
+                // MARK: - フィードバック設定セクション
+                Section("操作フィードバック") {
+                    // ハプティクスのオン・オフを切り替えるトグル
+                    Toggle("ハプティクスを有効にする", isOn: $hapticsEnabled)
+                }
+
                 // MARK: - 課金関連セクション
                 Section("課金") {
                     // 広告除去を購入するボタン
@@ -58,6 +78,12 @@ struct SettingsView: View {
                         Text("プライバシー設定")
                             .frame(maxWidth: .infinity, alignment: .center)
                     }
+                }
+
+                // MARK: - 開発者連絡先セクション
+                Section("お問い合わせ") {
+                    // メールアプリを起動して開発者へ問い合わせるリンク
+                    Link("メールで問い合わせ", destination: URL(string: "mailto:developer@example.com")!)
                 }
             }
             // 画面タイトルをナビゲーションバーに表示


### PR DESCRIPTION
## Summary
- add BGM/SE and haptics toggles backed by `@AppStorage`
- respect the haptics setting across ads and in-game feedback
- provide a mail link section for contacting the developer

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be6e0d5880832ca99251ff9136426a