### PR TITLE
Expose GameScene APIs to Game package consumers

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -6,23 +6,24 @@ import UIKit
 
 /// GameCore とのやり取りのためのプロトコル
 /// - ゲームロジック側で実装し、タップされたマスに対する移動処理を担当する
-protocol GameCoreProtocol: AnyObject {
+public protocol GameCoreProtocol: AnyObject {
     /// 指定されたマスをタップした際に呼び出される
     /// - Parameter point: タップされたマスの座標
     func handleTap(at point: GridPoint)
 }
 
 /// 盤面と駒を描画し、タップ入力を GameCore に渡すシーン
-class GameScene: SKScene {
+public final class GameScene: SKScene {
     /// ゲームロジックを保持する参照
-    weak var gameCore: GameCoreProtocol?
+    public weak var gameCore: GameCoreProtocol?
 
     /// 現在の盤面状態
     private var board = Board()
 
     /// SpriteKit 内で利用する配色セット
     /// - 備考: SwiftUI の `AppTheme` とは分離し、SpriteKit 専用の色情報のみを保持する
-    private var palette = GameScenePalette.fallbackLight
+    /// - NOTE: テーマ未設定時でも見た目が破綻しないよう共通フォールバックを適用しておく
+    private var palette = GameScenePalette.fallback
 
     /// 1 マスのサイズ
     private var tileSize: CGFloat = 0
@@ -187,7 +188,8 @@ class GameScene: SKScene {
 
     /// 盤面の状態を更新し、踏破済みマスの色を反映する
     /// - Parameter board: 新しい盤面
-    func updateBoard(_ board: Board) {
+    /// - NOTE: SwiftUI モジュールからも参照するため `public` で公開する
+    public func updateBoard(_ board: Board) {
         self.board = board
         updateTileColors()
         // 盤面更新に応じてアクセシビリティ要素も再構築
@@ -209,7 +211,8 @@ class GameScene: SKScene {
 
     /// ガイドモードで指定されたマスにハイライトを表示する
     /// - Parameter points: 発光させたい盤面座標の集合
-    func updateGuideHighlights(_ points: Set<GridPoint>) {
+    /// - NOTE: ガイド表示の更新を SwiftUI 側から呼び出せるよう公開する
+    public func updateGuideHighlights(_ points: Set<GridPoint>) {
         // 盤外座標が渡されても安全に無視できるよう、盤面内に限定した集合を用意
         let validPoints = Set(points.filter { board.contains($0) })
 
@@ -301,7 +304,8 @@ class GameScene: SKScene {
 
     /// 受け取った配色パレットを SpriteKit のノードへ適用し、背景や各マスの色を更新する
     /// - Parameter palette: SwiftUI 側で決定されたライト/ダーク用カラーを転写したパレット
-    func applyTheme(_ palette: GameScenePalette) {
+    /// - NOTE: パッケージ外からテーマを適用するため `public` を付与
+    public func applyTheme(_ palette: GameScenePalette) {
         // SwiftUI 側で生成されたテーマから変換されたパレットを保持し、今後の色更新にも使えるようにする
         self.palette = palette
 
@@ -323,7 +327,8 @@ class GameScene: SKScene {
 
     /// 駒を指定座標へ移動する
     /// - Parameter point: 移動先の座標
-    func moveKnight(to point: GridPoint) {
+    /// - NOTE: 駒の移動をゲームロジック外部から制御するため公開メソッドにする
+    public func moveKnight(to point: GridPoint) {
         let destination = position(for: point)
         let move = SKAction.move(to: destination, duration: 0.2)
         knightNode?.run(move)

--- a/Game/GameScenePalette.swift
+++ b/Game/GameScenePalette.swift
@@ -3,19 +3,19 @@ import SpriteKit
 
 /// SpriteKit で盤面表示に利用するカラーパレット
 /// - Note: SwiftUI とは別モジュールになるため、必要な `SKColor` 値のみを厳選して保持する
-struct GameScenePalette {
+public struct GameScenePalette {
     /// 盤面の背景色
-    let boardBackground: SKColor
+    public let boardBackground: SKColor
     /// グリッド線の色
-    let boardGridLine: SKColor
+    public let boardGridLine: SKColor
     /// 踏破済みタイルの塗り色
-    let boardTileVisited: SKColor
+    public let boardTileVisited: SKColor
     /// 未踏破タイルの塗り色
-    let boardTileUnvisited: SKColor
+    public let boardTileUnvisited: SKColor
     /// 駒の塗り色
-    let boardKnight: SKColor
+    public let boardKnight: SKColor
     /// ガイド枠の線色
-    let boardGuideHighlight: SKColor
+    public let boardGuideHighlight: SKColor
 
     /// 主要な色をまとめて指定できるイニシャライザ
     /// - Parameters:
@@ -25,7 +25,7 @@ struct GameScenePalette {
     ///   - boardTileUnvisited: 未踏破タイル色
     ///   - boardKnight: 駒の塗り色
     ///   - boardGuideHighlight: ガイド枠の線色
-    init(
+    public init(
         boardBackground: SKColor,
         boardGridLine: SKColor,
         boardTileVisited: SKColor,
@@ -42,9 +42,13 @@ struct GameScenePalette {
     }
 }
 
-extension GameScenePalette {
+public extension GameScenePalette {
+    /// SwiftUI 側でテーマが決まっていない時に使う共通フォールバック
+    /// - Note: ライトテーマ向けの値を採用し、最低限の視認性を確保する
+    public static var fallback: GameScenePalette { fallbackLight }
+
     /// SpriteKit 側にテーマが適用されるまで使用するフォールバック（ライト寄りの仮色）
-    static let fallbackLight = GameScenePalette(
+    public static let fallbackLight = GameScenePalette(
         boardBackground: SKColor(white: 0.94, alpha: 1.0),
         boardGridLine: SKColor(white: 0.15, alpha: 1.0),
         boardTileVisited: SKColor(white: 0.75, alpha: 1.0),
@@ -54,7 +58,7 @@ extension GameScenePalette {
     )
 
     /// ダークテーマ適用前後でのデバッグ確認用のフォールバック
-    static let fallbackDark = GameScenePalette(
+    public static let fallbackDark = GameScenePalette(
         boardBackground: SKColor(white: 0.05, alpha: 1.0),
         boardGridLine: SKColor(white: 0.75, alpha: 1.0),
         boardTileVisited: SKColor(white: 0.35, alpha: 1.0),

--- a/MonoKnight.xcodeproj/project.pbxproj
+++ b/MonoKnight.xcodeproj/project.pbxproj
@@ -9,25 +9,17 @@
 /* Begin PBXBuildFile section */
 		729791562E7EB35900361471 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 729791552E7EB35900361471 /* LaunchScreen.storyboard */; };
 		7297918B2E7F43F300361471 /* Game in Frameworks */ = {isa = PBXBuildFile; productRef = 7297918A2E7F43F300361471 /* Game */; };
-		7297919A2E7F499700361471 /* GameScenePalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729791992E7F499700361471 /* GameScenePalette.swift */; };
-		7297919B2E7F499700361471 /* DealtCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729791982E7F499700361471 /* DealtCard.swift */; };
 		72CF37F02E71616C0093B180 /* MonoKnightApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000004 /* MonoKnightApp.swift */; };
 		72CF38052E7162E20093B180 /* ErrorReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F92E7162E20093B180 /* ErrorReporter.swift */; };
 		72CF38072E7162E20093B180 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF38002E7162E20093B180 /* GameView.swift */; };
-		72CF38082E7162E20093B180 /* DebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F12E7162E20093B180 /* DebugLog.swift */; };
-		72CF38092E7162E20093B180 /* Deck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F22E7162E20093B180 /* Deck.swift */; };
-		72CF380A2E7162E20093B180 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F52E7162E20093B180 /* Models.swift */; };
 		72CF380B2E7162E20093B180 /* AdsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F82E7162E20093B180 /* AdsService.swift */; };
 		72CF380C2E7162E20093B180 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF38032E7162E20093B180 /* SettingsView.swift */; };
-		72CF380D2E7162E20093B180 /* GameCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F32E7162E20093B180 /* GameCore.swift */; };
 		72CF380E2E7162E20093B180 /* ServiceMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37FB2E7162E20093B180 /* ServiceMocks.swift */; };
 		72CF380F2E7162E20093B180 /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF38012E7162E20093B180 /* ResultView.swift */; };
 		72CF38102E7162E20093B180 /* ConsentFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37FE2E7162E20093B180 /* ConsentFlowView.swift */; };
 		72CF38112E7162E20093B180 /* GameCenterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37FA2E7162E20093B180 /* GameCenterService.swift */; };
 		72CF38122E7162E20093B180 /* StoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37FC2E7162E20093B180 /* StoreService.swift */; };
-		72CF38132E7162E20093B180 /* MoveCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F62E7162E20093B180 /* MoveCard.swift */; };
 		72CF38142E7162E20093B180 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF38022E7162E20093B180 /* RootView.swift */; };
-		72CF38152E7162E20093B180 /* GameScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F42E7162E20093B180 /* GameScene.swift */; };
 		72CF38182E7252460093B180 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 72CF38172E7252460093B180 /* GoogleMobileAds */; };
 		72F554A82E7E40100098A1B0 /* MoveCardIllustrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F554A72E7E40100098A1B0 /* MoveCardIllustrationView.swift */; };
 		72F554AC2E7E60850098A1B0 /* HowToPlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F554A92E7E60850098A1B0 /* HowToPlayView.swift */; };
@@ -385,23 +377,15 @@
 			files = (
 				72CF38052E7162E20093B180 /* ErrorReporter.swift in Sources */,
 				72CF38072E7162E20093B180 /* GameView.swift in Sources */,
-				72CF38082E7162E20093B180 /* DebugLog.swift in Sources */,
-				72CF38092E7162E20093B180 /* Deck.swift in Sources */,
-				72CF380A2E7162E20093B180 /* Models.swift in Sources */,
-				72CF380B2E7162E20093B180 /* AdsService.swift in Sources */,
-				72CF380C2E7162E20093B180 /* SettingsView.swift in Sources */,
-				72CF380D2E7162E20093B180 /* GameCore.swift in Sources */,
-				72CF380E2E7162E20093B180 /* ServiceMocks.swift in Sources */,
-				72F554A82E7E40100098A1B0 /* MoveCardIllustrationView.swift in Sources */,
-				72CF380F2E7162E20093B180 /* ResultView.swift in Sources */,
-				72CF38102E7162E20093B180 /* ConsentFlowView.swift in Sources */,
-				72CF38112E7162E20093B180 /* GameCenterService.swift in Sources */,
-				72CF38122E7162E20093B180 /* StoreService.swift in Sources */,
-				72CF38132E7162E20093B180 /* MoveCard.swift in Sources */,
-				7297919A2E7F499700361471 /* GameScenePalette.swift in Sources */,
-				7297919B2E7F499700361471 /* DealtCard.swift in Sources */,
-				72CF38142E7162E20093B180 /* RootView.swift in Sources */,
-				72CF38152E7162E20093B180 /* GameScene.swift in Sources */,
+                               72CF380B2E7162E20093B180 /* AdsService.swift in Sources */,
+                               72CF380C2E7162E20093B180 /* SettingsView.swift in Sources */,
+                               72CF380E2E7162E20093B180 /* ServiceMocks.swift in Sources */,
+                               72F554A82E7E40100098A1B0 /* MoveCardIllustrationView.swift in Sources */,
+                               72CF380F2E7162E20093B180 /* ResultView.swift in Sources */,
+                               72CF38102E7162E20093B180 /* ConsentFlowView.swift in Sources */,
+                               72CF38112E7162E20093B180 /* GameCenterService.swift in Sources */,
+                               72CF38122E7162E20093B180 /* StoreService.swift in Sources */,
+                               72CF38142E7162E20093B180 /* RootView.swift in Sources */,
 				72CF37F02E71616C0093B180 /* MonoKnightApp.swift in Sources */,
 				72F554AC2E7E60850098A1B0 /* HowToPlayView.swift in Sources */,
 				72F554AD2E7E60850098A1B0 /* AppTheme.swift in Sources */,


### PR DESCRIPTION
## Summary
- make `GameScenePalette` and `GameScene` related APIs public so they can be accessed from other modules
- add a shared fallback palette accessor and use it as the default in `GameScene`
- remove Game module sources from the MonoKnightApp target so it links the local package instead

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf1d30c86c832cb7c6afd34038ea37