### PR TITLE
Expand GameCore hand size to five cards

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -98,14 +98,14 @@ struct Deck {
     // MARK: - 全引き直し
     /// 手札と先読みカードをすべて捨札に送り、新しいカードを引き直す
     /// - Parameters:
-    ///   - hand: 現在の手札（3 枚を想定）
+    ///   - hand: 現在の手札（渡された枚数分だけ新たに引き直す）
     ///   - next: 先読みカード
     /// - Returns: 新しい手札と先読みカードのタプル
     mutating func fullRedraw(hand: [MoveCard], next: MoveCard?) -> (hand: [MoveCard], next: MoveCard?) {
         // 既存カードをすべて捨札へ
         hand.forEach { discard($0) }
         if let next = next { discard(next) }
-        // 新しい手札と先読みを引く
+        // hand.count を利用することで、手札枚数が 5 枚でも柔軟に再配布できる
         let newHand = draw(count: hand.count)
         let newNext = draw()
         return (newHand, newNext)


### PR DESCRIPTION
## Summary
- introduce a shared hand-size constant in `GameCore` and update related comments to assume five cards
- adjust `Deck.fullRedraw` documentation to describe hand-size dependent draws
- rebuild unit tests around five-card hands and add coverage for initialization/reset counts

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ce1230ea78832cb0b9fb7fd0b1c0dd