### PR TITLE
docs: READMEにシミュレーター手順リンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ swift test
 
 ## 開発の基本手順
 
- - 初めて環境構築を行う場合やデバッグビルドの作成方法については  
+ - 初めて環境構築を行う場合やデバッグビルドの作成方法については
    [`docs/development-basics.md`](docs/development-basics.md) を参照してください。
+ - iOS シミュレーターでアプリを動かすための設定手順は
+   [`docs/xcode-emulator-setup.md`](docs/xcode-emulator-setup.md) を参照してください。
 
 ## VSCode の設定共有
 


### PR DESCRIPTION
## Summary
- README の「開発の基本手順」に iOS シミュレーター実行手順のリンクを追加
- リンク先の目的がシミュレーター実行であることを明記

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68c0d66d6e5c832c84d17c4184c22b56