### PR TITLE
開発環境の生成物を無視する設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,14 @@ fastlane/test_output
 
 # VSCode の個別設定を除外
 .vscode/
+# macOS のメタデータを除外
+.DS_Store
+
+# Xcode のビルド成果物を除外
+DerivedData/
+
+# Swift Package Manager の作業ディレクトリを除外
+.swiftpm/
+
+# ローカル環境ごとの機密設定ファイルを除外
+Config/Local.xcconfig


### PR DESCRIPTION
## Summary
- macOS や SwiftPM で生成されるファイル・ディレクトリを .gitignore に追加

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68c0d6645d58832cb054be8c6c840ffb