### PR TITLE
Expose manual penalty button on main game screen

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -277,6 +277,10 @@ struct GameView: View {
                 }
             }
 
+            // MARK: - 手札引き直しボタン
+            // 以前はメニュー経由だった操作を下部に配置し、アクセス性を大幅に向上させる
+            manualPenaltyButton()
+
 #if DEBUG
             // MARK: - デバッグ専用ショートカット
             // 盤面の右上オーバーレイに重ねると UI が窮屈になるため、下部セクションへ移設
@@ -289,6 +293,67 @@ struct GameView: View {
 #endif
         }
         .padding(.bottom, 16)
+    }
+
+    /// 手動ペナルティ（手札引き直し）のショートカットボタン
+    /// - Note: メニュー内の操作を露出し、ワンタップで確認ダイアログへ遷移させる
+    private func manualPenaltyButton() -> some View {
+        // ゲームが進行中でない場合は無効化し、リザルト表示中などの誤操作を回避
+        let isDisabled = core.progress != .playing
+
+        return Button {
+            // 実行前に必ず確認ダイアログを挟むため、既存のメニューアクションを再利用
+            pendingMenuAction = .manualPenalty
+        } label: {
+            HStack(spacing: 12) {
+                // MARK: - アイコンによる視覚的な導線
+                ZStack {
+                    Circle()
+                        .fill(theme.accentOnPrimary.opacity(0.18))
+                        .frame(width: 42, height: 42)
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundColor(theme.accentOnPrimary)
+                }
+
+                // MARK: - 操作内容と補足の説明文
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("手札を引き直す")
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.accentOnPrimary)
+                    Text("手数+5で現在の手札を交換")
+                        .font(.system(size: 12, weight: .medium, design: .rounded))
+                        .foregroundColor(theme.accentOnPrimary.opacity(0.82))
+                }
+
+                Spacer(minLength: 0)
+
+                // MARK: - コスト表示を右端に配置して注意喚起
+                Text("+5")
+                    .font(.system(size: 18, weight: .bold, design: .rounded))
+                    .foregroundColor(theme.accentOnPrimary)
+            }
+            .padding(.horizontal, 18)
+            .padding(.vertical, 14)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(theme.accentPrimary)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(theme.accentOnPrimary.opacity(0.2), lineWidth: 1)
+            )
+            .shadow(color: theme.accentPrimary.opacity(0.28), radius: 14, x: 0, y: 10)
+            .opacity(isDisabled ? 0.55 : 1.0)
+            .animation(.easeInOut(duration: 0.2), value: isDisabled)
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .padding(.horizontal, 16)
+        .accessibilityIdentifier("manual_penalty_button")
+        .accessibilityLabel(Text("ペナルティを払って手札を引き直す"))
+        .accessibilityHint(Text("手数を5消費して現在の手札を全て捨て、新しいカードを3枚引きます。"))
     }
 
     /// 手詰まりペナルティを知らせるバナーのレイヤーを構成
@@ -467,17 +532,7 @@ private extension GameView {
     /// ゲーム全体に関わる操作をまとめたメニュー
     private var menuButton: some View {
         Menu {
-            // MARK: - ペナルティ支払いによる手札引き直し
-            Button {
-                // 誤タップ防止のため一度確認ダイアログへ回す
-                pendingMenuAction = .manualPenalty
-            } label: {
-                Label("ペナルティを払って引き直す", systemImage: "arrow.triangle.2.circlepath")
-            }
-            .accessibilityLabel(Text("ペナルティを払って引き直す"))
-            .accessibilityIdentifier("menu_manual_penalty")
-            // ゲームが進行中でない場合は選択肢を無効化する
-            .disabled(core.progress != .playing)
+            // MARK: - メニュー内にはリセット系のみ配置（手札引き直しは下部ボタンへ移動）
 
             // MARK: - ゲームリセット操作
             Button {


### PR DESCRIPTION
## Summary
- add a dedicated manual penalty redraw button directly on the hand section for quicker access during play
- keep confirmation via the existing GameMenuAction flow and simplify the overflow menu to reset/exit actions only

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce3a76736c832c96ed0cd2c38ccf25