### PR TITLE
Xcode ワークスペースを .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,11 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from the Xcode workspace
 # *.xcworkspace
 
+# Xcode プロジェクトのワークスペースを Git から除外する
+MonoKnight.xcodeproj/project.xcworkspace/
+# 他のワークスペースもまとめて除外したい場合は下記を使用
+# *.xcworkspace/
+
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.


### PR DESCRIPTION
## Summary
- `.gitignore` に `MonoKnight.xcodeproj/project.xcworkspace/` を追記して Xcode ワークスペースを除外

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68c0b47c0688832cbba09143ae98c6fb