### PR TITLE
Fix interstitial present API usage

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -120,7 +120,7 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
             return
         }
 
-        interstitial.present(fromRootViewController: root)
+        interstitial.present(from: root)
         if hapticsEnabled {
             UINotificationFeedbackGenerator().notificationOccurred(.warning)
         }


### PR DESCRIPTION
## Summary
- InterstitialAd.present 呼び出しを最新の引数ラベル `from:` に更新し、ビルドエラーを解消しました。

## Testing
- `swift build`


------
https://chatgpt.com/codex/tasks/task_e_68ce58e12a7c832c90684974a78c014e