### PR TITLE
Remove DummyInterstitialAdView from project

### DIFF
--- a/MonoKnight.xcodeproj/project.pbxproj
+++ b/MonoKnight.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		72CF37F02E71616C0093B180 /* MonoKnightApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000004 /* MonoKnightApp.swift */; };
 		72CF38052E7162E20093B180 /* ErrorReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F92E7162E20093B180 /* ErrorReporter.swift */; };
-		72CF38062E7162E20093B180 /* DummyInterstitialAdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37FF2E7162E20093B180 /* DummyInterstitialAdView.swift */; };
 		72CF38072E7162E20093B180 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF38002E7162E20093B180 /* GameView.swift */; };
 		72CF38082E7162E20093B180 /* DebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F12E7162E20093B180 /* DebugLog.swift */; };
 		72CF38092E7162E20093B180 /* Deck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F22E7162E20093B180 /* Deck.swift */; };
@@ -67,7 +66,6 @@
 		72CF37FB2E7162E20093B180 /* ServiceMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceMocks.swift; sourceTree = "<group>"; };
 		72CF37FC2E7162E20093B180 /* StoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreService.swift; sourceTree = "<group>"; };
 		72CF37FE2E7162E20093B180 /* ConsentFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentFlowView.swift; sourceTree = "<group>"; };
-		72CF37FF2E7162E20093B180 /* DummyInterstitialAdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyInterstitialAdView.swift; sourceTree = "<group>"; };
 		72CF38002E7162E20093B180 /* GameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameView.swift; sourceTree = "<group>"; };
 		72CF38012E7162E20093B180 /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
 		72CF38022E7162E20093B180 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
@@ -174,7 +172,6 @@
 				72F554AB2E7E60850098A1B0 /* Theme */,
 				72F554A72E7E40100098A1B0 /* MoveCardIllustrationView.swift */,
 				72CF37FE2E7162E20093B180 /* ConsentFlowView.swift */,
-				72CF37FF2E7162E20093B180 /* DummyInterstitialAdView.swift */,
 				72CF38002E7162E20093B180 /* GameView.swift */,
 				72CF38012E7162E20093B180 /* ResultView.swift */,
 				72CF38022E7162E20093B180 /* RootView.swift */,
@@ -370,7 +367,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				72CF38052E7162E20093B180 /* ErrorReporter.swift in Sources */,
-				72CF38062E7162E20093B180 /* DummyInterstitialAdView.swift in Sources */,
 				72CF38072E7162E20093B180 /* GameView.swift in Sources */,
 				72CF38082E7162E20093B180 /* DebugLog.swift in Sources */,
 				72CF38092E7162E20093B180 /* Deck.swift in Sources */,


### PR DESCRIPTION
## Summary
- remove the DummyInterstitialAdView.swift file reference from the project configuration
- drop the file from the UI group and sources build phase so it is no longer compiled

## Testing
- not run (configuration changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ce53326e9c832c911fabdff361609c