### PR TITLE
Remove next card indicator overlay

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -704,12 +704,10 @@ private struct PenaltyBannerView: View {
 }
 
 // MARK: - 先読みカード専用のオーバーレイ
-/// 「NEXT」「NEXT+1」などのバッジと点滅インジケータを重ね、操作不可であることを視覚的に伝える補助ビュー
+/// 「NEXT」「NEXT+1」などのバッジを重ね、操作不可であることを視覚的に伝える補助ビュー
 fileprivate struct NextCardOverlayView: View {
     /// 表示中のカードが何枚目の先読みか（0 が直近、1 以降は +1, +2 ...）
     let order: Int
-    /// 点滅インジケータの明るさを制御するステート
-    @State private var isIndicatorBright = false
     /// 先読みオーバーレイの配色を統一するテーマ
     private let theme = AppTheme()
 
@@ -746,32 +744,6 @@ fileprivate struct NextCardOverlayView: View {
                     Spacer()
                 }
                 Spacer()
-            }
-
-            // MARK: - 右下の点滅インジケータ
-            VStack {
-                Spacer()
-                HStack {
-                    Spacer()
-                    Circle()
-                        .stroke(theme.nextIndicatorStroke, lineWidth: 1.5)
-                        .frame(width: 16, height: 16)
-                        .overlay(
-                            Circle()
-                                .fill(theme.nextIndicatorFill)
-                                .frame(width: 8, height: 8)
-                                .opacity(isIndicatorBright ? 1.0 : 0.2)
-                        )
-                        .shadow(color: theme.nextIndicatorShadow.opacity(isIndicatorBright ? 1.0 : 0.2), radius: isIndicatorBright ? 4 : 0)
-                        .padding(6)
-                        .accessibilityHidden(true)  // 視覚的なアクセントのみのため VoiceOver では読み上げない
-                }
-            }
-        }
-        .onAppear {
-            // MARK: - 点滅アニメーションを開始
-            withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
-                isIndicatorBright = true
             }
         }
         .allowsHitTesting(false)  // 補助ビューはタップ処理に影響させない

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -354,36 +354,6 @@ struct AppTheme: DynamicProperty {
         }
     }
 
-    /// 先読みインジケータの枠線色
-    var nextIndicatorStroke: Color {
-        switch resolvedColorScheme {
-        case .dark:
-            return Color.white.opacity(0.7)
-        default:
-            return Color.black.opacity(0.35)
-        }
-    }
-
-    /// 先読みインジケータ内側の塗り色
-    var nextIndicatorFill: Color {
-        switch resolvedColorScheme {
-        case .dark:
-            return Color.white.opacity(0.85)
-        default:
-            return Color.black.opacity(0.65)
-        }
-    }
-
-    /// 先読みインジケータの発光色
-    var nextIndicatorShadow: Color {
-        switch resolvedColorScheme {
-        case .dark:
-            return Color.white.opacity(0.6)
-        default:
-            return Color.black.opacity(0.3)
-        }
-    }
-
     // MARK: - SpriteKit 盤面用カラー
 
     /// SpriteKit で描画する盤面の背景色


### PR DESCRIPTION
## Summary
- remove the blinking indicator from the next card overlay so the UI only shows the badge
- clean up theme color helpers that were only used by the indicator

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce43d582e8832cb9edd4a9dab580b2