### PR TITLE
Fix Google Mobile Ads initialization handling

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -70,25 +70,13 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
         super.init()
         guard hasValidAdConfiguration else { return }
 
-        // SDK 初期化。MobileAds.sharedInstance は v11 以降でメソッドからプロパティへ変更されたため () を付けない。
-        // Swift 6 では `nil` を渡すと型推論ができずビルドエラーになるため、空のクロージャで完了ハンドラを明示する。
-        MobileAds.sharedInstance.start { _ in
-            // 現状は初期化結果を使用していないが、将来的にログ出力や計測を行う余地を残すため空実装としておく。
-
-        // SDK 初期化。sharedInstance は v11 以降でメソッドではなくプロパティになったため () を付けない。
-        // Swift 6 では completionHandler に nil を渡すと型推論ができずコンパイルエラーとなるので、
-        // ここでは何もしない空クロージャを渡して初期化を完了させる。
-        GADMobileAds.sharedInstance.start { _ in
-            // 現時点では初期化結果を利用しないが、将来的にログ出力やイベント送信を追加できるよう空実装としておく。
-
         // SDK 初期化。v11 以降では shared プロパティ経由でシングルトンを取得するため、ここで参照を保持する。
         let mobileAds = GADMobileAds.shared
 
-        // SDK 初期化。Swift 6 では `nil` を渡すと型推論ができずビルドエラーになるため、
-        // ここでは結果を利用しない空クロージャを渡して初期化を完了させる。
+        // Swift 6 では completionHandler に nil を渡すと型推論ができずビルドエラーになるため、
+        // ここでは何もしない空クロージャを渡して初期化を完了させる。
         mobileAds.start { _ in
-            // 現時点では初期化結果を用いないが、将来ログ等を追加する余地を残すため空実装としておく。
-
+            // 現時点では初期化結果を利用しないが、将来的にログ出力やイベント送信を追加できるよう空実装としておく。
         }
 
         // 初期化直後から広告読み込みを開始（非同期で走らせる）


### PR DESCRIPTION
## Summary
- clean up the Google Mobile Ads SDK initialization in `AdsService`
- ensure the SDK is started via `GADMobileAds.shared` while keeping Japanese documentation comments
- keep interstitial loading kick-off intact after initialization

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce5bdcb490832c8a1159f9fde045e5