### PR TITLE
Fix ResultView initializer service resolution

### DIFF
--- a/UI/ResultView.swift
+++ b/UI/ResultView.swift
@@ -59,8 +59,9 @@ struct ResultView: View {
     ) {
         // `@MainActor` に隔離されたシングルトンへ安全にアクセスするため、
         // Swift 6 の規約に合わせてここで依存解決を行う。
-        let resolvedGameCenterService = gameCenterService ?? GameCenterService.shared
-        let resolvedAdsService = adsService ?? AdsService.shared
+        // テスト注入時にも同じコード経路を通せるよう、まずローカル定数に束縛してからプロパティへ代入する。
+        let resolvedGameCenterService = gameCenterService
+        let resolvedAdsService = adsService
 
         self.moveCount = moveCount
         self.penaltyCount = penaltyCount


### PR DESCRIPTION
## Summary
- remove the unnecessary nil-coalescing fallback in `ResultView`'s dependency injection
- clarify with comments that services are bound locally before property assignment

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce789b5030832cae5470be1c97dad6