### PR TITLE
Introduce shared theme colors for SwiftUI views

### DIFF
--- a/MonoKnightApp/Assets.xcassets/accentOnPrimary.colorset/Contents.json
+++ b/MonoKnightApp/Assets.xcassets/accentOnPrimary.colorset/Contents.json
@@ -1,0 +1,44 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.9686",
+          "green" : "0.9725",
+          "blue" : "0.9765",
+          "alpha" : "1.0000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.0471",
+          "green" : "0.0471",
+          "blue" : "0.0510",
+          "alpha" : "1.0000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MonoKnightApp/Assets.xcassets/accentPrimary.colorset/Contents.json
+++ b/MonoKnightApp/Assets.xcassets/accentPrimary.colorset/Contents.json
@@ -1,0 +1,44 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.0667",
+          "green" : "0.0667",
+          "blue" : "0.0667",
+          "alpha" : "1.0000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.9490",
+          "green" : "0.9490",
+          "blue" : "0.9490",
+          "alpha" : "1.0000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MonoKnightApp/Assets.xcassets/backgroundElevated.colorset/Contents.json
+++ b/MonoKnightApp/Assets.xcassets/backgroundElevated.colorset/Contents.json
@@ -1,0 +1,44 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.0000",
+          "green" : "1.0000",
+          "blue" : "1.0000",
+          "alpha" : "1.0000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.0863",
+          "green" : "0.0863",
+          "blue" : "0.0941",
+          "alpha" : "1.0000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MonoKnightApp/Assets.xcassets/backgroundPrimary.colorset/Contents.json
+++ b/MonoKnightApp/Assets.xcassets/backgroundPrimary.colorset/Contents.json
@@ -1,0 +1,44 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.9647",
+          "green" : "0.9686",
+          "blue" : "0.9765",
+          "alpha" : "1.0000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.0196",
+          "green" : "0.0196",
+          "blue" : "0.0275",
+          "alpha" : "1.0000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MonoKnightApp/Assets.xcassets/textPrimary.colorset/Contents.json
+++ b/MonoKnightApp/Assets.xcassets/textPrimary.colorset/Contents.json
@@ -1,0 +1,44 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.0667",
+          "green" : "0.0667",
+          "blue" : "0.0667",
+          "alpha" : "1.0000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.9569",
+          "green" : "0.9569",
+          "blue" : "0.9569",
+          "alpha" : "1.0000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MonoKnightApp/Assets.xcassets/textSecondary.colorset/Contents.json
+++ b/MonoKnightApp/Assets.xcassets/textSecondary.colorset/Contents.json
@@ -1,0 +1,44 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.3333",
+          "green" : "0.3373",
+          "blue" : "0.3529",
+          "alpha" : "1.0000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.7137",
+          "green" : "0.7176",
+          "blue" : "0.7333",
+          "alpha" : "1.0000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UI/DummyInterstitialAdView.swift
+++ b/UI/DummyInterstitialAdView.swift
@@ -3,11 +3,16 @@ import SwiftUI
 /// インタースティシャル広告のダミービュー
 /// 実際の広告 SDK を導入するまでのプレースホルダーとして使用する
 struct DummyInterstitialAdView: View {
+    /// 実広告導入までの暫定枠でもライト/ダーク対応させるためのテーマ
+    private var theme = AppTheme()
+
     var body: some View {
         // シンプルな灰色の矩形を広告枠として表示
         Text("広告")
+            .foregroundColor(theme.textSecondary)
             .frame(maxWidth: .infinity, minHeight: 60)
-            .background(Color.gray.opacity(0.3))
+            // 背景色はテーマから取得し、システム設定による明暗に追従させる
+            .background(theme.adPlaceholderBackground)
             .accessibilityIdentifier("dummy_interstitial_ad")
     }
 }

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -6,6 +6,10 @@ import UIKit  // ハプティクス用のフレームワークを追加
 /// 画面下部に手札 3 枚と次に引かれるカードを表示し、
 /// タップで GameCore を更新する
 struct GameView: View {
+    /// カラーテーマを生成し、ビュー全体で共通の配色を利用できるようにする
+    private var theme = AppTheme()
+    /// 現在のライト/ダーク設定を環境から取得し、SpriteKit 側の色にも反映する
+    @Environment(\.colorScheme) private var colorScheme
     /// 手札スロットの数（常に 5 枚分の枠を確保してレイアウトを安定させる）
     private let handSlotCount = 5
     /// ゲームロジックを保持する ObservableObject
@@ -90,13 +94,14 @@ struct GameView: View {
                         .padding(.horizontal, 12)
                         .padding(.vertical, 10)
                         .background(
-                            // 盤面外でも読みやすさを維持する半透明の黒背景
+                            // 盤面外でも読みやすさを維持する半透明の背景（テーマから取得）
                             RoundedRectangle(cornerRadius: 12)
-                                .fill(Color.black.opacity(0.8))
+                                .fill(theme.statisticBadgeBackground)
                         )
                         .overlay(
                             RoundedRectangle(cornerRadius: 12)
-                                .stroke(Color.white.opacity(0.25), lineWidth: 1)
+                                // テーマに合わせた薄い境界線でバッジを引き締める
+                                .stroke(theme.statisticBadgeBorder, lineWidth: 1)
                         )
                         .padding(.horizontal, 16)
                         .accessibilityElement(children: .contain)
@@ -134,7 +139,8 @@ struct GameView: View {
                                 // テキストでセクションを明示して VoiceOver からも認識しやすくする
                                 Text("次のカード")
                                     .font(.caption)
-                                    .foregroundColor(.white.opacity(0.7))
+                                    // テーマのサブ文字色で読みやすさと一貫性を確保
+                                    .foregroundColor(theme.textSecondary)
                                     .accessibilityHidden(true)  // ラベル自体は MoveCardIllustrationView のラベルに統合する
 
                                 // MARK: - 先読みカード本体
@@ -155,9 +161,17 @@ struct GameView: View {
                 // MARK: - 右上のメニューボタンとデバッグ向けショートカット
                 topRightOverlay
             }
-            // 画面全体を黒背景に統一
+            // 画面全体の背景もテーマで制御し、システム設定と調和させる
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.black)
+            .background(theme.backgroundPrimary)
+        }
+        // 初回表示時に SpriteKit の背景色もテーマに合わせて更新
+        .onAppear {
+            applyScenePalette(for: colorScheme)
+        }
+        // ライト/ダーク切り替えが発生した場合も SpriteKit 側へ反映
+        .onChange(of: colorScheme) { _, newScheme in
+            applyScenePalette(for: newScheme)
         }
         // progress が .cleared へ変化したタイミングで結果画面を表示
         .onChange(of: core.progress) { _, newValue in
@@ -255,6 +269,13 @@ struct GameView: View {
         .zIndex(2)
     }
 
+    /// SpriteKit シーンの背景色を現在のテーマに合わせて調整する
+    /// - Parameter scheme: ユーザーが選択中のライト/ダーク種別
+    private func applyScenePalette(for _: ColorScheme) {
+        // SwiftUI の Color から UIColor を生成し、SpriteKit の背景に適用する
+        scene.backgroundColor = UIColor(theme.backgroundPrimary)
+    }
+
     /// 指定カードが現在位置から盤内に収まるか判定
     /// - Note: MoveCard は列挙型であり、dx/dy プロパティから移動量を取得する
     private func isCardUsable(_ card: MoveCard) -> Bool {
@@ -282,12 +303,13 @@ struct GameView: View {
             Text(title)
                 .font(.caption2)
                 .fontWeight(.medium)
-                .foregroundColor(.white.opacity(0.65))
+                // テーマの補助文字色でライト/ダーク双方のコントラストを調整
+                .foregroundColor(theme.statisticTitleText)
 
             // 主数値は視認性を高めるためサイズとコントラストを強調
             Text(value)
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundColor(theme.statisticValueText)
         }
         // VoiceOver ではカスタムラベルと値を読み上げさせる
         .accessibilityElement(children: .ignore)
@@ -364,16 +386,19 @@ struct GameView: View {
     /// - Note: 実カードと同じサイズを確保してレイアウトのズレを防ぐ
     private func placeholderCardView() -> some View {
         RoundedRectangle(cornerRadius: 8)
-            .stroke(Color.white.opacity(0.25), style: StrokeStyle(lineWidth: 1, dash: [4]))
+            // テーマ由来の枠線色でライト/ダークの差異を吸収
+            .stroke(theme.placeholderStroke, style: StrokeStyle(lineWidth: 1, dash: [4]))
             .background(
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(Color.white.opacity(0.05))
+                    // 枠内もテーマ色で淡く塗りつぶし、背景とのコントラストを確保
+                    .fill(theme.placeholderBackground)
             )
             .frame(width: 60, height: 80)
             .overlay(
                 Image(systemName: "questionmark")
                     .font(.caption)
-                    .foregroundColor(Color.white.opacity(0.4))
+                    // プレースホルダアイコンもテーマ色で調整
+                    .foregroundColor(theme.placeholderIcon)
             )
             .accessibilityHidden(true)  // プレースホルダは VoiceOver の読み上げ対象外にして混乱を避ける
     }
@@ -419,15 +444,18 @@ private extension GameView {
             // 常に 44pt 以上のタップ領域を確保する
             Image(systemName: "ellipsis.circle")
                 .font(.system(size: 22, weight: .semibold))
-                .foregroundColor(.white)
+                // テーマの前景色でアイコンを描画し、背景色変更に追従
+                .foregroundColor(theme.menuIconForeground)
                 .frame(width: 44, height: 44)
                 .background(
                     Circle()
-                        .fill(Color.white.opacity(0.12))
+                        // 背景もテーマから取得し、ライトモードでも主張しすぎない色合いに調整
+                        .fill(theme.menuIconBackground)
                 )
                 .overlay(
                     Circle()
-                        .stroke(Color.white.opacity(0.25), lineWidth: 1)
+                        // わずかな境界線で視認性を高める
+                        .stroke(theme.menuIconBorder, lineWidth: 1)
                 )
         }
         .accessibilityIdentifier("game_menu")
@@ -522,16 +550,21 @@ private enum GameMenuAction: Hashable, Identifiable {
 // MARK: - 手詰まりペナルティ用のバナー表示
 /// ペナルティ発生をユーザーに伝えるトップバナーのビュー
 private struct PenaltyBannerView: View {
+    /// バナー配色を一元管理するテーマ
+    private var theme = AppTheme()
+
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
             // MARK: - 警告アイコン
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: 20, weight: .semibold))
-                .foregroundColor(.black)
+                // テーマの反転色を利用し、背景とのコントラストを確保
+                .foregroundColor(theme.penaltyIconForeground)
                 .padding(8)
                 .background(
                     Circle()
-                        .fill(Color.white)
+                        // アイコン背景もテーマ側のアクセントに合わせる
+                        .fill(theme.penaltyIconBackground)
                 )
                 .accessibilityHidden(true)  // アイコンは視覚的アクセントのみ
 
@@ -539,10 +572,11 @@ private struct PenaltyBannerView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text("手詰まり → 手札を引き直し (+5)")
                     .font(.system(size: 14, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white)
+                    // メインテキストはテーマに合わせた明度で表示
+                    .foregroundColor(theme.penaltyTextPrimary)
                 Text("使えるカードが無かったため、手数が 5 増加しました")
                     .font(.system(size: 12, weight: .medium, design: .rounded))
-                    .foregroundColor(.white.opacity(0.8))
+                    .foregroundColor(theme.penaltyTextSecondary)
             }
 
             Spacer(minLength: 0)
@@ -551,13 +585,14 @@ private struct PenaltyBannerView: View {
         .padding(.horizontal, 18)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color.white.opacity(0.18))
+                // バナーの背景はテーマ設定で透明感を調整
+                .fill(theme.penaltyBannerBackground)
                 .overlay(
                     RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(Color.white.opacity(0.35), lineWidth: 1)
+                        .stroke(theme.penaltyBannerBorder, lineWidth: 1)
                 )
         )
-        .shadow(color: Color.black.opacity(0.35), radius: 18, x: 0, y: 12)
+        .shadow(color: theme.penaltyBannerShadow, radius: 18, x: 0, y: 12)
         .accessibilityIdentifier("penalty_banner_content")
         .accessibilityElement(children: .combine)
         .accessibilityLabel("手詰まり。手札を引き直し、手数が 5 増加しました。")
@@ -569,6 +604,8 @@ private struct PenaltyBannerView: View {
 private struct NextCardOverlayView: View {
     /// 点滅インジケータの明るさを制御するステート
     @State private var isIndicatorBright = false
+    /// 先読みオーバーレイの配色を統一するテーマ
+    private var theme = AppTheme()
 
     var body: some View {
         ZStack {
@@ -579,11 +616,12 @@ private struct NextCardOverlayView: View {
                         .font(.system(size: 10, weight: .bold, design: .rounded))
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
-                        .foregroundColor(.white)
+                        // テーマ経由でラベル色を取得し、ライトモードでも視認性を保つ
+                        .foregroundColor(theme.nextBadgeText)
                         .background(
                             Capsule()
-                                .strokeBorder(Color.white.opacity(0.7), lineWidth: 1)
-                                .background(Capsule().fill(Color.white.opacity(0.18)))
+                                .strokeBorder(theme.nextBadgeBorder, lineWidth: 1)
+                                .background(Capsule().fill(theme.nextBadgeBackground))
                         )
                         .padding([.top, .leading], 6)
                         .accessibilityHidden(true)  // バッジは視覚的強調のみなので読み上げ対象外にする
@@ -598,15 +636,15 @@ private struct NextCardOverlayView: View {
                 HStack {
                     Spacer()
                     Circle()
-                        .stroke(Color.white.opacity(0.7), lineWidth: 1.5)
+                        .stroke(theme.nextIndicatorStroke, lineWidth: 1.5)
                         .frame(width: 16, height: 16)
                         .overlay(
                             Circle()
-                                .fill(Color.white.opacity(0.85))
+                                .fill(theme.nextIndicatorFill)
                                 .frame(width: 8, height: 8)
                                 .opacity(isIndicatorBright ? 1.0 : 0.2)
                         )
-                        .shadow(color: Color.white.opacity(isIndicatorBright ? 0.6 : 0.1), radius: isIndicatorBright ? 4 : 0)
+                        .shadow(color: theme.nextIndicatorShadow.opacity(isIndicatorBright ? 1.0 : 0.2), radius: isIndicatorBright ? 4 : 0)
                         .padding(6)
                         .accessibilityHidden(true)  // 視覚的なアクセントのみのため VoiceOver では読み上げない
                 }

--- a/UI/MoveCardIllustrationView.swift
+++ b/UI/MoveCardIllustrationView.swift
@@ -9,25 +9,24 @@ struct MoveCardIllustrationView: View {
         case next
 
         /// 背景色（RoundedRectangle 内部）をモードごとに返す
-        var backgroundColor: Color {
+        /// - Parameter theme: アプリ共通のテーマから色を取得
+        func backgroundColor(using theme: AppTheme) -> Color {
             switch self {
             case .hand:
-                // 手札用は従来の淡いグレー背景を踏襲
-                return Color.gray.opacity(0.2)
+                return theme.cardBackgroundHand
             case .next:
-                // 先読み用は少し明るめにし、枠とのコントラストを上げて視認性を確保
-                return Color.white.opacity(0.1)
+                return theme.cardBackgroundNext
             }
         }
 
         /// 枠線の色をモードに応じて返す
-        var borderColor: Color {
+        /// - Parameter theme: アプリ共通テーマ
+        func borderColor(using theme: AppTheme) -> Color {
             switch self {
             case .hand:
-                return Color.white
+                return theme.cardBorderHand
             case .next:
-                // 先読みはやや強めの白で存在感を出す
-                return Color.white.opacity(0.8)
+                return theme.cardBorderNext
             }
         }
 
@@ -42,31 +41,38 @@ struct MoveCardIllustrationView: View {
         }
 
         /// 中央セルのハイライト色
-        var centerHighlightColor: Color {
+        /// - Parameter theme: アプリ共通テーマ
+        func centerHighlightColor(using theme: AppTheme) -> Color {
             switch self {
             case .hand:
-                return Color.white.opacity(0.12)
+                return theme.centerHighlightHand
             case .next:
-                // 先読みは少し強めに光らせてカードの注目度を上げる
-                return Color.white.opacity(0.25)
+                return theme.centerHighlightNext
             }
         }
 
         /// グリッド線の色（手札よりもコントラストを強める）
-        var gridLineColor: Color {
+        /// - Parameter theme: アプリ共通テーマ
+        func gridLineColor(using theme: AppTheme) -> Color {
             switch self {
             case .hand:
-                return Color.white.opacity(0.4)
+                return theme.gridLineHand
             case .next:
-                return Color.white.opacity(0.55)
+                return theme.gridLineNext
             }
         }
 
         /// 矢印や目的地マーカーの色（モード共通）
-        var arrowColor: Color { Color.white }
+        /// - Parameter theme: アプリ共通テーマ
+        func arrowColor(using theme: AppTheme) -> Color {
+            theme.cardContentPrimary
+        }
 
         /// カード名ラベルの文字色
-        var labelColor: Color { Color.white }
+        /// - Parameter theme: アプリ共通テーマ
+        func labelColor(using theme: AppTheme) -> Color {
+            theme.cardContentPrimary
+        }
 
         /// VoiceOver で追加説明が必要な場合の末尾テキスト
         var accessibilitySuffix: String {
@@ -113,16 +119,18 @@ struct MoveCardIllustrationView: View {
     let card: MoveCard
     /// 現在の表示モード（デフォルトは手札表示）
     var mode: Mode = .hand
+    /// カラースキームに応じて派生色を提供するテーマ
+    private var theme = AppTheme()
 
     var body: some View {
         ZStack {
             // MARK: - カードの背景枠
             // 既存のカードスタイル（角丸の枠付き）を踏襲して統一感を保つ
             RoundedRectangle(cornerRadius: 8)
-                .stroke(mode.borderColor, lineWidth: mode.borderLineWidth)
+                .stroke(mode.borderColor(using: theme), lineWidth: mode.borderLineWidth)
                 .background(
                     RoundedRectangle(cornerRadius: 8)
-                        .fill(mode.backgroundColor)
+                        .fill(mode.backgroundColor(using: theme))
                 )
 
             VStack(spacing: 6) {
@@ -155,7 +163,7 @@ struct MoveCardIllustrationView: View {
                     ZStack {
                         // MARK: 中央マスのハイライト
                         Rectangle()
-                            .fill(mode.centerHighlightColor)
+                            .fill(mode.centerHighlightColor(using: theme))
                             .frame(width: cellSize, height: cellSize)
                             .position(startPoint)
 
@@ -174,24 +182,24 @@ struct MoveCardIllustrationView: View {
                                 path.addLine(to: CGPoint(x: origin.x + squareSize, y: y))
                             }
                         }
-                        .stroke(mode.gridLineColor, lineWidth: 0.5)
+                        .stroke(mode.gridLineColor(using: theme), lineWidth: 0.5)
 
                         // MARK: 現在地・目的地のマーカー
                         Circle()
-                            .fill(Color.white)
+                            .fill(theme.cardContentPrimary)
                             .frame(width: cellSize * 0.4, height: cellSize * 0.4)
                             .overlay(
                                 Circle()
-                                    .stroke(Color.black.opacity(0.8), lineWidth: 1)
+                                    .stroke(theme.startMarkerStroke, lineWidth: 1)
                             )
                             .position(startPoint)
 
                         Circle()
-                            .fill(Color.black)
+                            .fill(theme.cardContentInverted)
                             .frame(width: cellSize * 0.4, height: cellSize * 0.4)
                             .overlay(
                                 Circle()
-                                    .stroke(Color.white, lineWidth: 1)
+                                    .stroke(theme.destinationMarkerStroke, lineWidth: 1)
                             )
                             .position(destinationPoint)
 
@@ -200,7 +208,7 @@ struct MoveCardIllustrationView: View {
                             path.move(to: startPoint)
                             path.addLine(to: destinationPoint)
                         }
-                        .stroke(mode.arrowColor, style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
+                        .stroke(mode.arrowColor(using: theme), style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
 
                         if let (leftPoint, rightPoint) = arrowHeadVertices {
                             Path { path in
@@ -209,7 +217,7 @@ struct MoveCardIllustrationView: View {
                                 path.addLine(to: rightPoint)
                                 path.closeSubpath()
                             }
-                            .fill(mode.arrowColor)
+                            .fill(mode.arrowColor(using: theme))
                         }
                     }
                 }
@@ -219,7 +227,7 @@ struct MoveCardIllustrationView: View {
                 // テキストでも方向が確認できるよう小さめのフォントで表示
                 Text(card.displayName)
                     .font(.caption2)
-                    .foregroundColor(mode.labelColor)
+                    .foregroundColor(mode.labelColor(using: theme))
             }
             .padding(8)
         }
@@ -322,5 +330,6 @@ private extension MoveCardIllustrationView {
         MoveCardIllustrationView(card: .diagonalDownLeft2, mode: .next)
     }
     .padding()
-    .background(Color.black)
+    // プレビューでもテーマカラーを利用し、本番画面と同等の見た目を確認する
+    .background(Color("backgroundPrimary"))
 }

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -103,6 +103,8 @@ struct RootView: View {
 private struct TitleScreenView: View {
     /// ゲーム開始ボタンが押された際の処理
     let onStart: () -> Void
+    /// カラーテーマを用いてライト/ダーク両対応の配色を提供する
+    private var theme = AppTheme()
 
     var body: some View {
         VStack(spacing: 28) {
@@ -112,10 +114,12 @@ private struct TitleScreenView: View {
             VStack(spacing: 12) {
                 Text("MonoKnight")
                     .font(.system(size: 32, weight: .heavy, design: .rounded))
-                    .foregroundColor(.white)
+                    // テーマの主文字色を適用し、ライト/ダーク両方で視認性を確保
+                    .foregroundColor(theme.textPrimary)
                 Text("カードで騎士を導き、盤面を踏破しよう")
                     .font(.system(size: 16, weight: .medium, design: .rounded))
-                    .foregroundColor(.white.opacity(0.75))
+                    // 補足テキストはサブ文字色でコントラストを調整
+                    .foregroundColor(theme.textSecondary)
                     .multilineTextAlignment(.center)
             }
 
@@ -126,8 +130,9 @@ private struct TitleScreenView: View {
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
-            .tint(.white)
-            .foregroundColor(.black)
+            // ボタンはアクセントカラーとその上の文字色をテーマから取得
+            .tint(theme.accentPrimary)
+            .foregroundColor(theme.accentOnPrimary)
             .controlSize(.large)
             .accessibilityIdentifier("title_start_button")
 
@@ -136,7 +141,8 @@ private struct TitleScreenView: View {
         .padding(.horizontal, 32)
         .padding(.bottom, 36)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.black)
+        // 背景もテーマのベースカラーへ切り替え、システム設定と調和させる
+        .background(theme.backgroundPrimary)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("タイトル画面。ゲームを開始するボタンがあります。")
     }

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -1,0 +1,361 @@
+import SwiftUI
+
+/// アプリ全体で共通利用する配色をまとめたテーマコンポーネント
+/// DynamicProperty を採用することで、ダークモード切り替え時にも自動的に再評価される
+struct AppTheme: DynamicProperty {
+    /// 現在のカラースキームを環境から取得し、明暗で派生色を出し分ける
+    @Environment(\.colorScheme) private var colorScheme
+
+    // MARK: - ベースカラー（Assets.xcassets から取得）
+
+    /// 画面全体の背景色。ライトでは淡いグレー、ダークでは限りなく黒に近いトーンを採用
+    var backgroundPrimary: Color { Color("backgroundPrimary") }
+
+    /// カードやモーダルなど一段高いレイヤー用の背景色
+    var backgroundElevated: Color { Color("backgroundElevated") }
+
+    /// 標準の文字色。本文や主要なラベルで利用する
+    var textPrimary: Color { Color("textPrimary") }
+
+    /// サブ情報用の文字色。キャプションや補足テキスト向け
+    var textSecondary: Color { Color("textSecondary") }
+
+    /// ボタンなど強調表示する要素の背景色
+    var accentPrimary: Color { Color("accentPrimary") }
+
+    /// アクセント背景上で使用する文字色
+    var accentOnPrimary: Color { Color("accentOnPrimary") }
+
+    // MARK: - バッジ／統計表示向けカラー
+
+    /// 統計バッジの背景色。盤面上でも視認性を損なわない半透明トーン
+    var statisticBadgeBackground: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.black.opacity(0.8)
+        default:
+            return Color.white.opacity(0.9)
+        }
+    }
+
+    /// 統計バッジの枠線色。ライトでは黒系、ダークでは白系で薄く縁取る
+    var statisticBadgeBorder: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.25)
+        default:
+            return Color.black.opacity(0.1)
+        }
+    }
+
+    /// 統計バッジの補助ラベルに使う文字色
+    var statisticTitleText: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.65)
+        default:
+            return Color.black.opacity(0.6)
+        }
+    }
+
+    /// 統計バッジのメイン数値に使う文字色
+    var statisticValueText: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white
+        default:
+            return Color.black
+        }
+    }
+
+    // MARK: - カード表示向けカラー
+
+    /// 手札カードの背景色。淡いトーンで盤面との差を演出
+    var cardBackgroundHand: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.08)
+        default:
+            return Color.black.opacity(0.05)
+        }
+    }
+
+    /// 先読みカードの背景色。手札よりわずかに明るくして注目度を上げる
+    var cardBackgroundNext: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.12)
+        default:
+            return Color.black.opacity(0.08)
+        }
+    }
+
+    /// 手札カードの枠線色
+    var cardBorderHand: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white
+        default:
+            return Color.black.opacity(0.85)
+        }
+    }
+
+    /// 先読みカードの枠線色
+    var cardBorderNext: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.8)
+        default:
+            return Color.black.opacity(0.9)
+        }
+    }
+
+    /// 盤面中央セルのハイライト色（手札用）
+    var centerHighlightHand: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.12)
+        default:
+            return Color.black.opacity(0.08)
+        }
+    }
+
+    /// 盤面中央セルのハイライト色（先読み用）
+    var centerHighlightNext: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.25)
+        default:
+            return Color.black.opacity(0.12)
+        }
+    }
+
+    /// グリッド線の色（手札用）
+    var gridLineHand: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.4)
+        default:
+            return Color.black.opacity(0.3)
+        }
+    }
+
+    /// グリッド線の色（先読み用）
+    var gridLineNext: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.55)
+        default:
+            return Color.black.opacity(0.4)
+        }
+    }
+
+    /// 矢印やラベルなどカード上の主要要素の色
+    var cardContentPrimary: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white
+        default:
+            return Color.black
+        }
+    }
+
+    /// カード上で白黒を反転して利用する際の色
+    var cardContentInverted: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.black
+        default:
+            return Color.white
+        }
+    }
+
+    /// 現在位置マーカーの縁取り色
+    var startMarkerStroke: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.black.opacity(0.8)
+        default:
+            return Color.white.opacity(0.8)
+        }
+    }
+
+    /// 目的地マーカーの縁取り色
+    var destinationMarkerStroke: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white
+        default:
+            return Color.black
+        }
+    }
+
+    // MARK: - プレースホルダ／メニュー等の付随 UI
+
+    /// 手札が空の時に表示する枠線色
+    var placeholderStroke: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.25)
+        default:
+            return Color.black.opacity(0.2)
+        }
+    }
+
+    /// 手札プレースホルダの背景色
+    var placeholderBackground: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.05)
+        default:
+            return Color.black.opacity(0.03)
+        }
+    }
+
+    /// 手札プレースホルダのアイコン色
+    var placeholderIcon: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.4)
+        default:
+            return Color.black.opacity(0.35)
+        }
+    }
+
+    /// 右上メニューアイコンの前景色
+    var menuIconForeground: Color { cardContentPrimary }
+
+    /// 右上メニューアイコンの背景色
+    var menuIconBackground: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.12)
+        default:
+            return Color.black.opacity(0.08)
+        }
+    }
+
+    /// 右上メニューアイコンの枠線色
+    var menuIconBorder: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.25)
+        default:
+            return Color.black.opacity(0.12)
+        }
+    }
+
+    /// ダミー広告の背景色。実広告導入まで視認性を保つプレースホルダ用
+    var adPlaceholderBackground: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.1)
+        default:
+            return Color.black.opacity(0.05)
+        }
+    }
+
+    // MARK: - ペナルティバナー／先読みオーバーレイ
+
+    /// ペナルティバナーの背景色
+    var penaltyBannerBackground: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.18)
+        default:
+            return Color.black.opacity(0.08)
+        }
+    }
+
+    /// ペナルティバナーの枠線色
+    var penaltyBannerBorder: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.35)
+        default:
+            return Color.black.opacity(0.15)
+        }
+    }
+
+    /// ペナルティバナーの影色
+    var penaltyBannerShadow: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.black.opacity(0.35)
+        default:
+            return Color.black.opacity(0.12)
+        }
+    }
+
+    /// ペナルティバナーのメインテキスト色
+    var penaltyTextPrimary: Color { cardContentPrimary }
+
+    /// ペナルティバナーの補足テキスト色
+    var penaltyTextSecondary: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.8)
+        default:
+            return Color.black.opacity(0.7)
+        }
+    }
+
+    /// ペナルティバナーのアイコン（シンボル）の色
+    var penaltyIconForeground: Color { cardContentInverted }
+
+    /// ペナルティバナーのアイコン背景色
+    var penaltyIconBackground: Color { cardContentPrimary }
+
+    /// NEXT バッジの文字色
+    var nextBadgeText: Color { cardContentPrimary }
+
+    /// NEXT バッジの背景色
+    var nextBadgeBackground: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.18)
+        default:
+            return Color.black.opacity(0.08)
+        }
+    }
+
+    /// NEXT バッジの枠線色
+    var nextBadgeBorder: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.7)
+        default:
+            return Color.black.opacity(0.35)
+        }
+    }
+
+    /// 先読みインジケータの枠線色
+    var nextIndicatorStroke: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.7)
+        default:
+            return Color.black.opacity(0.35)
+        }
+    }
+
+    /// 先読みインジケータ内側の塗り色
+    var nextIndicatorFill: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.85)
+        default:
+            return Color.black.opacity(0.65)
+        }
+    }
+
+    /// 先読みインジケータの発光色
+    var nextIndicatorShadow: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.white.opacity(0.6)
+        default:
+            return Color.black.opacity(0.3)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add light/dark color sets for core surfaces and text into the asset catalog and expose them via a reusable `AppTheme`
- replace hardcoded colors in the title screen, game HUD, card illustrations, and dummy ad with theme-driven values that honor light/dark mode
- update `GameView` to react to color scheme changes, including forwarding the background color to the embedded SpriteKit scene

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ce24c8a468832cbd8a65bb37d2c1cc