### PR TITLE
Handle privacy form errors and refresh ad consent

### DIFF
--- a/Services/ServiceMocks.swift
+++ b/Services/ServiceMocks.swift
@@ -44,6 +44,9 @@ final class MockAdsService: AdsServiceProtocol {
     /// UMP 同意フォームも表示しないダミー実装
     func requestConsentIfNeeded() async {}
 
+    /// 同意状況の再評価も行わないダミー実装
+    func refreshConsentStatus() async {}
+
     /// ダミー広告ビュー
     private struct MockAdView: View {
         @Environment(\.dismiss) private var dismiss


### PR DESCRIPTION
## Summary
- show alert when privacy settings form fails to present
- refresh consent after privacy form to update ad configuration
- support consent refresh in `AdsService` and mocks

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68be787b37ec832c97af4e7b2c378c8e