### PR TITLE
デバッグ用ログ出力とグリッド座標表示を追加

### DIFF
--- a/Game/DebugLog.swift
+++ b/Game/DebugLog.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// デバッグ用ログ出力をまとめたユーティリティ
+/// - Note: リリースビルドでは呼び出しても何も表示されない
+func debugLog(_ message: String, file: String = #file, line: Int = #line) {
+#if DEBUG
+    // ファイル名のみを抜き出してログに含める
+    let filename = URL(fileURLWithPath: file).lastPathComponent
+    print("[DEBUG] \(filename):\(line) - \(message)")
+#else
+    // リリースビルドでは何もしない
+#endif
+}

--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -60,6 +60,9 @@ final class GameCore: ObservableObject {
         // UI 側で無効カードを弾く想定だが、念のため安全確認
         guard board.contains(target) else { return }
 
+        // デバッグログ: 使用カードと移動先を出力
+        debugLog("カード \(card) を使用し \(current) -> \(target) へ移動")
+
         // 移動処理
         current = target
         board.markVisited(target)
@@ -99,6 +102,9 @@ final class GameCore: ObservableObject {
         }
         guard allUnusable else { return }
 
+        // デバッグログ: 手札詰まりの発生を通知
+        debugLog("手札が全て使用不可のためペナルティを適用")
+
         // ペナルティ加算 (+5 手数)
         penaltyCount += 5
         progress = .deadlock
@@ -108,6 +114,9 @@ final class GameCore: ObservableObject {
         let result = deck.fullRedraw(hand: hand, next: next)
         hand = result.hand
         next = result.next
+
+        // デバッグログ: 引き直し後の手札を表示
+        debugLog("引き直し後の手札: \(hand)")
 
         // 引き直し後も詰みの場合があるので再チェック
         progress = .playing
@@ -127,6 +136,10 @@ final class GameCore: ObservableObject {
         checkDeadlockAndApplyPenaltyIfNeeded()
         // リセット後の残り踏破数を読み上げ
         announceRemainingTiles()
+
+        // デバッグログ: リセット後の状態を表示
+        let nextText = next.map { "\($0)" } ?? "なし"
+        debugLog("ゲームをリセット: 手札 \(hand), 次カード \(nextText)")
     }
 
     /// 現在の残り踏破数を VoiceOver で通知する
@@ -147,6 +160,9 @@ extension GameCore: GameCoreProtocol {
     func handleTap(at point: GridPoint) {
         // ゲーム進行中でなければ入力を無視
         guard progress == .playing else { return }
+
+        // デバッグログ: タップされたマスを表示
+        debugLog("マス \(point) をタップ")
 
         // タップされたマスと現在位置の差分を計算
         let dx = point.x - current.x

--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -109,6 +109,15 @@ class GameScene: SKScene {
                 addChild(node)
                 let point = GridPoint(x: x, y: y)
                 tileNodes[point] = node
+
+#if DEBUG
+                // デバッグ時は各マスの座標を赤文字で表示
+                let label = SKLabelNode(text: "\(x),\(y)")
+                label.fontSize = tileSize * 0.3
+                label.fontColor = .red
+                label.position = CGPoint(x: rect.midX, y: rect.midY - label.fontSize / 2)
+                addChild(label)
+#endif
             }
         }
     }

--- a/Game/Models.swift
+++ b/Game/Models.swift
@@ -114,3 +114,10 @@ enum GameProgress {
     case deadlock
 }
 
+// MARK: - デバッグ支援
+extension GridPoint: CustomStringConvertible {
+    /// デバッグ出力時に座標を分かりやすく表示する
+    /// - Returns: "(x, y)" 形式の文字列
+    var description: String { "(\(x),\(y))" }
+}
+

--- a/Game/MoveCard.swift
+++ b/Game/MoveCard.swift
@@ -117,6 +117,12 @@ enum MoveCard: CaseIterable {
     }
 }
 
+// MARK: - デバッグ用表示名
+extension MoveCard: CustomStringConvertible {
+    /// デバッグログでカード名をわかりやすくするため displayName を返す
+    var description: String { displayName }
+}
+
 // MARK: - Identifiable への適合
 extension MoveCard: Identifiable {
     /// `Identifiable` 準拠のための一意な識別子


### PR DESCRIPTION
## 概要
- `debugLog` ユーティリティでデバッグログを一元化
- `GameCore` に各種ログ出力を追加し手番を追跡
- デバッグビルド時にグリッド座標を表示

## テスト
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68bec06cc2c4832c9b8799b5d1a2a586