### PR TITLE
Integrate UMP consent handling into AdsService

### DIFF
--- a/MonoKnight.xcodeproj/project.pbxproj
+++ b/MonoKnight.xcodeproj/project.pbxproj
@@ -25,7 +25,8 @@
 		72CF38132E7162E20093B180 /* MoveCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F62E7162E20093B180 /* MoveCard.swift */; };
 		72CF38142E7162E20093B180 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF38022E7162E20093B180 /* RootView.swift */; };
 		72CF38152E7162E20093B180 /* GameScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F42E7162E20093B180 /* GameScene.swift */; };
-		72CF38182E7252460093B180 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 72CF38172E7252460093B180 /* GoogleMobileAds */; };
+               72CF38182E7252460093B180 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 72CF38172E7252460093B180 /* GoogleMobileAds */; };
+               E8D21FD579F341979EC2D134 /* UserMessagingPlatform in Frameworks */ = {isa = PBXBuildFile; productRef = 105A27EF1E5D4B35AABCA169 /* UserMessagingPlatform */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,9 +82,10 @@
 		72CF37C62E7161160093B180 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
-			files = (
-				72CF38182E7252460093B180 /* GoogleMobileAds in Frameworks */,
-			);
+                       files = (
+                               72CF38182E7252460093B180 /* GoogleMobileAds in Frameworks */,
+                               E8D21FD579F341979EC2D134 /* UserMessagingPlatform in Frameworks */,
+                       );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		72CF37D22E7161170093B180 /* Frameworks */ = {
@@ -210,9 +212,10 @@
 				72CF37CA2E7161160093B180 /* MonoKnightApp */,
 			);
 			name = MonoKnightApp;
-			packageProductDependencies = (
-				72CF38172E7252460093B180 /* GoogleMobileAds */,
-			);
+                       packageProductDependencies = (
+                               72CF38172E7252460093B180 /* GoogleMobileAds */,
+                               105A27EF1E5D4B35AABCA169 /* UserMessagingPlatform */,
+                       );
 			productName = MonoKnightApp;
 			productReference = 72CF37C92E7161160093B180 /* MonoKnightApp.app */;
 			productType = "com.apple.product-type.application";
@@ -295,9 +298,10 @@
 				Base,
 			);
 			mainGroup = 000000000000000000000006;
-			packageReferences = (
-				72CF38162E7252460093B180 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
-			);
+                       packageReferences = (
+                               72CF38162E7252460093B180 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
+                               D69092A1023F49BD9F36DD45 /* XCRemoteSwiftPackageReference "swift-package-manager-user-messaging-platform" */,
+                       );
 			productRefGroup = 000000000000000000000008 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -942,22 +946,35 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		72CF38162E7252460093B180 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/googleads/swift-package-manager-google-mobile-ads";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 12.11.0;
-			};
-		};
+               72CF38162E7252460093B180 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {
+                       isa = XCRemoteSwiftPackageReference;
+                       repositoryURL = "https://github.com/googleads/swift-package-manager-google-mobile-ads";
+                       requirement = {
+                               kind = upToNextMajorVersion;
+                               minimumVersion = 12.11.0;
+                       };
+               };
+               D69092A1023F49BD9F36DD45 /* XCRemoteSwiftPackageReference "swift-package-manager-user-messaging-platform" */ = {
+                       isa = XCRemoteSwiftPackageReference;
+                       repositoryURL = "https://github.com/googleads/swift-package-manager-user-messaging-platform";
+                       requirement = {
+                               kind = upToNextMajorVersion;
+                               minimumVersion = 2.1.0;
+                       };
+               };
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		72CF38172E7252460093B180 /* GoogleMobileAds */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 72CF38162E7252460093B180 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
-			productName = GoogleMobileAds;
-		};
+               72CF38172E7252460093B180 /* GoogleMobileAds */ = {
+                       isa = XCSwiftPackageProductDependency;
+                       package = 72CF38162E7252460093B180 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
+                       productName = GoogleMobileAds;
+               };
+               105A27EF1E5D4B35AABCA169 /* UserMessagingPlatform */ = {
+                       isa = XCSwiftPackageProductDependency;
+                       package = D69092A1023F49BD9F36DD45 /* XCRemoteSwiftPackageReference "swift-package-manager-user-messaging-platform" */;
+                       productName = UserMessagingPlatform;
+               };
 /* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 000000000000000000000001 /* Project object */;

