### PR TITLE
Update GAD request type

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -151,7 +151,8 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
 
         isLoadingAd = true
 
-        let request = GADRequest()
+        // Google Mobile Ads SDK v11 以降では `GADRequest` が `Request` にリネームされたため、新しい型名を利用する
+        let request = GoogleMobileAds.Request()
         if shouldUseNPA {
             // UMP の結果に従い非パーソナライズ広告をリクエスト
             let extras = GADExtras()


### PR DESCRIPTION
## Summary
- Google Mobile Ads SDK のリネームに合わせてインタースティシャル広告のリクエスト生成処理を更新

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce571d1ac0832c9fc8e3806bf29c75