### PR TITLE
Fix TitleScreenView access level

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -100,7 +100,8 @@ struct RootView: View {
 }
 
 // MARK: - タイトル画面（簡易版）
-private struct TitleScreenView: View {
+// fileprivate にすることで同ファイル内の RootView から初期化可能にする
+fileprivate struct TitleScreenView: View {
     /// ゲーム開始ボタンが押された際の処理
     let onStart: () -> Void
 


### PR DESCRIPTION
## Summary
- loosen the access level of `TitleScreenView` so RootView can initialize it
- document why the type remains file-private in the same file

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce2a01f050832ca3382ee7d1a603fb