### PR TITLE
アプリ名をMonoKnightに統一

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,8 @@
 ## 3. リポジトリ構成（提案）
 
 ```
-KnightCards/
-  ├─ KnightCardsApp.swift
+MonoKnight/
+  ├─ MonoKnightApp.swift
   ├─ Game/
   │   ├─ GameScene.swift          # 盤面描画・タッチ入力
   │   ├─ GameCore.swift           # ルール・手番進行・スコア計算

--- a/MonoKnightApp.swift
+++ b/MonoKnightApp.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 
-// MARK: - アプリのエントリーポイント
+// MARK: - MonoKnight アプリのエントリーポイント
 // `@main` 属性を付与した構造体からアプリが開始される
 @main
-struct KnightCardsApp: App {
+/// アプリ全体のライフサイクルを管理する構造体
+struct MonoKnightApp: App {
     /// Game Center と広告サービスのインスタンス
     /// - NOTE: UI テスト時はモックを使用する
     private let gameCenterService: GameCenterServiceProtocol


### PR DESCRIPTION
## Summary
- rename main app struct and file to `MonoKnightApp`
- update documentation to reflect official name

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68c0b079999c832cb28f6402edd7c9e9