### PR TITLE
Info.plist にポートレート固定設定を追加

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -60,5 +60,19 @@
             <string>f38h382jlk.skadnetwork</string>
         </dict>
     </array>
+
+    <!-- 画面回転の対応方向を指定 -->
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <!-- iPhone ではポートレートのみ許可 -->
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+
+    <!-- iPad でも同様に縦向きで固定 -->
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <!-- iPad における不要な回転を防止 -->
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Info.plist に `UISupportedInterfaceOrientations` を追加して iPhone の画面をポートレート固定
- `UISupportedInterfaceOrientations~ipad` を追加して iPad でも縦向き固定に設定

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be786da55c832cb8e7d0953074c4bc