### PR TITLE
Expose metrics counters with on-board overlay

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -30,12 +30,14 @@ final class GameCore: ObservableObject {
     /// ゲームの進行状態
     @Published private(set) var progress: GameProgress = .playing
 
-    /// 実際に移動した回数
-    private(set) var moveCount: Int = 0
-    /// ペナルティによる加算手数
-    private(set) var penaltyCount: Int = 0
+    /// 実際に移動した回数（UI へ即時反映させるため @Published を付与）
+    @Published private(set) var moveCount: Int = 0
+    /// ペナルティによる加算手数（手詰まり通知に利用するため公開）
+    @Published private(set) var penaltyCount: Int = 0
     /// 合計スコア（小さいほど良い）
     var score: Int { moveCount + penaltyCount }
+    /// 未踏破マスの残り数を UI へ公開する計算プロパティ
+    var remainingTiles: Int { board.remainingCount }
 
     /// 山札管理（`Deck.swift` に定義された構造体を使用）
     private var deck = Deck()

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -51,19 +51,58 @@ struct GameView: View {
         GeometryReader { geometry in
             ZStack(alignment: .topTrailing) {
                 VStack(spacing: 16) {
-                    // MARK: SpriteKit 表示領域
-                    SpriteView(scene: scene)
-                        // 正方形で表示したいため幅に合わせる
-                        .frame(width: geometry.size.width, height: geometry.size.width)
-                        .onAppear {
-                            // サイズと初期状態を反映
-                            scene.size = CGSize(
-                                width: geometry.size.width, height: geometry.size.width)
-                            scene.updateBoard(core.board)
-                            scene.moveKnight(to: core.current)
+                    // MARK: SpriteKit 表示領域（上部に統計バッジを重ねる）
+                    ZStack(alignment: .topLeading) {
+                        SpriteView(scene: scene)
+                            // 正方形で表示したいため幅に合わせる
+                            .frame(width: geometry.size.width, height: geometry.size.width)
+
+                        // 盤面進行度を示すモノクロバッジ（VoiceOver 対応）
+                        HStack(spacing: 12) {
+                            statisticBadge(
+                                title: "移動",
+                                value: "\(core.moveCount)",
+                                accessibilityLabel: "移動回数",
+                                accessibilityValue: "\(core.moveCount)回"
+                            )
+
+                            statisticBadge(
+                                title: "ペナルティ",
+                                value: "\(core.penaltyCount)",
+                                accessibilityLabel: "ペナルティ回数",
+                                accessibilityValue: "\(core.penaltyCount)手"
+                            )
+
+                            statisticBadge(
+                                title: "残りマス",
+                                value: "\(core.remainingTiles)",
+                                accessibilityLabel: "残りマス数",
+                                accessibilityValue: "残り\(core.remainingTiles)マス"
+                            )
                         }
-                        .onReceive(core.$board) { newBoard in scene.updateBoard(newBoard) }
-                        .onReceive(core.$current) { newPoint in scene.moveKnight(to: newPoint) }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(
+                            // モノクロ構成を崩さず読みやすさを確保する半透明黒
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.black.opacity(0.75))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color.white.opacity(0.25), lineWidth: 1)
+                        )
+                        .padding(16)
+                    }
+                    .frame(width: geometry.size.width, height: geometry.size.width)
+                    .onAppear {
+                        // サイズと初期状態を反映
+                        scene.size = CGSize(
+                            width: geometry.size.width, height: geometry.size.width)
+                        scene.updateBoard(core.board)
+                        scene.moveKnight(to: core.current)
+                    }
+                    .onReceive(core.$board) { newBoard in scene.updateBoard(newBoard) }
+                    .onReceive(core.$current) { newPoint in scene.moveKnight(to: newPoint) }
 
                     // MARK: 手札と先読みカードの表示
                     VStack(spacing: 8) {
@@ -148,6 +187,37 @@ struct GameView: View {
         let target = core.current.offset(dx: card.dx, dy: card.dy)
         // 目的地が盤面内に含まれているかどうかを判定
         return core.board.contains(target)
+    }
+
+    /// 盤面上部に表示する統計テキストの共通レイアウト
+    /// - Parameters:
+    ///   - title: メトリクスのラベル（例: 移動）
+    ///   - value: 表示する数値文字列
+    ///   - accessibilityLabel: VoiceOver に読み上げさせる日本語ラベル
+    ///   - accessibilityValue: VoiceOver 用の値（単位を含めた文章）
+    /// - Returns: モノクロ配色の小型バッジビュー
+    private func statisticBadge(
+        title: String,
+        value: String,
+        accessibilityLabel: String,
+        accessibilityValue: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            // 補助ラベルは控えめなトーンで表示
+            Text(title)
+                .font(.caption2)
+                .fontWeight(.medium)
+                .foregroundColor(.white.opacity(0.65))
+
+            // 主数値は視認性を高めるためサイズとコントラストを強調
+            Text(value)
+                .font(.headline)
+                .foregroundColor(.white)
+        }
+        // VoiceOver ではカスタムラベルと値を読み上げさせる
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(accessibilityValue)
     }
 
     /// 指定したスロットのカード（存在しない場合は nil）を取得するヘルパー


### PR DESCRIPTION
## Summary
- publish move and penalty counters from `GameCore` and expose a computed remaining tile count for UI bindings
- overlay a monochrome metrics bar on the game board showing moves, penalties, and remaining tiles with VoiceOver labels
- refactor the view helper to render accessible metric badges matching the updated design guidance

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce1e9945f0832c8d0625e8f529e328