### PR TITLE
Fix accessibility trait enum cases

### DIFF
--- a/UI/MoveCardIllustrationView.swift
+++ b/UI/MoveCardIllustrationView.swift
@@ -94,7 +94,7 @@ struct MoveCardIllustrationView: View {
             case .hand:
                 return .isButton
             case .next:
-                return .staticText
+                return .isStaticText
             }
         }
 
@@ -102,7 +102,7 @@ struct MoveCardIllustrationView: View {
         var traitsToRemove: AccessibilityTraits {
             switch self {
             case .hand:
-                return .staticText
+                return .isStaticText
             case .next:
                 return .isButton
             }


### PR DESCRIPTION
## Summary
- adjust MoveCardIllustrationView accessibility traits to use the updated `.isStaticText` constant for static content

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68ce14d31750832c8b1f806ca0ebab4b