### PR TITLE
Fix AdsServiceProtocol actor isolation

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -5,6 +5,8 @@ import AppTrackingTransparency
 import GoogleMobileAds
 
 // MARK: - Protocol
+/// UI レイヤーからメインスレッド経由で利用する前提のため、プロトコル自体も MainActor に固定する
+@MainActor
 protocol AdsServiceProtocol: AnyObject {
     func showInterstitial()
     func resetPlayFlag()


### PR DESCRIPTION
## Summary
- mark `AdsServiceProtocol` as `@MainActor` so that its requirements match the service implementation
- document the actor isolation decision in Japanese for future maintainers

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce751212b8832c8602a3910993ae6e