### PR TITLE
docs: unify Xcode project location and structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ fastlane/test_output
 
 # VSCode の個別設定を除外
 .vscode/
+
+# iOS アプリの個人設定ファイルを除外
+MonoKnightApp/Config/Local.xcconfig

--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ swift test
 
 ## 開発の基本手順
 
- - 初めて環境構築を行う場合やデバッグビルドの作成方法については  
+ - 初めて環境構築を行う場合やデバッグビルドの作成方法については
    [`docs/development-basics.md`](docs/development-basics.md) を参照してください。
+ - iOS アプリ用の Xcode プロジェクトはリポジトリ内の `MonoKnightApp/` に配置し、
+   個人設定は `.gitignore` 済みの `MonoKnightApp/Config/Local.xcconfig` で管理します。
+ - シミュレーターでの起動手順は [`docs/xcode-emulator-setup.md`](docs/xcode-emulator-setup.md) を参照してください。
 
 ## VSCode の設定共有
 

--- a/docs/files.md
+++ b/docs/files.md
@@ -5,42 +5,25 @@
 GitHub 上の **MonoKnight** リポジトリを Xcode
 で開発・実行できるようにし、チームメンバー間で個人依存設定が衝突しない管理方法を確立する。
 
+> **方針**：iOS アプリ用の Xcode プロジェクトはリポジトリ内（`MonoKnight/MonoKnightApp`）に配置し、個人設定ファイルは `.gitignore` で除外する。
+
 ------------------------------------------------------------------------
 
 ## フォルダ構成（最終版）
 
     MonoKnight/
-    ├─ MonoKnight.xcodeproj      # Xcode プロジェクト
-    ├─ MonoKnightApp.swift       # エントリポイント
-    │
-    ├─ Game/
-    │   ├─ GameScene.swift
-    │   ├─ GameCore.swift
-    │   ├─ Deck.swift
-    │   ├─ MoveCard.swift
-    │   └─ Models.swift
-    │
-    ├─ UI/
-    │   ├─ RootView.swift
-    │   ├─ GameView.swift
-    │   ├─ ResultView.swift
-    │   └─ SettingsView.swift
-    │
-    ├─ Services/
-    │   ├─ StoreService.swift
-    │   ├─ AdsService.swift
-    │   └─ GameCenterService.swift
-    │
-    ├─ Resources/
-    │   ├─ Assets.xcassets
-    │   └─ Localizable.strings
-    │
-    ├─ Config/
-    │   ├─ Default.xcconfig
-    │   └─ Local.xcconfig.sample
-    │
-    ├─ AGENTS.md
-    └─ .gitignore
+    ├─ Game/                       # ルール・山札などのライブラリ
+    ├─ UI/                         # 画面表示用コンポーネント
+    ├─ Services/                   # 課金・広告・GameCenter
+    ├─ Resources/                  # 画像や文字列
+    └─ MonoKnightApp/              # iOS アプリ本体（Xcode プロジェクト）
+        ├─ MonoKnightApp.xcodeproj
+        ├─ Sources/
+        │   └─ MonoKnightApp.swift # エントリポイント
+        ├─ Config/
+        │   ├─ Default.xcconfig
+        │   └─ Local.xcconfig.sample
+        └─ Info.plist
 
 ------------------------------------------------------------------------
 
@@ -63,7 +46,7 @@ build/
 .build/
 
 # 個人設定ファイル
