### PR TITLE
Fix MainActor singleton defaults in UI initializers

### DIFF
--- a/UI/ConsentFlowView.swift
+++ b/UI/ConsentFlowView.swift
@@ -15,8 +15,10 @@ struct ConsentFlowView: View {
 
     /// サービスを外部から注入可能にする初期化処理
     /// - Parameter adsService: 広告処理を担うサービス（デフォルトはシングルトン）
-    init(adsService: AdsServiceProtocol = AdsService.shared) {
-        self.adsService = adsService
+    init(adsService: AdsServiceProtocol? = nil) {
+        // デフォルト引数で `AdsService.shared` を直接参照すると Swift 6 でコンカレンシー違反となるため、
+        // MainActor 上で初期化されるこのタイミングで解決する。
+        self.adsService = adsService ?? AdsService.shared
     }
 
     var body: some View {

--- a/UI/ResultView.swift
+++ b/UI/ResultView.swift
@@ -35,14 +35,19 @@ struct ResultView: View {
         moveCount: Int,
         penaltyCount: Int,
         onRetry: @escaping () -> Void,
-        gameCenterService: GameCenterServiceProtocol = GameCenterService.shared,  // ない場合は GameCenterService()
-        adsService: AdsServiceProtocol = AdsService.shared  // ない場合は AdsService()
+        gameCenterService: GameCenterServiceProtocol? = nil,
+        adsService: AdsServiceProtocol? = nil
     ) {
+        // `@MainActor` に隔離されたシングルトンへ安全にアクセスするため、
+        // Swift 6 の規約に合わせてここで依存解決を行う。
+        let resolvedGameCenterService = gameCenterService ?? GameCenterService.shared
+        let resolvedAdsService = adsService ?? AdsService.shared
+
         self.moveCount = moveCount
         self.penaltyCount = penaltyCount
         self.onRetry = onRetry
-        self.gameCenterService = gameCenterService
-        self.adsService = adsService
+        self.gameCenterService = resolvedGameCenterService
+        self.adsService = resolvedAdsService
     }
 
     var body: some View {

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -21,11 +21,17 @@ struct RootView: View {
     /// - Parameters:
     ///   - gameCenterService: Game Center 連携用サービス（デフォルトはシングルトン）
     ///   - adsService: 広告表示用サービス（デフォルトはシングルトン）
-    init(gameCenterService: GameCenterServiceProtocol = GameCenterService.shared,
-         adsService: AdsServiceProtocol = AdsService.shared) {
-        self.gameCenterService = gameCenterService
-        self.adsService = adsService
-        _isAuthenticated = State(initialValue: gameCenterService.isAuthenticated)
+    init(gameCenterService: GameCenterServiceProtocol? = nil,
+         adsService: AdsServiceProtocol? = nil) {
+        // Swift 6 ではデフォルト引数の評価が非分離コンテキストで行われるため、
+        // `@MainActor` に隔離されたシングルトンを安全に利用するためにイニシャライザ内で解決する。
+        let resolvedGameCenterService = gameCenterService ?? GameCenterService.shared
+        let resolvedAdsService = adsService ?? AdsService.shared
+
+        self.gameCenterService = resolvedGameCenterService
+        self.adsService = resolvedAdsService
+        // 認証状態の初期値も解決済みのサービスから取得し、@State へ格納する。
+        _isAuthenticated = State(initialValue: resolvedGameCenterService.isAuthenticated)
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- resolve GameCenterService and AdsService dependencies inside RootView to avoid Swift 6 main actor isolation errors
- align ResultView and ConsentFlowView initializers with the same pattern so their singleton lookups stay on the main actor

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce772cbb0c832c8be0b9065a50836f