--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -2,6 +2,8 @@ import Foundation
 import UIKit
 import SwiftUI
 import AppTrackingTransparency
+import GoogleMobileAds
+import UserMessagingPlatform
 
 // MARK: - Protocol
 protocol AdsServiceProtocol: AnyObject {
@@ -13,62 +15,363 @@ protocol AdsServiceProtocol: AnyObject {
     func refreshConsentStatus() async
 }
 
-// MARK: - Stub Impl (SDKなしでもビルド可)
+// MARK: - 本番実装
+@MainActor
 final class AdsService: NSObject, ObservableObject, AdsServiceProtocol {
+    /// グローバルに共有するシングルトンインスタンス
     static let shared = AdsService()
 
+    // MARK: 永続化フラグ
+    /// 広告除去購入済みフラグ。`true` の場合は一切の広告読み込みを停止する。
     @AppStorage("remove_ads") private var removeAds: Bool = false
+    /// ハプティクスの有効／無効設定。広告表示時の通知に利用する。
     @AppStorage("haptics_enabled") private var hapticsEnabled: Bool = true
+    /// パーソナライズ広告を許可してよいかどうか。UMP の同意結果に応じて更新する。
+    @AppStorage("ads_is_personalized") private var isPersonalized: Bool = false
+    /// プライバシー設定フォームを再表示できるかどうか。設定画面の文言と連携する。
+    @AppStorage("ads_privacy_options_available") private var isPrivacyOptionsAvailable: Bool = false
 
+    // MARK: UMP 関連
+    /// Google UMP の同意情報を管理するシングルトン。
+    private let consentInformation = UMPConsentInformation.sharedInstance()
+    /// 直近で読み込んだ同意フォーム。再表示が必要な場合に保持しておく。
+    private var consentForm: UMPConsentForm?
+    /// 同意フォームを多重起動しないためのフラグ。
+    private var isPresentingForm: Bool = false
+
+    // MARK: AdMob 関連
+    /// 現在保持しているインタースティシャル広告オブジェクト。
+    private var interstitial: GADInterstitialAd?
+    /// 読み込みリクエストの多重実行を防ぐためのフラグ。
+    private var isLoadingInterstitial: Bool = false
+    /// 読み込み中のリクエストを識別する ID。途中で設定が変わった場合は旧リクエストを無効化する。
+    private var currentLoadIdentifier: UUID = .init()
+
+    /// 前回広告を表示した日時（90 秒間隔制御用）。
     private var lastInterstitialDate: Date?
+    /// 1 プレイ中に既に広告を表示したかどうか。
     private var hasShownInCurrentPlay: Bool = false
 
+    /// テスト用／本番用のインタースティシャル広告ユニット ID。
+    /// - NOTE: 実機リリース前に本番用 ID へ差し替えること。
+    private let interstitialAdUnitID: String
+
+    private override init() {
+        #if DEBUG
+        self.interstitialAdUnitID = "ca-app-pub-3940256099942544/4411468910"
+        #else
+        self.interstitialAdUnitID = "ca-app-pub-3940256099942544/4411468910" // 本番リリース前に実際の広告ユニット ID へ差し替える
+        #endif
+        super.init()
+        // SDK 初期化を先に行い、以降のロードが確実に動作するようにする。
+        GADMobileAds.sharedInstance().start(completionHandler: nil)
+        // 起動直後は保持している同意情報に基づきフラグを整合させる。
+        _ = updateConsentFlags()
+        // 初回の広告読み込みを準備しておく（除去済みの場合は内部でスキップされる）。
+        loadInterstitial()
+    }
+
+    // MARK: ATT
     func requestTrackingAuthorization() async {
         guard ATTrackingManager.trackingAuthorizationStatus == .notDetermined else { return }
         _ = await ATTrackingManager.requestTrackingAuthorization()
     }
 
-    // UMP/GMA は後で導入。今は no-op で良い
-    func requestConsentIfNeeded() async { /* no-op */ }
-    func refreshConsentStatus() async { /* no-op */ }
+    // MARK: UMP - 初回同意取得
+    func requestConsentIfNeeded() async {
+        guard !removeAds else { return }
+        let parameters = buildRequestParameters()
 
+        do {
+            // 最新の同意状況を取得
+            try await requestConsentInfoUpdate(with: parameters)
+            _ = updateConsentFlags()
+
+            if consentInformation.formStatus == .available {
+                do {
+                    // 同意フォームを読み込み → 表示の順で実行
+                    try await presentConsentFormFlow()
+                } catch {
+                    // フォーム表示で失敗した場合もユーザーに致命的影響は無いためログのみに留める。
+                    debugError(error, message: "UMP 同意フォームの表示に失敗")
+                }
+            }
+
+            // フォーム完了後の最終ステータスを反映し、必要なら広告を再ロード
+            let didChange = updateConsentFlags()
+            if didChange {
+                reloadInterstitialForConsentChange()
+            } else if interstitial == nil {
+                loadInterstitial()
+            }
+        } catch {
+            debugError(error, message: "UMP 同意情報の取得に失敗")
+        }
+    }
+
+    // MARK: UMP - 状態更新
+    func refreshConsentStatus() async {
+        guard !removeAds else { return }
+        let parameters = buildRequestParameters()
+
+        do {
+            try await requestConsentInfoUpdate(with: parameters)
+            _ = updateConsentFlags()
+
+            // 規制対象地域などで再同意が必要になった場合のみフォームを再表示
+            if consentInformation.formStatus == .available && consentInformation.consentStatus == .required {
+                do {
+                    try await presentConsentFormFlow()
+                } catch {
+                    debugError(error, message: "UMP 同意フォームの再提示に失敗")
+                }
+            }
+
+            let didChange = updateConsentFlags()
+            if didChange {
+                reloadInterstitialForConsentChange()
+            } else if interstitial == nil {
+                loadInterstitial()
+            }
+        } catch {
+            debugError(error, message: "UMP 同意状況の更新に失敗")
+        }
+    }
+
+    // MARK: インタースティシャル表示
     func showInterstitial() {
-        // 1プレイ1回 & インターバル & 購入済なら出さない
         guard !removeAds,
               canShowByTime(),
               !hasShownInCurrentPlay,
-              let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-              let root = scene.windows.first?.rootViewController else { return }
+              let presentingViewController = topViewController(),
+              let interstitial else {
+            // 条件未達の場合は次回のために読み込みだけ仕込んでおく。
+            if self.interstitial == nil { loadInterstitial() }
+            return
+        }
 
-        // ダミーの全画面ビューを表示（タップで閉じる）
-        let vc = UIHostingController(rootView: DummyInterstitialView())
-        vc.modalPresentationStyle = .fullScreen
-        root.present(vc, animated: true)
-
+        // 実際に広告を表示。警告ハプティクスも併用して注意喚起する。
+        interstitial.present(fromRootViewController: presentingViewController)
         if hapticsEnabled { UINotificationFeedbackGenerator().notificationOccurred(.warning) }
-        lastInterstitialDate = Date()
         hasShownInCurrentPlay = true
+        lastInterstitialDate = Date()
     }
 
-    func resetPlayFlag() { hasShownInCurrentPlay = false }
-    func disableAds()    { /* no-op */ }
+    func resetPlayFlag() {
+        hasShownInCurrentPlay = false
+    }
 
+    func disableAds() {
+        removeAds = true
+        discardInterstitial()
+    }
+
+    // MARK: - プライベートヘルパー
+    /// ユーザーの年齢設定などを考慮した UMP リクエストパラメータを構築する。
+    private func buildRequestParameters() -> UMPRequestParameters {
+        let parameters = UMPRequestParameters()
+        parameters.tagForUnderAgeOfConsent = false
+        return parameters
+    }
+
+    /// UMP の consentInfoUpdate を async/await で扱えるようラップする。
+    private func requestConsentInfoUpdate(with parameters: UMPRequestParameters) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            consentInformation.requestConsentInfoUpdate(with: parameters) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    /// 同意フォームを読み込み、表示まで完了させる。
+    private func presentConsentFormFlow() async throws {
+        guard !isPresentingForm else { return }
+        isPresentingForm = true
+        defer { isPresentingForm = false }
+
+        let form = try await loadConsentForm()
+        consentForm = form
+        do {
+            try await present(consentForm: form)
+        } catch {
+            consentForm = nil
+            throw error
+        }
+        consentForm = nil
+    }
+
+    /// UMP の同意フォーム読み込み処理を async/await へ変換する。
+    private func loadConsentForm() async throws -> UMPConsentForm {
+        try await withCheckedThrowingContinuation { continuation in
+            UMPConsentForm.load { form, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let form {
+                    continuation.resume(returning: form)
+                } else {
+                    continuation.resume(throwing: AdsServiceError.formUnavailable)
+                }
+            }
+        }
+    }
+
+    /// 同意フォームを最前面の ViewController から表示する。
+    private func present(consentForm: UMPConsentForm) async throws {
+        let viewController = try fetchRootViewController()
+        try await withCheckedThrowingContinuation { continuation in
+            consentForm.present(from: viewController) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    /// 現在の同意ステータスを `@AppStorage` と同期し、変更有無を返す。
+    @discardableResult
+    private func updateConsentFlags() -> Bool {
+        isPrivacyOptionsAvailable = (consentInformation.formStatus == .available)
+
+        let previousPersonalized = isPersonalized
+        let newPersonalized: Bool
+        switch consentInformation.consentStatus {
+        case .obtained, .notRequired:
+            // 同意済み、または規制対象外の場合はパーソナライズ可能
+            newPersonalized = true
+        case .required, .unknown:
+            // 同意が未取得・不明な場合は安全側で非パーソナライズに倒す
+            newPersonalized = false
+        @unknown default:
+            newPersonalized = false
+        }
+        isPersonalized = newPersonalized
+        return previousPersonalized != newPersonalized
+    }
+
+    /// 広告読み込み専用の `GADRequest` を生成し、NPA 指定を付与した上でロードを開始する。
+    private func loadInterstitial() {
+        guard !removeAds else { return }
+        guard !isLoadingInterstitial else { return }
+
+        let request = GADRequest()
+        let extras = GADExtras()
+        if !isPersonalized {
+            // 非パーソナライズ広告を要求する場合は npa=1 を付与する。
+            extras.additionalParameters = ["npa": "1"]
+        }
+        request.register(extras)
+
+        isLoadingInterstitial = true
+        let loadIdentifier = UUID()
+        currentLoadIdentifier = loadIdentifier
+
+        GADInterstitialAd.load(withAdUnitID: interstitialAdUnitID, request: request) { [weak self] ad, error in
+            guard let self else { return }
+            // 最新のロードでなければ破棄する（同意更新直後など）。
+            guard self.currentLoadIdentifier == loadIdentifier else { return }
+
+            self.isLoadingInterstitial = false
+            if let error {
+                debugError(error, message: "インタースティシャル広告の読み込みに失敗")
+                return
+            }
+            guard let ad else { return }
+            ad.fullScreenContentDelegate = self
+            self.interstitial = ad
+            debugLog("インタースティシャル広告を読み込み済み")
+        }
+    }
+
+    /// 現在保持している広告を破棄し、新たにロードを仕掛ける。
+    private func reloadInterstitialForConsentChange() {
+        discardInterstitial()
+        loadInterstitial()
+    }
+
+    /// 既存のインタースティシャルを解放し、デリゲート参照も破棄する。
+    private func discardInterstitial() {
+        interstitial?.fullScreenContentDelegate = nil
+        interstitial = nil
+        isLoadingInterstitial = false
+        currentLoadIdentifier = UUID()
+    }
+
+    /// 表示可能な最前面 ViewController を取得する。
+    private func topViewController() -> UIViewController? {
+        guard let root = try? fetchRootViewController() else { return nil }
+        return root
+    }
+
+    /// UIWindowScene から最前面の ViewController を探索する。
+    private func fetchRootViewController() throws -> UIViewController {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = scene.windows.first(where: { $0.isKeyWindow }) ?? scene.windows.first,
+              let root = window.rootViewController else {
+            throw AdsServiceError.rootViewControllerMissing
+        }
+        return traversePresentedViewController(from: root)
+    }
+
+    /// 再帰的に `presentedViewController` を辿り、最前面の VC を返す。
+    private func traversePresentedViewController(from controller: UIViewController) -> UIViewController {
+        if let navigation = controller as? UINavigationController,
+           let visible = navigation.visibleViewController {
+            return traversePresentedViewController(from: visible)
+        }
+        if let tab = controller as? UITabBarController,
+           let selected = tab.selectedViewController {
+            return traversePresentedViewController(from: selected)
+        }
+        if let presented = controller.presentedViewController {
+            return traversePresentedViewController(from: presented)
+        }
+        return controller
+    }
+
+    /// 90 秒以上経過しているかを確認し、広告表示の頻度制御を行う。
     private func canShowByTime() -> Bool {
         guard let last = lastInterstitialDate else { return true }
         return Date().timeIntervalSince(last) >= 90
     }
 }
 
-// ダミー広告ビュー
-private struct DummyInterstitialView: View {
-    @Environment(\.dismiss) private var dismiss
-    var body: some View {
-        ZStack {
-            Color.black
-            Text("Test Ad").foregroundColor(.white)
-        }
-        .ignoresSafeArea()
-        .accessibilityIdentifier("dummy_interstitial_ad")
-        .onTapGesture { dismiss() }
+// MARK: - GADFullScreenContentDelegate
+@MainActor
+extension AdsService: GADFullScreenContentDelegate {
+    func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+        // 閉じたら次回に備えて新しい広告を読み込む。
+        discardInterstitial()
+        loadInterstitial()
+    }
+
+    func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        // 表示失敗時も再度ロードしておく。
+        debugError(error, message: "インタースティシャル広告の表示に失敗")
+        discardInterstitial()
+        loadInterstitial()
     }
 }
+
+// MARK: - エラー定義
+private enum AdsServiceError: LocalizedError {
+    /// 最前面の ViewController を取得できなかった場合。
+    case rootViewControllerMissing
+    /// UMP フォームが nil で返却された場合。
+    case formUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .rootViewControllerMissing:
+            return "ルート ViewController の取得に失敗"
+        case .formUnavailable:
+            return "UMP 同意フォームを取得できませんでした"
+        }
+    }
+}
+

--- a/Services/ServiceMocks.swift
+++ b/Services/ServiceMocks.swift
@@ -22,6 +22,11 @@ final class MockGameCenterService: GameCenterServiceProtocol {
 
 /// インタースティシャル広告をダミー表示する UI テスト用モック
 final class MockAdsService: AdsServiceProtocol {
+    /// パーソナライズ設定を UI テストでも反映させるためのフラグ
+    @AppStorage("ads_is_personalized") private var isPersonalized: Bool = true
+    /// プライバシーオプションの可否を保持するフラグ（モックでは常に false）
+    @AppStorage("ads_privacy_options_available") private var isPrivacyOptionsAvailable: Bool = false
+
     /// ダミー広告を全画面で表示する
     func showInterstitial() {
         guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
@@ -36,16 +41,24 @@ final class MockAdsService: AdsServiceProtocol {
     func resetPlayFlag() {}
 
     /// 広告読み込み停止も不要なので空実装
-    func disableAds() {}
+    func disableAds() {
+        // モックでは広告表示を止めるだけなのでフラグは変更しない
+    }
 
     /// ATT 許可ダイアログは表示しないダミー実装
     func requestTrackingAuthorization() async {}
 
     /// UMP 同意フォームも表示しないダミー実装
-    func requestConsentIfNeeded() async {}
+    func requestConsentIfNeeded() async {
+        // 常に同意済みとして扱い、パーソナライズ可否を有効化する
+        isPersonalized = true
+        isPrivacyOptionsAvailable = false
+    }
 
     /// 同意状況の再評価も行わないダミー実装
-    func refreshConsentStatus() async {}
+    func refreshConsentStatus() async {
+        // モックでは常に同意済みのままとする
+    }
 
     /// ダミー広告ビュー
     private struct MockAdView: View {


### PR DESCRIPTION
## Summary
- add the Google User Messaging Platform Swift package to the project
- implement consent requests, refresh logic, and personalized flag storage inside `AdsService`
- update the ads service mock to keep the new consent flags in sync for UI tests

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce49987d5c832c859e78eff742ab1f