### PR TITLE
Add AdMob configuration placeholders and validations

### DIFF
--- a/Config/Default.xcconfig
+++ b/Config/Default.xcconfig
@@ -11,6 +11,14 @@ PRODUCT_BUNDLE_IDENTIFIER = com.koki.monoknight$(BUNDLE_ID_SUFFIX)
 DEVELOPMENT_TEAM =
 BUNDLE_ID_SUFFIX =
 
+# Google Mobile Ads のテスト用識別子
+# 実機テストやスクリーンショット撮影では必ずテスト ID を利用する
+GAD_APPLICATION_ID = ca-app-pub-3940256099942544~1458002511
+
+# インタースティシャル広告ユニットのテスト ID
+# 本番値は Local.xcconfig で上書きする
+GAD_INTERSTITIAL_UNIT_ID = ca-app-pub-3940256099942544/4411468910
+
 # 表示名（ホーム画面に表示される名称）
 APP_DISPLAY_NAME = $(PRODUCT_NAME)
 

--- a/Config/Local.xcconfig.sample
+++ b/Config/Local.xcconfig.sample
@@ -7,3 +7,7 @@ DEVELOPMENT_TEAM = YOUR_TEAM_ID
 
 # バンドルIDのサフィックスを記入
 BUNDLE_ID_SUFFIX = .koki
+
+# AdMob の本番用 ID を設定（テスト ID のまま申請しないこと）
+#GAD_APPLICATION_ID = ca-app-pub-xxxxxxxxxxxxxxxx~yyyyyyyyyy
+#GAD_INTERSTITIAL_UNIT_ID = ca-app-pub-xxxxxxxxxxxxxxxx/zzzzzzzzzz

--- a/Info.plist
+++ b/Info.plist
@@ -6,6 +6,14 @@
     <key>NSUserTrackingUsageDescription</key>
     <string>広告の最適化と効果測定のためにデバイスのトラッキングを利用します。</string>
 
+    <!-- AdMob のアプリ ID（xcconfig で環境ごとに差し替え） -->
+    <key>GADApplicationIdentifier</key>
+    <string>$(GAD_APPLICATION_ID)</string>
+
+    <!-- インタースティシャル広告ユニット ID（xcconfig で環境ごとに差し替え） -->
+    <key>GADInterstitialAdUnitID</key>
+    <string>$(GAD_INTERSTITIAL_UNIT_ID)</string>
+
     <!-- SKAdNetwork 用の広告ネットワーク ID 一覧 -->
     <key>SKAdNetworkItems</key>
     <array>

--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -22,6 +22,31 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol {
 
     private var lastInterstitialDate: Date?
     private var hasShownInCurrentPlay: Bool = false
+    private let interstitialAdUnitID: String
+
+    override private init() {
+        // Info.plist から GMA のアプリ ID を取得し、未設定なら開発者に通知
+        if let appID = Bundle.main.object(forInfoDictionaryKey: "GADApplicationIdentifier") as? String,
+           !appID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            // ここでは値を保持しないが、設定されていることを確認しておく
+        } else {
+            assertionFailure("GADApplicationIdentifier が Info.plist に設定されていません。")
+        }
+
+        // 同様に広告ユニット ID を検証し、空文字の場合はダミーを代入しておく
+        if let unitID = Bundle.main.object(forInfoDictionaryKey: "GADInterstitialAdUnitID") as? String,
+           !unitID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            interstitialAdUnitID = unitID
+        } else {
+            interstitialAdUnitID = ""
+            assertionFailure("GADInterstitialAdUnitID が Info.plist に設定されていません。")
+        }
+
+        super.init()
+
+        // SDK 導入時に備えて起動直後にロード処理を呼び出す
+        loadInterstitial()
+    }
 
     func requestTrackingAuthorization() async {
         guard ATTrackingManager.trackingAuthorizationStatus == .notDetermined else { return }
@@ -56,6 +81,15 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol {
     private func canShowByTime() -> Bool {
         guard let last = lastInterstitialDate else { return true }
         return Date().timeIntervalSince(last) >= 90
+    }
+
+    private func loadInterstitial() {
+        // 実装メモ: GMA SDK を導入したら下記のように読み込みを行う想定
+        // GADInterstitialAd.load(withAdUnitID: interstitialAdUnitID, request: GADRequest(), completionHandler: ...)
+        guard !interstitialAdUnitID.isEmpty else { return }
+#if DEBUG
+        NSLog("[AdsService] インタースティシャル広告を読み込む想定の adUnitID: %@", interstitialAdUnitID)
+#endif
     }
 }
 


### PR DESCRIPTION
## Summary
- add AdMob test identifiers to the shared xcconfig and document overriding with production values locally
- wire GAD application and interstitial identifiers from Info.plist using xcconfig variables
- validate Info.plist ad identifiers in AdsService and prepare load stub for future SDK integration

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce499a2478832ca8d35db0af66f9c4