### PR TITLE
iOS アプリの最小プロジェクトと設定ファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
 ## User settings
-xcuserdata/
+**/*.xcuserdata/
+**/*.xcuserdatad/
 
 ## Obj-C/Swift specific
 *.hmap
@@ -68,3 +69,6 @@ fastlane/test_output
 
 # VSCode の個別設定を除外
 .vscode/
+
+# 開発者ごとの個別設定ファイル
+Config/Local.xcconfig

--- a/Config/Default.xcconfig
+++ b/Config/Default.xcconfig
@@ -1,0 +1,18 @@
+# 共通設定ファイル
+# すべての開発者が共有するビルド設定をここに記述する
+
+# アプリ名
+PRODUCT_NAME = MonoKnight
+
+# バンドルID
+PRODUCT_BUNDLE_IDENTIFIER = com.koki.monoknight$(BUNDLE_ID_SUFFIX)
+
+# チームIDやサフィックスは環境ごとに上書き
+DEVELOPMENT_TEAM =
+BUNDLE_ID_SUFFIX =
+
+# 表示名（ホーム画面に表示される名称）
+APP_DISPLAY_NAME = $(PRODUCT_NAME)
+
+# 個人設定を上書きするファイルを読み込む（存在しない場合は無視）
+#include? "Local.xcconfig"

--- a/Config/Local.xcconfig.sample
+++ b/Config/Local.xcconfig.sample
@@ -1,0 +1,9 @@
+# 開発者ごとの個別設定サンプル
+# このファイルを Local.xcconfig にコピーして使用する
+# Local.xcconfig は .gitignore に登録されているためコミットされない
+
+# Apple Developer の Team ID を記入
+DEVELOPMENT_TEAM = YOUR_TEAM_ID
+
+# バンドルIDのサフィックスを記入
+BUNDLE_ID_SUFFIX = .koki

