### PR TITLE
Add guide mode highlights across board and settings

### DIFF
--- a/UI/SettingsView.swift
+++ b/UI/SettingsView.swift
@@ -9,6 +9,10 @@ struct SettingsView: View {
     // ユーザーのハプティクス利用有無を永続化する。デフォルトは有効。
     @AppStorage("haptics_enabled") private var hapticsEnabled: Bool = true
 
+    // MARK: - ガイドモード設定
+    // 盤面の移動候補ハイライトを保存し、GameView 側の @AppStorage と連動させる。
+    @AppStorage("guide_mode_enabled") private var guideModeEnabled: Bool = true
+
     // MARK: - 戦績管理
     // ベスト手数を UserDefaults から取得・更新する。未設定時は Int.max で初期化しておく。
     @AppStorage("best_moves_5x5") private var bestMoves: Int = .max
@@ -48,6 +52,16 @@ struct SettingsView: View {
                 } footer: {
                     // 広告警告などの振動もオフになることを明示
                     Text("ゲーム内操作や広告警告の振動を制御します。オフにすると警告通知でも振動しません。")
+                }
+
+                // ガイドモードのオン/オフをユーザーが選択できるようにするセクション
+                Section {
+                    Toggle("ガイドモード（移動候補をハイライト）", isOn: $guideModeEnabled)
+                } header: {
+                    Text("ガイド")
+                } footer: {
+                    // どのような効果があるかを具体的に説明し、不要ならオフにできると案内
+                    Text("手札から移動できるマスを盤面上で光らせます。集中して考えたい場合はオフにできます。")
                 }
 
                 // プライバシー操作セクション

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -429,6 +429,17 @@ struct AppTheme: DynamicProperty {
         }
     }
 
+    /// ガイドモードで候補マスを照らす際の基準色
+    /// - Note: ライトでは少し深みのあるアンバー、ダークでは柔らかいゴールドに寄せてコントラストを確保する
+    var boardGuideHighlight: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            return Color(red: 1.0, green: 0.88, blue: 0.55)
+        default:
+            return Color(red: 0.95, green: 0.72, blue: 0.25)
+        }
+    }
+
     #if canImport(UIKit)
     /// 指定したライト/ダークそれぞれの Color から動的 UIColor を生成するユーティリティ
     private func dynamicUIColor(light: Color, dark: Color) -> UIColor {
@@ -494,6 +505,14 @@ struct AppTheme: DynamicProperty {
             dark: color(for: .dark, keyPath: \.boardKnight)
         )
     }
+
+    /// SpriteKit ガイドハイライトの UIColor 版
+    var uiBoardGuideHighlight: UIColor {
+        dynamicUIColor(
+            light: color(for: .light, keyPath: \.boardGuideHighlight),
+            dark: color(for: .dark, keyPath: \.boardGuideHighlight)
+        )
+    }
     #endif
 
     #if canImport(SpriteKit) && canImport(UIKit)
@@ -511,5 +530,8 @@ struct AppTheme: DynamicProperty {
 
     /// SpriteKit の SKColor へ変換した駒の塗り色
     var skBoardKnight: SKColor { SKColor(cgColor: uiBoardKnight.cgColor) }
+
+    /// SpriteKit の SKColor へ変換したガイドハイライト色
+    var skBoardGuideHighlight: SKColor { SKColor(cgColor: uiBoardGuideHighlight.cgColor) }
     #endif
 }


### PR DESCRIPTION
## Summary
- add a guide highlight color to the app theme including SwiftUI, UIColor, and SKColor helpers
- render and maintain guide highlight nodes inside GameScene and keep them in sync with theme updates
- surface guide mode controls in GameView and SettingsView so available moves light up only when the toggle is enabled

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ce43e16e2c832cacb9d3fa61765002