-Config/Local.xcconfig
+MonoKnightApp/Config/Local.xcconfig
 ```
 
 ------------------------------------------------------------------------
@@ -101,7 +84,7 @@ BUNDLE_ID_SUFFIX = .koki
 -   **リポジトリは1つ（MonoKnight）**\
     → コード、UI、サービス、リソースをひとまとめ。
 -   **個人依存を分離**\
-    → `Local.xcconfig` は追跡しない。
+    → `MonoKnightApp/Config/Local.xcconfig` は追跡しない。
 -   **衝突しやすいファイルは無視**\
     → `.xcuserdata`, `DerivedData` はコミット禁止。
 -   **共有したいスキームだけ Shared にする**\
@@ -113,10 +96,10 @@ BUNDLE_ID_SUFFIX = .koki
 ## 開発フロー
 
 1.  リポジトリを `git clone`。
-2.  Xcode で `MonoKnight.xcodeproj` を開く。
+2.  Xcode で `MonoKnightApp/MonoKnightApp.xcodeproj` を開く。
 3.  Config を設定：
-    -   `Default.xcconfig` は共通\
-    -   `Local.xcconfig.sample` をコピーして `Local.xcconfig`
+    -   `MonoKnightApp/Config/Default.xcconfig` は共通\
+    -   `MonoKnightApp/Config/Local.xcconfig.sample` をコピーして `Local.xcconfig`
         を作り、必要に応じて編集
 4.  スキーム：`MonoKnight` を選択、デバイス：シミュレーター（例: iPhone
     15）。
@@ -127,6 +110,6 @@ BUNDLE_ID_SUFFIX = .koki
 ## チェックリスト
 
 -   [ ] `.gitignore` が正しいか？\
--   [ ] `Local.xcconfig` はコミットしていないか？\
+-   [ ] `MonoKnightApp/Config/Local.xcconfig` はコミットしていないか？\
 -   [ ] スキームは Shared のみ共有されているか？\
 -   [ ] シミュレーターで起動できるか？

--- a/docs/xcode-emulator-setup.md
+++ b/docs/xcode-emulator-setup.md
@@ -4,6 +4,8 @@
 > 想定読者：**Swift / VS Code / Xcode / Mac 初体験**の人。
 > ゴールまでの所要時間：30–60分（ネット環境・Macの速度で変動）。
 
+> **注意**：この手順書では、Xcode のアプリプロジェクトを **リポジトリ内**（例：`MonoKnight/MonoKnightApp`）に配置する方針とする。個人で外部に置く場合は、衝突回避のため該当ディレクトリを `.gitignore` で除外すること。
+
 ---
 
 ## 0. 事前に知っておくと安心な用語（1分でOK）
@@ -88,7 +90,7 @@ xcode-select --install
    * **Team**：未選択でもOK（後で設定）
    * **Organization Identifier**：`com.koki` など（仮でOK）
    * **Interface**：SwiftUI / **Language**：Swift
-4. 保存先は `MonoKnight` の**親フォルダ**（例：`~/work`）にするのが分かりやすい。
+4. 保存先は `MonoKnight` リポジトリ内に**`MonoKnightApp` フォルダ**を作成して指定する（例：`MonoKnight/MonoKnightApp`）。
 
 > 既にリポジトリに iOS アプリのターゲットが存在する場合は、この章の作成は不要。**プロジェクトナビゲータでアプリターゲットを選んで先へ**。
 
@@ -214,12 +216,16 @@ A. ライブラリ（`Game`）にユニットテストがある場合に、**タ
 
 ```
 MonoKnight/                 # GitHub 管理ルート
-└─ MonoKnightApp/           # iOSアプリ本体
+├─ Game/                    # ルールなどのライブラリ
+├─ UI/                      # 画面レイアウト群
+├─ Services/                # 課金・広告・GC など
+└─ MonoKnightApp/           # iOSアプリ本体（ここに Xcode プロジェクトを置く）
    ├─ MonoKnightApp.xcodeproj
    ├─ Config/
    │  ├─ Default.xcconfig          # 共有設定（追跡）
    │  └─ Local.xcconfig.sample     # 個人設定の雛形（追跡）
    ├─ Sources/
+   │  └─ MonoKnightApp.swift       # アプリのエントリポイント
    └─ Info.plist
 ```
 


### PR DESCRIPTION
## Summary
- document that the Xcode app project lives inside the repository (`MonoKnight/MonoKnightApp`)
- align Appendix A structure diagram with text
- update README and files manual accordingly
- ignore `MonoKnightApp/Config/Local.xcconfig`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68c0d676f7ac832ca902dc489dd1ce28