### PR TITLE
Fix interstitial load call signature

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -168,7 +168,7 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
             request.register(extras)
         }
 
-        InterstitialAd.load(withAdUnitID: interstitialAdUnitID, request: request) { [weak self] ad, error in
+        InterstitialAd.load(with: interstitialAdUnitID, request: request) { [weak self] ad, error in
             Task { [weak self] in
                 await MainActor.run {
                     guard let self else { return }


### PR DESCRIPTION
## Summary
- update the interstitial ad load invocation to use the current Google Mobile Ads API signature

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68ce5aa94b80832c9004b14d44987098