### PR TITLE
Add illustrative move card view

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -69,7 +69,7 @@ struct GameView: View {
                         HStack(spacing: 12) {
                             // MoveCard は Identifiable に準拠していないため、enumerated の offset を id として利用
                             ForEach(Array(core.hand.enumerated()), id: \.offset) { index, card in
-                                cardView(for: card)
+                                MoveCardIllustrationView(card: card)
                                     // 盤外に出るカードは薄く表示し、タップを無効化
                                     .opacity(isCardUsable(card) ? 1.0 : 0.4)
                                     .onTapGesture {
@@ -98,7 +98,7 @@ struct GameView: View {
                             HStack(spacing: 4) {
                                 Text("次のカード")
                                     .font(.caption)
-                                cardView(for: next)
+                                MoveCardIllustrationView(card: next)
                                     .opacity(0.6)  // 先読みは操作不可なので半透明
                             }
                         }
@@ -158,30 +158,6 @@ struct GameView: View {
         return core.board.contains(target)
     }
 
-    /// カードの簡易表示ビュー
-    /// - Parameter card: 表示対象の MoveCard（列挙型）
-    private func cardView(for card: MoveCard) -> some View {
-        ZStack {
-            // 枠付きの白いカードを描画
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(Color.white, lineWidth: 1)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(Color.gray.opacity(0.2))
-                )
-            // MoveCard に定義された displayName を表示（例: 上2右1）
-            Text(card.displayName)
-                .font(.caption)
-                .foregroundColor(.white)
-        }
-        .frame(width: 60, height: 80)
-        // VoiceOver での読み上げ用ラベルを設定
-        .accessibilityLabel(Text(card.displayName))
-        // 操作方法を案内するヒントを付与（ダブルタップで使用）
-        .accessibilityHint(Text("ダブルタップでこの方向に移動します"))
-        // ボタンとして扱わせるためのトレイトを追加
-        .accessibilityAddTraits(.isButton)
-    }
 }
 
 // MARK: - プレビュー

--- a/UI/MoveCardIllustrationView.swift
+++ b/UI/MoveCardIllustrationView.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+
+/// 移動カードの内容を視覚的に表現するビュー
+/// 5×5 のグリッドと現在地・目的地・移動方向を描画してカード効果を直感的に把握できるようにする
+struct MoveCardIllustrationView: View {
+    /// 表示対象の移動カード
+    let card: MoveCard
+
+    var body: some View {
+        ZStack {
+            // MARK: - カードの背景枠
+            // 既存のカードスタイル（角丸の枠付き）を踏襲して統一感を保つ
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.white, lineWidth: 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.gray.opacity(0.2))
+                )
+
+            VStack(spacing: 6) {
+                // MARK: - 盤面イメージ
+                // 正方形の領域に 5×5 グリッドと矢印などを描画する
+                GeometryReader { geometry in
+                    // 利用可能な領域から正方形サイズを算出（縦横いずれか小さい方を採用）
+                    let squareSize = min(geometry.size.width, geometry.size.height)
+                    let cellSize = squareSize / 5.0
+                    // 正方形を中心に配置するため、余白のオフセットを計算
+                    let originX = (geometry.size.width - squareSize) / 2.0
+                    let originY = (geometry.size.height - squareSize) / 2.0
+
+                    // SwiftUI の座標系は y 軸が下向きなので、盤面の「上」を画面上方向へ合わせるための変換
+                    // 盤面中央 (2,2) を基準に目的地セルを求める
+                    let centerColumn = 2
+                    let centerRow = 2
+                    let destinationColumn = centerColumn + card.dx
+                    let destinationRow = centerRow - card.dy
+
+                    // 各セルの中心座標を計算するヘルパー
+                    func cellCenter(column: Int, row: Int) -> CGPoint {
+                        CGPoint(
+                            x: originX + (CGFloat(column) + 0.5) * cellSize,
+                            y: originY + (CGFloat(row) + 0.5) * cellSize
+                        )
+                    }
+
+                    // 現在地（中央）と目的地セルの中心座標
+                    let startPoint = cellCenter(column: centerColumn, row: centerRow)
+                    let destinationPoint = cellCenter(column: destinationColumn, row: destinationRow)
+
+                    // 矢印描画のためのベクトル計算
+                    let vector = CGVector(dx: destinationPoint.x - startPoint.x, dy: destinationPoint.y - startPoint.y)
+                    let vectorLength = hypot(vector.dx, vector.dy)
+                    // 矢印の頭部分のサイズ（カードの大きさに応じて決定）
+                    let arrowHeadLength = cellSize * 0.5
+                    let arrowHeadWidth = cellSize * 0.4
+
+                    // 矢印の頭（三角形）の 2 点を求める（ベクトルがゼロの場合は描画しない）
+                    let arrowHeadPoints: (CGPoint, CGPoint)? = vectorLength > 0
+                        ? {
+                            let unit = CGVector(dx: vector.dx / vectorLength, dy: vector.dy / vectorLength)
+                            let basePoint = CGPoint(
+                                x: destinationPoint.x - unit.dx * arrowHeadLength,
+                                y: destinationPoint.y - unit.dy * arrowHeadLength
+                            )
+                            let perpendicular = CGVector(dx: -unit.dy, dy: unit.dx)
+                            let leftPoint = CGPoint(
+                                x: basePoint.x + perpendicular.dx * arrowHeadWidth / 2.0,
+                                y: basePoint.y + perpendicular.dy * arrowHeadWidth / 2.0
+                            )
+                            let rightPoint = CGPoint(
+                                x: basePoint.x - perpendicular.dx * arrowHeadWidth / 2.0,
+                                y: basePoint.y - perpendicular.dy * arrowHeadWidth / 2.0
+                            )
+                            return (leftPoint, rightPoint)
+                        }() : nil
+
+                    ZStack {
+                        // MARK: 中央マスのハイライト
+                        Rectangle()
+                            .fill(Color.white.opacity(0.12))
+                            .frame(width: cellSize, height: cellSize)
+                            .position(startPoint)
+
+                        // MARK: グリッド線（縦横 5 分割）
+                        Path { path in
+                            // 縦線を描画
+                            for index in 0...5 {
+                                let x = originX + CGFloat(index) * cellSize
+                                path.move(to: CGPoint(x: x, y: originY))
+                                path.addLine(to: CGPoint(x: x, y: originY + squareSize))
+                            }
+                            // 横線を描画
+                            for index in 0...5 {
+                                let y = originY + CGFloat(index) * cellSize
+                                path.move(to: CGPoint(x: originX, y: y))
+                                path.addLine(to: CGPoint(x: originX + squareSize, y: y))
+                            }
+                        }
+                        .stroke(Color.white.opacity(0.4), lineWidth: 0.5)
+
+                        // MARK: 現在地・目的地のマーカー
+                        Circle()
+                            .fill(Color.white)
+                            .frame(width: cellSize * 0.4, height: cellSize * 0.4)
+                            .overlay(
+                                Circle()
+                                    .stroke(Color.black.opacity(0.8), lineWidth: 1)
+                            )
+                            .position(startPoint)
+
+                        Circle()
+                            .fill(Color.black)
+                            .frame(width: cellSize * 0.4, height: cellSize * 0.4)
+                            .overlay(
+                                Circle()
+                                    .stroke(Color.white, lineWidth: 1)
+                            )
+                            .position(destinationPoint)
+
+                        // MARK: 移動方向を示す矢印（線 + 矢じり）
+                        Path { path in
+                            path.move(to: startPoint)
+                            path.addLine(to: destinationPoint)
+                        }
+                        .stroke(Color.white, style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
+
+                        if let (leftPoint, rightPoint) = arrowHeadPoints {
+                            Path { path in
+                                path.move(to: destinationPoint)
+                                path.addLine(to: leftPoint)
+                                path.addLine(to: rightPoint)
+                                path.closeSubpath()
+                            }
+                            .fill(Color.white)
+                        }
+                    }
+                }
+                .aspectRatio(1, contentMode: .fit)
+
+                // MARK: - カード名の補助ラベル
+                // テキストでも方向が確認できるよう小さめのフォントで表示
+                Text(card.displayName)
+                    .font(.caption2)
+                    .foregroundColor(.white)
+            }
+            .padding(8)
+        }
+        .frame(width: 60, height: 80)
+        // VoiceOver で方向が伝わるよう既存のラベルを継承
+        .accessibilityLabel(Text(card.displayName))
+        // カード操作のヒントも旧仕様を維持
+        .accessibilityHint(Text("ダブルタップでこの方向に移動します"))
+        // VoiceOver 上でボタンとして扱えるようトレイトを付与
+        .accessibilityAddTraits(.isButton)
+    }
+}
+
+// MARK: - プレビュー
+#Preview {
+    VStack(spacing: 12) {
+        MoveCardIllustrationView(card: .knightUp2Right1)
+        MoveCardIllustrationView(card: .diagonalDownLeft2)
+    }
+    .padding()
+    .background(Color.black)
+}


### PR DESCRIPTION
## Summary
- create `MoveCardIllustrationView` to render 5x5 grid, markers, and arrow based on card offsets
- adopt the new illustration view in `GameView` hand and preview card slots while keeping accessibility labels

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ce054c4dd8832ca9b997aa809508c4