--- a/MonoKnight.xcodeproj/project.pbxproj
+++ b/MonoKnight.xcodeproj/project.pbxproj
@@ -1,0 +1,174 @@
+// !$*UTF8*$!
+/* 最小構成の Xcode プロジェクト。詳細な設定は xcconfig で管理する */
+{
+archiveVersion = 1;
+classes = {
+};
+objectVersion = 56;
+objects = {
+
+/* Begin PBXBuildFile section */
+000000000000000000000005 /* MonoKnightApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000004 /* MonoKnightApp.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+000000000000000000000003 /* MonoKnight.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MonoKnight.app; sourceTree = BUILT_PRODUCTS_DIR; };
+000000000000000000000004 /* MonoKnightApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonoKnightApp.swift; sourceTree = "<group>"; };
+000000000000000000000009 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+000000000000000000000006 = {
+isa = PBXGroup;
+children = (
+000000000000000000000007 /* MonoKnight */,
+000000000000000000000008 /* Products */,
+);
+sourceTree = "<group>";
+};
+000000000000000000000007 /* MonoKnight */ = {
+isa = PBXGroup;
+children = (
+000000000000000000000004 /* MonoKnightApp.swift */,
+000000000000000000000009 /* Info.plist */,
+);
+path = "";
+sourceTree = "<group>";
+};
+000000000000000000000008 /* Products */ = {
+isa = PBXGroup;
+children = (
+000000000000000000000003 /* MonoKnight.app */,
+);
+name = Products;
+sourceTree = "<group>";
+};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+000000000000000000000002 /* MonoKnight */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = 00000000000000000000000D /* Build configuration list for PBXNativeTarget "MonoKnight" */;
+buildPhases = (
+00000000000000000000000A /* Sources */,
+00000000000000000000000B /* Resources */,
+);
+buildRules = (
+);
+dependencies = (
+);
+name = MonoKnight;
+productName = MonoKnight;
+productReference = 000000000000000000000003 /* MonoKnight.app */;
+productType = "com.apple.product-type.application";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+000000000000000000000001 /* Project object */ = {
+isa = PBXProject;
+attributes = {
+BuildIndependentTargetsInParallel = YES;
+LastSwiftUpdateCheck = 1500;
+LastUpgradeCheck = 1500;
+};
+buildConfigurationList = 00000000000000000000000C /* Build configuration list for PBXProject "MonoKnight" */;
+compatibilityVersion = "Xcode 15.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+knownRegions = (
+en,
+Base,
+);
+mainGroup = 000000000000000000000006;
+productRefGroup = 000000000000000000000008 /* Products */;
+projectDirPath = "";
+projectRoot = "";
+targets = (
+000000000000000000000002 /* MonoKnight */,
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+00000000000000000000000B /* Resources */ = {
+isa = PBXResourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+00000000000000000000000A /* Sources */ = {
+isa = PBXSourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+000000000000000000000005 /* MonoKnightApp.swift in Sources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+00000000000000000000000E /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+INFOPLIST_FILE = Info.plist;
+PRODUCT_BUNDLE_IDENTIFIER = com.koki.monoknight;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1";
+};
+name = Debug;
+};
+00000000000000000000000F /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+INFOPLIST_FILE = Info.plist;
+PRODUCT_BUNDLE_IDENTIFIER = com.koki.monoknight;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1";
+};
+name = Release;
+};
+000000000000000000000010 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+};
+name = Debug;
+};
+000000000000000000000011 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+};
+name = Release;
+};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+00000000000000000000000D /* Build configuration list for PBXNativeTarget "MonoKnight" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+00000000000000000000000E /* Debug */,
+00000000000000000000000F /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+00000000000000000000000C /* Build configuration list for PBXProject "MonoKnight" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+000000000000000000000010 /* Debug */,
+000000000000000000000011 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+/* End XCConfigurationList section */
+
+};
+rootObject = 000000000000000000000001 /* Project object */;
+}

--- a/docs/files.md
+++ b/docs/files.md
@@ -11,34 +11,37 @@ GitHub 上の **MonoKnight** リポジトリを Xcode
 
     MonoKnight/
     ├─ MonoKnight.xcodeproj      # Xcode プロジェクト
-    ├─ MonoKnightApp.swift       # エントリポイント
+    ├─ MonoKnightApp.swift       # アプリのエントリポイント
+    ├─ Info.plist                # アプリ設定
+    ├─ Package.swift             # SwiftPM 設定
+    ├─ README.md                 # プロジェクト概要
     │
-    ├─ Game/
+    ├─ Game/                     # ゲームロジック
     │   ├─ GameScene.swift
     │   ├─ GameCore.swift
     │   ├─ Deck.swift
     │   ├─ MoveCard.swift
     │   └─ Models.swift
     │
-    ├─ UI/
+    ├─ UI/                       # 画面関連
     │   ├─ RootView.swift
     │   ├─ GameView.swift
     │   ├─ ResultView.swift
     │   └─ SettingsView.swift
     │
-    ├─ Services/
+    ├─ Services/                 # プラットフォーム機能
     │   ├─ StoreService.swift
     │   ├─ AdsService.swift
     │   └─ GameCenterService.swift
     │
-    ├─ Resources/
-    │   ├─ Assets.xcassets
-    │   └─ Localizable.strings
+    ├─ Tests/                    # テストコード
+    │   └─ ...
     │
     ├─ Config/
     │   ├─ Default.xcconfig
     │   └─ Local.xcconfig.sample
     │
+    ├─ docs/                     # ドキュメント
     ├─ AGENTS.md
     └─ .gitignore
 


### PR DESCRIPTION
## Summary
- 共有用の Xcode プロジェクト `MonoKnight.xcodeproj` を追加
- 共通およびローカル設定の `xcconfig` テンプレートを作成
- `Local.xcconfig` と `*.xcuserdata` を `.gitignore` で除外
- ドキュメントのフォルダ構成を実際のレイアウトに更新

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68c0d666ca64832c80f23e472df1b642