### PR TITLE
Update AdMob interstitial API usage

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -32,7 +32,7 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
     @AppStorage("ads_should_use_npa") private var shouldUseNPA: Bool = false
 
     /// インタースティシャル広告のキャッシュ
-    private var interstitial: GADInterstitialAd?
+    private var interstitial: InterstitialAd?
     /// 直近に広告を表示した日時（頻度制御用）
     private var lastInterstitialDate: Date?
     /// 1プレイ1回の制御フラグ
@@ -159,7 +159,7 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
             request.register(extras)
         }
 
-        GADInterstitialAd.load(withAdUnitID: interstitialAdUnitID, request: request) { [weak self] ad, error in
+        InterstitialAd.load(withAdUnitID: interstitialAdUnitID, request: request) { [weak self] ad, error in
             Task { [weak self] in
                 await MainActor.run {
                     guard let self else { return }


### PR DESCRIPTION
## Summary
- Google Mobile Ads SDK の API 変更に合わせてインタースティシャル広告クラスを `InterstitialAd` に更新

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce56e4d66c832c95ac5a6736a76fe2