### PR TITLE
VSCode 設定を除外しサンプル設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# VSCode の個別設定を除外
+.vscode/

--- a/.vscode.sample/settings.json
+++ b/.vscode.sample/settings.json
@@ -1,0 +1,9 @@
+{
+    // VSCode で Swift 開発を行う際の推奨設定サンプル
+    "editor.tabSize": 4, // インデント幅を半角スペース4つに統一
+    "editor.insertSpaces": true, // タブの代わりにスペースを使用
+    "files.exclude": {
+        // ビルド成果物をエクスプローラーから非表示にする
+        "**/.build": true
+    }
+}

--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ swift test
 
  - 初めて環境構築を行う場合やデバッグビルドの作成方法については  
    [`docs/development-basics.md`](docs/development-basics.md) を参照してください。
+
+## VSCode の設定共有
+
+開発者ごとの VSCode 設定は `.vscode/` ディレクトリに保存しますが、リポジトリでは追跡しません。
+共有したい設定を `.vscode.sample` にサンプルとして用意しているので、必要に応じて以下のコマンドでコピーしてください。
+
+```bash
+cp -r .vscode.sample .vscode
+```
+
+コピー後、環境に合わせて設定内容を調整してから利用してください。


### PR DESCRIPTION
## Summary
- `.vscode/` を `.gitignore` に追加してエディタ固有の設定を除外
- 共有用の VSCode サンプル設定を `.vscode.sample/settings.json` に追加
- README にサンプル設定を `.vscode` にコピーする手順を追記

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68c0b48257d4832cbd7a53f5c42d505b