### PR TITLE
GameScene の配色パレット導入

### DIFF
--- a/Game/GameScenePalette.swift
+++ b/Game/GameScenePalette.swift
@@ -1,0 +1,66 @@
+#if canImport(SpriteKit)
+import SpriteKit
+
+/// SpriteKit で盤面表示に利用するカラーパレット
+/// - Note: SwiftUI とは別モジュールになるため、必要な `SKColor` 値のみを厳選して保持する
+struct GameScenePalette {
+    /// 盤面の背景色
+    let boardBackground: SKColor
+    /// グリッド線の色
+    let boardGridLine: SKColor
+    /// 踏破済みタイルの塗り色
+    let boardTileVisited: SKColor
+    /// 未踏破タイルの塗り色
+    let boardTileUnvisited: SKColor
+    /// 駒の塗り色
+    let boardKnight: SKColor
+    /// ガイド枠の線色
+    let boardGuideHighlight: SKColor
+
+    /// 主要な色をまとめて指定できるイニシャライザ
+    /// - Parameters:
+    ///   - boardBackground: 盤面背景色
+    ///   - boardGridLine: グリッド線色
+    ///   - boardTileVisited: 踏破済みタイル色
+    ///   - boardTileUnvisited: 未踏破タイル色
+    ///   - boardKnight: 駒の塗り色
+    ///   - boardGuideHighlight: ガイド枠の線色
+    init(
+        boardBackground: SKColor,
+        boardGridLine: SKColor,
+        boardTileVisited: SKColor,
+        boardTileUnvisited: SKColor,
+        boardKnight: SKColor,
+        boardGuideHighlight: SKColor
+    ) {
+        self.boardBackground = boardBackground
+        self.boardGridLine = boardGridLine
+        self.boardTileVisited = boardTileVisited
+        self.boardTileUnvisited = boardTileUnvisited
+        self.boardKnight = boardKnight
+        self.boardGuideHighlight = boardGuideHighlight
+    }
+}
+
+extension GameScenePalette {
+    /// SpriteKit 側にテーマが適用されるまで使用するフォールバック（ライト寄りの仮色）
+    static let fallbackLight = GameScenePalette(
+        boardBackground: SKColor(white: 0.94, alpha: 1.0),
+        boardGridLine: SKColor(white: 0.15, alpha: 1.0),
+        boardTileVisited: SKColor(white: 0.75, alpha: 1.0),
+        boardTileUnvisited: SKColor(white: 0.98, alpha: 1.0),
+        boardKnight: SKColor(white: 0.1, alpha: 1.0),
+        boardGuideHighlight: SKColor(white: 0.4, alpha: 0.6)
+    )
+
+    /// ダークテーマ適用前後でのデバッグ確認用のフォールバック
+    static let fallbackDark = GameScenePalette(
+        boardBackground: SKColor(white: 0.05, alpha: 1.0),
+        boardGridLine: SKColor(white: 0.75, alpha: 1.0),
+        boardTileVisited: SKColor(white: 0.35, alpha: 1.0),
+        boardTileUnvisited: SKColor(white: 0.12, alpha: 1.0),
+        boardKnight: SKColor(white: 0.95, alpha: 1.0),
+        boardGuideHighlight: SKColor(white: 0.85, alpha: 0.55)
+    )
+}
+#endif

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -486,9 +486,21 @@ struct GameView: View {
     /// SpriteKit シーンの配色を現在のテーマに合わせて調整する
     /// - Parameter scheme: ユーザーが選択中のライト/ダーク種別
     private func applyScenePalette(for scheme: ColorScheme) {
-        // SwiftUI 環境のカラースキームを明示指定した AppTheme を生成し、SpriteKit 側へ適用
-        let spriteTheme = AppTheme(colorScheme: scheme)
-        scene.applyTheme(spriteTheme)
+        // SwiftUI 環境のカラースキームを明示指定した AppTheme を生成
+        let appTheme = AppTheme(colorScheme: scheme)
+
+        // AppTheme から SpriteKit 用のカラーパレットへ値を写し替える
+        let palette = GameScenePalette(
+            boardBackground: appTheme.skBoardBackground,
+            boardGridLine: appTheme.skBoardGridLine,
+            boardTileVisited: appTheme.skBoardTileVisited,
+            boardTileUnvisited: appTheme.skBoardTileUnvisited,
+            boardKnight: appTheme.skBoardKnight,
+            boardGuideHighlight: appTheme.skBoardGuideHighlight
+        )
+
+        // 変換したパレットを SpriteKit シーンへ適用し、UI と配色を一致させる
+        scene.applyTheme(palette)
     }
 
     /// ガイドモードの設定と現在の手札から移動可能なマスを算出し、SpriteKit 側へ通知する


### PR DESCRIPTION
## Summary
- SpriteKit 用の GameScenePalette 型を追加し、盤面描画に必要な SKColor を集約
- GameScene が AppTheme に依存しないようにし、パレットから背景・タイル・ハイライト色を取得
- GameView で AppTheme からパレットを生成してシーンへ適用するように更新

## Testing
- `swift build --target Game`


------
https://chatgpt.com/codex/tasks/task_e_68cf0d956ed8832cbd53a31fa78a5ca8