### PR TITLE
Fix AdMob initialization for MobileAds v11

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -70,13 +70,11 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
         super.init()
         guard hasValidAdConfiguration else { return }
 
-        // SDK 初期化。sharedInstance は v11 以降でメソッドではなくプロパティになったため () を付けない
-        GADMobileAds.sharedInstance.start(completionHandler: nil)
-
-        // SDK 初期化。Swift 6 では `nil` を渡すと型推論ができずビルドエラーになるため、
-        // ここでは結果を利用しない空クロージャを渡して初期化を完了させる。
-        GADMobileAds.sharedInstance().start { _ in
-            // 現時点では初期化結果を用いないが、将来ログ等を追加する余地を残すため空実装としておく。
+        // SDK 初期化。sharedInstance は v11 以降でメソッドではなくプロパティになったため () を付けない。
+        // Swift 6 では completionHandler に nil を渡すと型推論ができずコンパイルエラーとなるので、
+        // ここでは何もしない空クロージャを渡して初期化を完了させる。
+        GADMobileAds.sharedInstance.start { _ in
+            // 現時点では初期化結果を利用しないが、将来的にログ出力やイベント送信を追加できるよう空実装としておく。
         }
 
         // 初期化直後から広告読み込みを開始（非同期で走らせる）


### PR DESCRIPTION
## Summary
- remove the deprecated sharedInstance() call introduced by Google Mobile Ads v11
- initialize the SDK through the property-based sharedInstance and a no-op completion handler to satisfy Swift 6 inference

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce5aa6278c832ca287a8ea0171850c