### PR TITLE
Annotate RootView with MainActor

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 /// ゲーム画面と設定画面を切り替えるルートビュー
 /// `TabView` を用いて 2 つのタブを提供する
+@MainActor
+/// SwiftUI ビュー全体を MainActor 上で扱い、MainActor 隔離されたシングルトン（GameCenterService / AdsService）へアクセスする際の競合を防ぐ
+/// - NOTE: Swift 6 で厳格化された並行性モデルに追従し、ビルドエラー（MainActor 分離違反）を確実に回避するための指定
 struct RootView: View {
     /// Game Center 連携を扱うサービス（プロトコル型で受け取る）
     private let gameCenterService: GameCenterServiceProtocol


### PR DESCRIPTION
## Summary
- mark `RootView` as `@MainActor` so it can safely access main-actor-isolated singletons
- add documentation explaining the concurrency requirement in Japanese to follow the repository guidelines

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68ce751d3370832c98d32e2ce10172c8