### PR TITLE
Update AdsService for Mobile Ads SDK v11 singleton rename

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -70,8 +70,9 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
         super.init()
         guard hasValidAdConfiguration else { return }
 
-        // SDK 初期化。v11 以降では shared プロパティ経由でシングルトンを取得するため、ここで参照を保持する。
-        let mobileAds = GADMobileAds.shared
+        // SDK 初期化。v11 以降では `GADMobileAds` が `MobileAds` に改名されたため、shared プロパティから最新 API を取得する。
+        // （名称変更に追従しつつ、将来的な API 差分を把握しやすくする意図で明示的にコメントを残している）
+        let mobileAds = MobileAds.shared
 
         // Swift 6 では completionHandler に nil を渡すと型推論ができずビルドエラーになるため、
         // ここでは何もしない空クロージャを渡して初期化を完了させる。


### PR DESCRIPTION
## Summary
- update AdsService to use `MobileAds.shared` instead of the deprecated `GADMobileAds.shared`
- document the API rename with detailed Japanese comments for maintainability

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ce5c8ba4d4832cb1d394810c6e025d