### PR TITLE
明示的な ColorScheme 指定とコメント追加

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -22,7 +22,8 @@ class GameScene: SKScene {
     private var board = Board()
 
     /// SpriteKit 内で利用するテーマ（SwiftUI 環境が無いので手動で適用する）
-    private var theme = AppTheme(colorScheme: .light)
+    /// - 備考: SpriteKit では SwiftUI の推論が効きにくいため ColorScheme を明示的に指定する
+    private var theme = AppTheme(colorScheme: ColorScheme.light)
 
     /// 1 マスのサイズ
     private var tileSize: CGFloat = 0


### PR DESCRIPTION
## Summary
- SpriteKit シーンで使用する AppTheme に ColorScheme.light を明示し、SwiftUI 推論に依存しないように調整
- 上記意図を日本語コメントとして追記し、コードの読みやすさを向上

## Testing
- xcodebuild -list *(fails: command not found inコンテナ環境)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0cf7d230832caa79cf65ddcf27e1