### PR TITLE
Add how to play guide and integrate into UI

### DIFF
--- a/UI/HowToPlayView.swift
+++ b/UI/HowToPlayView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+/// ゲームの遊び方を段階的に説明するビュー
+/// カード挙動の例や勝利条件・ペナルティの概要をまとめ、初見でも流れを理解しやすくする
+struct HowToPlayView: View {
+    /// モーダル表示時に閉じるボタンを出すかどうかのフラグ
+    /// - Note: タイトル画面からシートで開く場合のみ true を渡す
+    let showsCloseButton: Bool
+    /// 画面を閉じるための環境変数
+    @Environment(\.dismiss) private var dismiss
+
+    /// デフォルト引数付きのイニシャライザ
+    /// - Parameter showsCloseButton: ナビゲーションバーに「閉じる」ボタンを表示するか
+    init(showsCloseButton: Bool = false) {
+        self.showsCloseButton = showsCloseButton
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                // MARK: - 導入文
+                Text("MonoKnight は移動カードを使って 5×5 の盤面を踏破するパズルです。以下の流れを押さえておけば、すぐにプレイを始められます。")
+                    .font(.body)
+                    .padding(.bottom, 8)
+
+                // MARK: - 基本移動の説明
+                HowToPlaySectionView(
+                    title: "1. カードを 1 枚選んで駒を動かす",
+                    description: "手札に並ぶカードから 1 枚を選び、描かれた方向へ騎士を移動させます。",
+                    card: .kingUp,
+                    tips: [
+                        "カードの矢印が示す方向に 1 マス進みます。",
+                        "白い丸が現在位置、黒い丸が移動先を表します。"
+                    ]
+                )
+
+                // MARK: - ナイト移動の例
+                HowToPlaySectionView(
+                    title: "2. ナイト型カードで L 字に跳ぶ",
+                    description: "一部のカードはチェスのナイトと同じく L 字に移動します。盤面を広く踏破する鍵になります。",
+                    card: .knightUp2Right1,
+                    tips: [
+                        "2 マス進んだ後に 1 マス横へ曲がります。",
+                        "行き止まりを回避するために温存しておく戦略も重要です。"
+                    ]
+                )
+
+                // MARK: - 遠距離カードの例
+                HowToPlaySectionView(
+                    title: "3. 2 マス先まで届くカード",
+                    description: "直線や斜めに 2 マス進むカードもあります。使えるマスが限られるため、盤外判定に注意しましょう。",
+                    card: .straightUp2,
+                    tips: [
+                        "盤外へ出るカードは自動で選べなくなり、半透明表示になります。",
+                        "移動先が未踏破マスであればカウントが増え、全マス踏破でクリアです。"
+                    ]
+                )
+
+                // MARK: - 勝利条件の説明
+                HowToPlaySectionView(
+                    title: "4. 勝利条件",
+                    description: "25 マスすべてを一度ずつ踏破するとクリアとなり、手数がスコアとして記録されます。",
+                    card: nil,
+                    tips: [
+                        "踏破済みマスはグレー表示になり、未踏破との区別がつきます。",
+                        "最小の手数でクリアを目指し、Game Center ランキング上位を狙いましょう。"
+                    ]
+                )
+
+                // MARK: - ペナルティの説明
+                HowToPlaySectionView(
+                    title: "5. 行き詰まったときはペナルティ",
+                    description: "手札 3 枚すべてが盤外で使えない場合、手数に +5 のペナルティが加算され、手札が引き直されます。",
+                    card: nil,
+                    tips: [
+                        "ペナルティ後は新しい手札で再挑戦できますが、スコアには不利です。",
+                        "盤外になりやすいカードを連続で消費しないよう計画的にプレイしましょう。"
+                    ]
+                )
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 28)
+        }
+        .background(Color(UIColor.systemBackground))
+        .navigationTitle("遊び方")
+        .toolbar {
+            // MARK: - モーダル用の閉じるボタン
+            if showsCloseButton {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("閉じる") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - 共通セクション描画用サブビュー
+private struct HowToPlaySectionView: View {
+    /// セクションタイトル
+    let title: String
+    /// 説明文
+    let description: String
+    /// 例示するカード（任意）
+    let card: MoveCard?
+    /// 補足のポイント一覧
+    let tips: [String]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // MARK: - タイトル
+            Text(title)
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            // MARK: - 説明文
+            Text(description)
+                .font(.body)
+
+            // MARK: - カード挙動の例
+            if let card {
+                MoveCardIllustrationView(card: card)
+                    .frame(height: 180)
+                    .padding(.vertical, 4)
+            }
+
+            // MARK: - 補足事項のリスト
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(tips.indices, id: \.self) { index in
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.caption)
+                            .foregroundColor(.accentColor)
+                            .padding(.top, 2)
+                        Text(tips[index])
+                            .font(.callout)
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(UIColor.secondarySystemBackground))
+        )
+    }
+}
+
+#Preview {
+    NavigationStack {
+        HowToPlayView()
+    }
+}

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -103,6 +103,9 @@ struct RootView: View {
 private struct TitleScreenView: View {
     /// ゲーム開始ボタンが押された際の処理
     let onStart: () -> Void
+    /// 遊び方シートの表示状態を保持するフラグ
+    /// - Note: ボタンのタップで true にしてモーダルを開く
+    @State private var isPresentingHowToPlay: Bool = false
 
     var body: some View {
         VStack(spacing: 28) {
@@ -131,6 +134,21 @@ private struct TitleScreenView: View {
             .controlSize(.large)
             .accessibilityIdentifier("title_start_button")
 
+            // MARK: - 遊び方シートを開くボタン
+            Button {
+                // 遊び方の詳細解説をモーダルで表示する
+                isPresentingHowToPlay = true
+            } label: {
+                Label("遊び方を見る", systemImage: "questionmark.circle")
+                    .font(.system(size: 16, weight: .medium, design: .rounded))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .tint(.white.opacity(0.8))
+            .foregroundColor(.white)
+            .controlSize(.large)
+            .accessibilityIdentifier("title_how_to_play_button")
+
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 32)
@@ -139,6 +157,13 @@ private struct TitleScreenView: View {
         .background(Color.black)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("タイトル画面。ゲームを開始するボタンがあります。")
+        // 遊び方シートの表示設定
+        .sheet(isPresented: $isPresentingHowToPlay) {
+            // NavigationStack でタイトルバーを付与しつつ共通ビューを利用
+            NavigationStack {
+                HowToPlayView(showsCloseButton: true)
+            }
+        }
     }
 }
 

--- a/UI/SettingsView.swift
+++ b/UI/SettingsView.swift
@@ -6,35 +6,52 @@ struct SettingsView: View {
     @AppStorage("haptics_enabled") private var hapticsEnabled: Bool = true
 
     var body: some View {
-        List {
-            // ハプティクス制御セクション
-            Section {
-                Toggle("ハプティクスを有効にする", isOn: $hapticsEnabled)
-            } header: {
-                Text("ハプティクス")
-            } footer: {
-                // 広告警告などの振動もオフになることを明示
-                Text("ゲーム内操作や広告警告の振動を制御します。オフにすると警告通知でも振動しません。")
-            }
+        NavigationStack {
+            List {
+                // ハプティクス制御セクション
+                Section {
+                    Toggle("ハプティクスを有効にする", isOn: $hapticsEnabled)
+                } header: {
+                    Text("ハプティクス")
+                } footer: {
+                    // 広告警告などの振動もオフになることを明示
+                    Text("ゲーム内操作や広告警告の振動を制御します。オフにすると警告通知でも振動しません。")
+                }
 
-            // プライバシー操作セクション
-            Section {
-                Button("プライバシー設定を更新") {
-                    Task { await AdsService.shared.refreshConsentStatus() }
-                }
-                Button("同意取得フローをやり直す") {
-                    Task {
-                        await AdsService.shared.requestTrackingAuthorization()
-                        await AdsService.shared.requestConsentIfNeeded()
+                // プライバシー操作セクション
+                Section {
+                    Button("プライバシー設定を更新") {
+                        Task { await AdsService.shared.refreshConsentStatus() }
                     }
+                    Button("同意取得フローをやり直す") {
+                        Task {
+                            await AdsService.shared.requestTrackingAuthorization()
+                            await AdsService.shared.requestConsentIfNeeded()
+                        }
+                    }
+                } header: {
+                    Text("プライバシー設定")
+                } footer: {
+                    // ユーザーが何を行えるのかを補足
+                    Text("広告配信に関するトラッキング許可や同意フォームを再確認できます。")
                 }
-            } header: {
-                Text("プライバシー設定")
-            } footer: {
-                // ユーザーが何を行えるのかを補足
-                Text("広告配信に関するトラッキング許可や同意フォームを再確認できます。")
+
+                // MARK: - ヘルプセクション
+                Section {
+                    NavigationLink {
+                        // 遊び方の詳細解説をいつでも確認できるようにする
+                        HowToPlayView()
+                    } label: {
+                        Label("遊び方を見る", systemImage: "questionmark.circle")
+                    }
+                } header: {
+                    Text("ヘルプ")
+                } footer: {
+                    // プレイ中に迷った際の確認先を案内
+                    Text("カードの動きや勝利条件をいつでも振り返れます。")
+                }
             }
+            .navigationTitle("設定")
         }
-        .navigationTitle("設定")
     }
 }


### PR DESCRIPTION
## Summary
- add a new HowToPlayView that explains the core flow with MoveCardIllustrationView examples
- show the how-to-play sheet from the title screen for first-time players
- add a navigation link in settings so the tutorial can be opened during play

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce253a56d8832cbdea4b55a27ca797