### PR TITLE
Update Google Mobile Ads initialization for SDK v11

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -70,13 +70,10 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
         super.init()
         guard hasValidAdConfiguration else { return }
 
-        // SDK 初期化。sharedInstance は v11 以降でメソッドではなくプロパティになったため () を付けない
-        GADMobileAds.sharedInstance.start(completionHandler: nil)
-
-        // SDK 初期化。Swift 6 では `nil` を渡すと型推論ができずビルドエラーになるため、
-        // ここでは結果を利用しない空クロージャを渡して初期化を完了させる。
-        GADMobileAds.sharedInstance().start { _ in
-            // 現時点では初期化結果を用いないが、将来ログ等を追加する余地を残すため空実装としておく。
+        // SDK 初期化。MobileAds.sharedInstance は v11 以降でメソッドからプロパティへ変更されたため () を付けない。
+        // Swift 6 では `nil` を渡すと型推論ができずビルドエラーになるため、空のクロージャで完了ハンドラを明示する。
+        MobileAds.sharedInstance.start { _ in
+            // 現状は初期化結果を使用していないが、将来的にログ出力や計測を行う余地を残すため空実装としておく。
         }
 
         // 初期化直後から広告読み込みを開始（非同期で走らせる）


### PR DESCRIPTION
## Summary
- 既存の `GADMobileAds` 呼び出しを `MobileAds.sharedInstance` に置き換えて Google Mobile Ads SDK v11 に追従
- Swift 6 での型推論エラーを避けるため初期化完了ハンドラを空クロージャで明示するコメントを更新

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce5a966e60832ca6225335d8e71a7c