### PR TITLE
Adjust guide highlight to rectangular stroke

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -198,15 +198,25 @@ class GameScene: SKScene {
     ///   - node: 更新対象のノード
     ///   - point: 対応する盤面座標
     private func configureGuideHighlightNode(_ node: SKShapeNode, for point: GridPoint) {
-        let radius = tileSize * 0.38
-        let rect = CGRect(x: -radius, y: -radius, width: radius * 2, height: radius * 2)
-        node.path = CGPath(ellipseIn: rect, transform: nil)
+        // マスの外枠にめり込まないよう内側へ余白を設ける
+        let inset = tileSize * 0.1
+        // SpriteKit の座標系ではノード中心が (0,0) となるため、原点から半分引いた位置に矩形を構築する
+        let rect = CGRect(
+            x: -tileSize / 2 + inset,
+            y: -tileSize / 2 + inset,
+            width: tileSize - inset * 2,
+            height: tileSize - inset * 2
+        )
+        node.path = CGPath(rect: rect, transform: nil)
 
         let baseColor = theme.skBoardGuideHighlight
-        node.fillColor = baseColor.withAlphaComponent(0.28)
-        node.strokeColor = baseColor.withAlphaComponent(0.85)
-        node.lineWidth = tileSize * 0.08
-        node.glowWidth = tileSize * 0.2
+        // 充填色は透過させ、枠線のみでマス位置を柔らかく示す
+        node.fillColor = SKColor.clear
+        node.strokeColor = baseColor.withAlphaComponent(0.9)
+        node.lineWidth = tileSize * 0.12
+        node.glowWidth = 0
+        node.lineJoin = .round
+        node.lineCap = .round
         node.position = position(for: point)
         node.zPosition = 1  // タイルより前面、駒より背面で控えめに表示
         node.isAntialiased = true


### PR DESCRIPTION
## Summary
- replace the guide highlight's circular path with an inset rectangle based on the tile size
- use a transparent fill, stronger stroke alpha, and rounded joins/caps for a softer rectangular outline

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ce4697c26c832cbf84e9d10317b493