### PR TITLE
NEXTカードの先読みを3枚に拡張

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -106,16 +106,18 @@ struct Deck {
     /// 手札と先読みカードをすべて捨札に送り、新しいカードを引き直す
     /// - Parameters:
     ///   - hand: 現在の手札（渡された枚数分だけ新たに引き直す）
-    ///   - next: 先読みカード
-    /// - Returns: 新しい手札と先読みカードのタプル
-    mutating func fullRedraw(hand: [MoveCard], next: MoveCard?) -> (hand: [MoveCard], next: MoveCard?) {
+    ///   - nextCards: 現在先読みとして保持しているカード群
+    ///   - nextCount: 先読みとして確保したい枚数（例: 3 枚）
+    /// - Returns: 新しい手札と先読みカード群のタプル
+    mutating func fullRedraw(hand: [MoveCard], nextCards: [MoveCard], nextCount: Int) -> (hand: [MoveCard], nextCards: [MoveCard]) {
         // 既存カードをすべて捨札へ
         hand.forEach { discard($0) }
-        if let next = next { discard(next) }
+        nextCards.forEach { discard($0) }
         // hand.count を利用することで、手札枚数が 5 枚でも柔軟に再配布できる
         let newHand = draw(count: hand.count)
-        let newNext = draw()
-        return (newHand, newNext)
+        // 先読み枚数は nextCount を基準に確保する
+        let newNextCards = draw(count: nextCount)
+        return (newHand, newNextCards)
     }
 }
 

--- a/Tests/GameTests/GameCoreTests.swift
+++ b/Tests/GameTests/GameCoreTests.swift
@@ -14,8 +14,14 @@ final class GameCoreTests: XCTestCase {
             .diagonalUpRight2,
             .straightRight2,
             .knightUp1Right2,
-            // 先読みカード（ペナルティ前の next として使用）
+            // 引き直し後に表示される先読みカード 3 枚
+            .kingDown,
+            .kingLeft,
+            .kingUpLeft,
+            // 初期表示の先読みカード 3 枚（この順番で補充される想定）
             .diagonalUpLeft2,
+            .kingUp,
+            .kingRight,
             // ここから手札 5 枚（すべて盤外になるカード）
             .knightDown2Left1,
             .knightDown2Right1,
@@ -35,6 +41,8 @@ final class GameCoreTests: XCTestCase {
         // 引き直し後の手札に使用可能なカードが少なくとも 1 枚あるか
         let playableExists = core.hand.contains { $0.canUse(from: core.current) }
         XCTAssertTrue(playableExists, "引き直し後の手札に利用可能なカードが存在しない")
+        // 先読みカードが 3 枚揃っているか（NEXT 表示用）
+        XCTAssertEqual(core.nextCards.count, 3, "引き直し後の先読みカードが 3 枚補充されていない")
     }
 
     /// reset() が初期状態に戻すかを確認
@@ -47,8 +55,14 @@ final class GameCoreTests: XCTestCase {
             .diagonalUpRight2,
             .straightRight2,
             .knightUp1Right2,
-            // 先読みカード（初期 next）
+            // 引き直し後に表示される先読みカード 3 枚
+            .kingDown,
+            .kingLeft,
+            .kingUpLeft,
+            // 初期の先読みカード（この順で補充される）
             .diagonalUpLeft2,
+            .kingUp,
+            .kingRight,
             // 初期手札 5 枚（全て盤外でペナルティを誘発）
             .knightDown2Left1,
             .knightDown2Right1,
@@ -72,7 +86,7 @@ final class GameCoreTests: XCTestCase {
         XCTAssertEqual(core.penaltyCount, 0, "ペナルティカウントがリセットされていない")
         XCTAssertEqual(core.progress, .playing, "ゲーム状態が playing に戻っていない")
         XCTAssertEqual(core.hand.count, 5, "手札枚数が初期値と異なる")
-        XCTAssertNotNil(core.next, "先読みカードが設定されていない")
+        XCTAssertEqual(core.nextCards.count, 3, "先読みカードが 3 枚確保されていない")
         // 盤面の踏破状態も初期化されているか
         XCTAssertTrue(core.board.isVisited(.center), "盤面中央が踏破済みになっていない")
         XCTAssertFalse(core.board.isVisited(GridPoint(x: 0, y: 0)), "開始位置が踏破済みのままになっている")

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -127,23 +127,31 @@ struct GameView: View {
                             }
                         }
 
-                        // 先読みカードが存在する場合に表示
-                        if let next = core.next {
+                        // 先読みカードが存在する場合に表示（最大 3 枚を横並びで案内）
+                        if !core.nextCards.isEmpty {
                             VStack(alignment: .leading, spacing: 6) {
                                 // MARK: - 先読みカードのラベル
                                 // テキストでセクションを明示して VoiceOver からも認識しやすくする
                                 Text("次のカード")
                                     .font(.caption)
                                     .foregroundColor(.white.opacity(0.7))
-                                    .accessibilityHidden(true)  // ラベル自体は MoveCardIllustrationView のラベルに統合する
+                                    .accessibilityHidden(true)  // ラベル自体はカード要素のラベルで読み上げる
 
                                 // MARK: - 先読みカード本体
-                                // MoveCardIllustrationView の next モードで専用スタイルを適用しつつ、操作不可のバッジを重ねる
-                                ZStack {
-                                    MoveCardIllustrationView(card: next, mode: .next)
-                                    NextCardOverlayView()
+                                // 3 枚までのカードを順番に描画し、それぞれにインジケータを重ねる
+                                HStack(spacing: 12) {
+                                    ForEach(Array(core.nextCards.enumerated()), id: \.offset) { index, card in
+                                        ZStack {
+                                            MoveCardIllustrationView(card: card, mode: .next)
+                                            NextCardOverlayView(order: index)
+                                        }
+                                        // VoiceOver で順番が伝わるようラベルを上書き
+                                        .accessibilityElement(children: .combine)
+                                        .accessibilityLabel(Text("次のカード\(index == 0 ? "" : "+\(index)"): \(card.displayName)"))
+                                        .accessibilityHint(Text("この順番で手札に補充されます"))
+                                        .allowsHitTesting(false)  // 先読みは閲覧専用
+                                    }
                                 }
-                                .allowsHitTesting(false)  // 先読みはタップ不可であることを UI 上でも保証
                             }
                         }
                     }
@@ -565,17 +573,24 @@ private struct PenaltyBannerView: View {
 }
 
 // MARK: - 先読みカード専用のオーバーレイ
-/// 「NEXT」バッジと点滅インジケータを重ね、操作不可であることを視覚的に伝える補助ビュー
+/// 「NEXT」「NEXT+1」などのバッジと点滅インジケータを重ね、操作不可であることを視覚的に伝える補助ビュー
 private struct NextCardOverlayView: View {
+    /// 表示中のカードが何枚目の先読みか（0 が直近、1 以降は +1, +2 ...）
+    let order: Int
     /// 点滅インジケータの明るさを制御するステート
     @State private var isIndicatorBright = false
+
+    /// バッジに表示する文言を算出するヘルパー
+    private var badgeText: String {
+        order == 0 ? "NEXT" : "NEXT+\(order)"
+    }
 
     var body: some View {
         ZStack {
             // MARK: - 上部の NEXT バッジ
             VStack {
                 HStack {
-                    Text("NEXT")
+                    Text(badgeText)
                         .font(.system(size: 10, weight: .bold, design: .rounded))
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)


### PR DESCRIPTION
## Summary
- ゲームロジックの先読み保持数を3枚に拡張し、山札の再補充処理を追加
- GameViewでNEXTカードを最大3枚並べて表示し、順番が分かるアクセシビリティ文言を付与
- テスト用デッキと検証を更新し、ペナルティ後やリセット直後でも先読みが3枚揃うことを確認

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ce250df2e0832ca0420273dbc4d3d6