### PR TITLE
feat: add global error logging for debugging

### DIFF
--- a/Game/DebugLog.swift
+++ b/Game/DebugLog.swift
@@ -50,8 +50,10 @@ func debugError(
     parts.append("code: \(nsError.code)")
     parts.append("description: \(nsError.localizedDescription)")
     let detail = parts.joined(separator: " | ")
-    // [ERROR] プレフィックスを付け、発生箇所と共に出力
-    print("[ERROR] \(filename):\(line) \(function) - \(detail)")
+    // スタックトレースを取得し、行単位で改行を入れて読みやすくする
+    let stackSymbols = Thread.callStackSymbols.joined(separator: "\n")
+    // [ERROR] プレフィックスを付け、発生箇所と詳細な情報を出力
+    print("[ERROR] \(filename):\(line) \(function) - \(detail)\nスタックトレース:\n\(stackSymbols)")
 #else
     // リリースビルドでは何もしない
 #endif

--- a/KnightCardsApp.swift
+++ b/KnightCardsApp.swift
@@ -15,6 +15,9 @@ struct KnightCardsApp: App {
 
     /// 初期化時に環境変数を確認してモックの使用有無を決定する
     init() {
+        // MARK: グローバルエラーハンドラの設定
+        // デバッグ中にどこでクラッシュしても詳細な情報を得られるようにする
+        ErrorReporter.setup()
         if ProcessInfo.processInfo.environment["UITEST_MODE"] != nil {
             // UI テストではモックを利用して即時認証・ダミー広告を表示
             self.gameCenterService = MockGameCenterService()

--- a/Services/ErrorReporter.swift
+++ b/Services/ErrorReporter.swift
@@ -1,0 +1,42 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+
+/// アプリ全体で未捕捉のエラーを捕捉し詳細なログを出力するハンドラ
+/// - Note: DEBUG ビルドのみ有効
+enum ErrorReporter {
+    /// グローバルなエラーハンドラを設定する
+    static func setup() {
+#if DEBUG
+#if canImport(Darwin)
+        // MARK: 未捕捉例外の捕捉
+        // Swift 以外の例外(NSException)が発生した場合にも
+        // 詳細な情報をログへ出力できるようハンドラを登録する
+        NSSetUncaughtExceptionHandler { exception in
+            // 例外名と理由をデバッグログに出力
+            debugLog("未捕捉例外: \(exception.name.rawValue) - \(exception.reason ?? \"理由不明\")")
+            // スタックトレースを取得し、改行区切りで表示
+            let trace = exception.callStackSymbols.joined(separator: "\n")
+            debugLog("スタックトレース:\n\(trace)")
+        }
+
+        // MARK: 致命的シグナルの捕捉
+        // プロセス終了につながる代表的なシグナルを横取りし
+        // スタックトレースを表示した上で終了する
+        func handleSignal(_ signalValue: Int32, name: String) {
+            debugLog("\(name) を受信")
+            let stack = Thread.callStackSymbols.joined(separator: "\n")
+            debugLog("スタックトレース:\n\(stack)")
+            exit(signalValue)
+        }
+        signal(SIGABRT) { _ in handleSignal(SIGABRT, name: "SIGABRT") }
+        signal(SIGILL)  { _ in handleSignal(SIGILL,  name: "SIGILL") }
+        signal(SIGSEGV) { _ in handleSignal(SIGSEGV, name: "SIGSEGV") }
+        signal(SIGFPE)  { _ in handleSignal(SIGFPE,  name: "SIGFPE") }
+        signal(SIGBUS)  { _ in handleSignal(SIGBUS,  name: "SIGBUS") }
+#endif
+#endif
+    }
+}
+


### PR DESCRIPTION
## Summary
- capture uncaught exceptions and fatal signals to log stack traces
- include stack traces in `debugError`
- enable global error logging at app startup

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68bec4347c98832cab9819459c48522e