### PR TITLE
Remove debug coordinate overlay from game board

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -109,15 +109,7 @@ class GameScene: SKScene {
                 addChild(node)
                 let point = GridPoint(x: x, y: y)
                 tileNodes[point] = node
-
-#if DEBUG
-                // デバッグ時は各マスの座標を赤文字で表示
-                let label = SKLabelNode(text: "\(x),\(y)")
-                label.fontSize = tileSize * 0.3
-                label.fontColor = .red
-                label.position = CGPoint(x: rect.midX, y: rect.midY - label.fontSize / 2)
-                addChild(label)
-#endif
+                // テストプレイ時の没入感を損なわないよう、デバッグ用の座標ラベルは描画しない
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove the debug-only coordinate labels from each board tile so they no longer appear during test play

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce241edcdc832cb8d15f8661845d86