### PR TITLE
Implement dealt card model and animated play transitions

### DIFF
--- a/Game/DealtCard.swift
+++ b/Game/DealtCard.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// 山札から配られたカードを UI で一意に識別するための薄いラッパー構造体
+/// - Note: アニメーションや SwiftUI の `Identifiable` に準拠させるため、UUID を別途付与する。
+struct DealtCard: Identifiable, Equatable {
+    /// SwiftUI の差分計算とアニメーションで利用する一意な識別子
+    let id: UUID
+    /// これまでのロジックが扱っていた移動カード本体
+    let move: MoveCard
+
+    /// 新しいカードを生成する
+    /// - Parameters:
+    ///   - id: 既存カードからラップし直す場合に利用する識別子（省略時は新規採番）
+    ///   - move: 実際の移動ロジックを担う `MoveCard`
+    init(id: UUID = UUID(), move: MoveCard) {
+        self.id = id
+        self.move = move
+    }
+}

--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -98,26 +98,26 @@ struct Deck {
     // MARK: - ドロー処理
     /// 1 枚カードを引く
     /// - Returns: 重み付き抽選によって得られたカード（必ず値を返す想定）
-    mutating func draw() -> MoveCard? {
-        #if DEBUG
+    mutating func draw() -> DealtCard? {
+#if DEBUG
         // テストで事前登録されたカードがあれば優先的に返す
         if !presetDrawQueue.isEmpty {
-            let card = presetDrawQueue.removeFirst()
-            applyProbabilityReduction(afterDrawing: card)
-            return card
+            let move = presetDrawQueue.removeFirst()
+            applyProbabilityReduction(afterDrawing: move)
+            return DealtCard(move: move)
         }
-        #endif
-        guard let card = drawWithDynamicWeights() else { return nil }
-        applyProbabilityReduction(afterDrawing: card)
-        return card
+#endif
+        guard let move = drawWithDynamicWeights() else { return nil }
+        applyProbabilityReduction(afterDrawing: move)
+        return DealtCard(move: move)
     }
 
     /// 複数枚まとめて引く
     /// - Parameter count: 引く枚数
     /// - Returns: 要求枚数分のカード（不足時は取得できた分のみ返す）
-    mutating func draw(count: Int) -> [MoveCard] {
+    mutating func draw(count: Int) -> [DealtCard] {
         guard count > 0 else { return [] }
-        var result: [MoveCard] = []
+        var result: [DealtCard] = []
         result.reserveCapacity(count)
         for _ in 0..<count {
             if let card = draw() {

--- a/Tests/GameTests/DeckTests.swift
+++ b/Tests/GameTests/DeckTests.swift
@@ -10,11 +10,11 @@ final class DeckTests: XCTestCase {
         var counts: [MoveCard: Int] = [:]
 
         for _ in 0..<sampleCount {
-            guard let card = deck.draw() else {
+            guard let dealtCard = deck.draw() else {
                 XCTFail("ドロー結果が nil になるのは想定外です")
                 return
             }
-            counts[card, default: 0] += 1
+            counts[dealtCard.move, default: 0] += 1
         }
 
         // --- 各カテゴリの平均出現回数を計算 ---
@@ -88,7 +88,7 @@ final class DeckTests: XCTestCase {
                 XCTFail("プリセット配列の長さ分を引けませんでした")
                 return
             }
-            drawn.append(card)
+            drawn.append(card.move)
         }
         XCTAssertEqual(drawn, preset, "プリセット順にカードが返却されていません")
 
@@ -105,7 +105,7 @@ final class DeckTests: XCTestCase {
                 XCTFail("リセット後にプリセットを再取得できませんでした")
                 return
             }
-            drawn.append(card)
+            drawn.append(card.move)
         }
         XCTAssertEqual(drawn, preset, "リセット後のプリセット順が一致しません")
     }

--- a/Tests/GameTests/GameCoreTests.swift
+++ b/Tests/GameTests/GameCoreTests.swift
@@ -39,7 +39,7 @@ final class GameCoreTests: XCTestCase {
         // 引き直し後の手札枚数が 5 枚確保されているか
         XCTAssertEqual(core.hand.count, 5, "引き直し後の手札枚数が 5 枚ではない")
         // 引き直し後の手札に使用可能なカードが少なくとも 1 枚あるか
-        let playableExists = core.hand.contains { $0.canUse(from: core.current) }
+        let playableExists = core.hand.contains { $0.move.canUse(from: core.current) }
         XCTAssertTrue(playableExists, "引き直し後の手札に利用可能なカードが存在しない")
         // 先読みカードが 3 枚揃っているか（NEXT 表示用）
         XCTAssertEqual(core.nextCards.count, 3, "引き直し後の先読みカードが 3 枚補充されていない")
@@ -73,7 +73,7 @@ final class GameCoreTests: XCTestCase {
         let core = GameCore.makeTestInstance(deck: deck, current: GridPoint(x: 0, y: 0))
 
         // 手札の中から使用可能なカードを 1 枚選び、実際に移動させる
-        if let index = core.hand.firstIndex(where: { $0.canUse(from: core.current) }) {
+        if let index = core.hand.firstIndex(where: { $0.move.canUse(from: core.current) }) {
             core.playCard(at: index)
         }
         // 移動が記録されているか確認


### PR DESCRIPTION
## 概要
- 山札から取得するカードを `DealtCard` でラップし、Deck/GameCore が一貫して UUID 付きカードを扱うよう更新
- GameView にアニメーション制御用ステートと matchedGeometryEffect を導入し、手札から盤面への移動や NEXT スライドを自然に演出
- 新しいカード構造に合わせて単体テストを修正

## テスト
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68cea7fb69bc832c8c3dffa8991f08c0