### PR TITLE
Adjust guide highlight stroke joins

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -215,8 +215,12 @@ class GameScene: SKScene {
         node.strokeColor = baseColor.withAlphaComponent(0.9)
         node.lineWidth = tileSize * 0.12
         node.glowWidth = 0
-        node.lineJoin = .round
-        node.lineCap = .round
+        // 角をシャープに保つために角丸設定を無効化し、SpriteKit のデフォルトより明示的にミタージョインを指定する
+        node.lineJoin = .miter
+        // lineJoin をミターにした際にエッジが過度に尖らないよう、適度な上限値を設ける
+        node.miterLimit = 2.5
+        // 終端も角を丸めず、グリッドの直線的な印象を優先する
+        node.lineCap = .square
         node.position = position(for: point)
         node.zPosition = 1  // タイルより前面、駒より背面で控えめに表示
         node.isAntialiased = true


### PR DESCRIPTION
## Summary
- set the guide highlight stroke join to miter and cap to square to remove rounded corners
- add a miter limit to prevent excessive spikes after the join change

## Testing
- not run (SpriteKit rendering not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ce87a908c8832cae07d0af18c29d36