### PR TITLE
Board を Equatable に準拠して onChange エラーを解消

### DIFF
--- a/Game/Models.swift
+++ b/Game/Models.swift
@@ -37,7 +37,8 @@ enum TileState {
 }
 
 /// 5×5 の盤面を管理する構造体
-struct Board {
+/// SwiftUI の `onChange` で盤面の変化を検知できるよう Equatable に準拠
+struct Board: Equatable {
     /// 盤面のサイズ (5×5 固定)
     static let size = 5
 


### PR DESCRIPTION
## 概要
- Board 構造体を Equatable に準拠させ、SwiftUI の `onChange` に対応

## テスト
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68c22258c958832c80c144c2ee31967b