### PR TITLE
Fix AdsService build error with updated AdMob extras type

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -154,7 +154,7 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
         let request = GADRequest()
         if shouldUseNPA {
             // UMP の結果に従い非パーソナライズ広告をリクエスト
-            let extras = GADExtras()
+            let extras = Extras()
             extras.additionalParameters = ["npa": "1"]
             request.register(extras)
         }


### PR DESCRIPTION
## Summary
- replace deprecated `GADExtras` usage with the new `Extras` type when configuring non-personalized ad requests

## Testing
- `swift build`


------
https://chatgpt.com/codex/tasks/task_e_68ce57a168fc832cbd73bdcaf7bf621d