### PR TITLE
デバッグ用盤面表示の追加

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -46,6 +46,8 @@ final class GameCore: ObservableObject {
         checkDeadlockAndApplyPenaltyIfNeeded()
         // 初期状態の残り踏破数を読み上げ
         announceRemainingTiles()
+        // デバッグ: 初期盤面を表示して状態を確認
+        board.debugDump(current: current)
     }
 
     /// 指定インデックスのカードで駒を移動させる
@@ -87,11 +89,16 @@ final class GameCore: ObservableObject {
         // クリア判定
         if board.isCleared {
             progress = .cleared
+            // デバッグ: クリア時の盤面を表示
+            board.debugDump(current: current)
             return
         }
 
         // 手詰まりチェック（全カード盤外ならペナルティ）
         checkDeadlockAndApplyPenaltyIfNeeded()
+
+        // デバッグ: 現在の盤面を表示
+        board.debugDump(current: current)
     }
 
     /// 手札がすべて盤外となる場合にペナルティを課し、手札を引き直す
@@ -117,6 +124,8 @@ final class GameCore: ObservableObject {
 
         // デバッグログ: 引き直し後の手札を表示
         debugLog("引き直し後の手札: \(hand)")
+        // デバッグ: 引き直し後の盤面を表示
+        board.debugDump(current: current)
 
         // 引き直し後も詰みの場合があるので再チェック
         progress = .playing
@@ -140,6 +149,8 @@ final class GameCore: ObservableObject {
         // デバッグログ: リセット後の状態を表示
         let nextText = next.map { "\($0)" } ?? "なし"
         debugLog("ゲームをリセット: 手札 \(hand), 次カード \(nextText)")
+        // デバッグ: リセット直後の盤面を表示
+        board.debugDump(current: current)
     }
 
     /// 現在の残り踏破数を VoiceOver で通知する

--- a/Game/Models.swift
+++ b/Game/Models.swift
@@ -121,3 +121,28 @@ extension GridPoint: CustomStringConvertible {
     var description: String { "(\(x),\(y))" }
 }
 
+#if DEBUG
+extension Board {
+    /// 現在の盤面状態をコンソールに可視化する
+    /// - Parameter current: 駒の現在位置（省略時は表示しない）
+    func debugDump(current: GridPoint? = nil) {
+        // y 軸を上から下へ走査し、行単位で文字列を構築する
+        for y in stride(from: Board.size - 1, through: 0, by: -1) {
+            var row = ""
+            for x in 0..<Board.size {
+                let point = GridPoint(x: x, y: y)
+                if let current = current, current == point {
+                    // 駒の位置は K で表現
+                    row += "K "
+                } else {
+                    // 踏破済みマスは x、未踏破は . を使用
+                    row += tiles[y][x] == .visited ? "x " : ". "
+                }
+            }
+            // 末尾の空白を削除してからデバッグログに出力
+            debugLog(row.trimmingCharacters(in: .whitespaces))
+        }
+    }
+}
+#endif
+


### PR DESCRIPTION
## Summary
- Boardに盤面のテキスト出力`debugDump`を追加
- GameCore各所で`debugDump`を呼び出し、開発時に盤面状態を確認しやすく

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68bec18e4394832c9ca4a270d3dfc37b