### PR TITLE
Fix consent flow main actor isolation issue

### DIFF
--- a/UI/ConsentFlowView.swift
+++ b/UI/ConsentFlowView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 /// 初回起動時に表示するオンボーディングビュー
 /// 広告・トラッキングに関する説明と同意取得を行う
+// Swift 6 のコンカレンシーモデルでは MainActor 以外から AdsService.shared に触れるとエラーになるため、
+// ビュー全体を MainActor 管理下に置き、UI 系処理をメインスレッドで扱うことを明示する
+@MainActor
 struct ConsentFlowView: View {
     /// 広告サービス。ATT/UMP の許諾処理を呼び出す
     private let adsService: AdsServiceProtocol


### PR DESCRIPTION
## Summary
- mark `ConsentFlowView` as `@MainActor` so the default `AdsService.shared` dependency can be resolved safely
- document the reasoning inline to clarify the Swift 6 actor-isolation requirement

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ce75360bf8832c90cc543c3ab8e564