### PR TITLE
Expose Game models for GameScene API

### DIFF
--- a/Game/Models.swift
+++ b/Game/Models.swift
@@ -2,28 +2,38 @@ import Foundation
 
 /// 座標を表す構造体
 /// - 備考: 原点は左下、x は右方向、y は上方向に増加する
-struct GridPoint: Hashable {
+public struct GridPoint: Hashable {
     /// x 座標 (0...4)
-    let x: Int
+    public let x: Int
     /// y 座標 (0...4)
-    let y: Int
+    public let y: Int
+
+    /// 指定座標を生成するための公開イニシャライザ
+    /// - Parameters:
+    ///   - x: x 座標
+    ///   - y: y 座標
+    /// - Note: 外部モジュールからも `GridPoint` を構築できるよう `public` を付与する
+    public init(x: Int, y: Int) {
+        self.x = x
+        self.y = y
+    }
 
     /// 盤面の範囲を表す定数
-    static let range = 0...4
+    public static let range = 0...4
     /// 盤面の中央位置 `(2,2)`
-    static let center = GridPoint(x: 2, y: 2)
+    public static let center = GridPoint(x: 2, y: 2)
 
     /// 座標を移動させた新しい座標を返す
     /// - Parameters:
     ///   - dx: x 方向の移動量
     ///   - dy: y 方向の移動量
     /// - Returns: 移動後の座標
-    func offset(dx: Int, dy: Int) -> GridPoint {
+    public func offset(dx: Int, dy: Int) -> GridPoint {
         GridPoint(x: x + dx, y: y + dy)
     }
 
     /// 盤面内に収まっているかを判定する
-    var isInside: Bool {
+    public var isInside: Bool {
         GridPoint.range.contains(x) && GridPoint.range.contains(y)
     }
 }
@@ -31,23 +41,23 @@ struct GridPoint: Hashable {
 /// 1 マスの状態
 /// - untouched: 未踏破
 /// - visited: 踏破済み
-enum TileState {
+public enum TileState {
     case untouched
     case visited
 }
 
 /// 5×5 の盤面を管理する構造体
 /// SwiftUI の `onChange` で盤面の変化を検知できるよう Equatable に準拠
-struct Board: Equatable {
+public struct Board: Equatable {
     /// 盤面のサイズ (5×5 固定)
-    static let size = 5
+    public static let size = 5
 
     /// 各マスの状態を保持する二次元配列
     /// y インデックスが先、x インデックスが後となる
     private var tiles: [[TileState]]
 
     /// 初期化。全マス未踏破として生成し、中央を踏破済みに設定する
-    init() {
+    public init() {
         let row = Array(repeating: TileState.untouched, count: Board.size)
         self.tiles = Array(repeating: row, count: Board.size)
         markVisited(GridPoint.center)
@@ -56,14 +66,14 @@ struct Board: Equatable {
     /// 指定座標が盤面内かどうかを判定する
     /// - Parameter point: 判定したい座標
     /// - Returns: 盤面内であれば true
-    func contains(_ point: GridPoint) -> Bool {
+    public func contains(_ point: GridPoint) -> Bool {
         point.isInside
     }
 
     /// 指定座標の踏破状態を返す
     /// - Parameter point: 調べたい座標
     /// - Returns: 盤面内であれば状態を返し、盤外なら nil
-    func state(at point: GridPoint) -> TileState? {
+    public func state(at point: GridPoint) -> TileState? {
         guard contains(point) else { return nil }
         return tiles[point.y][point.x]
     }
@@ -71,20 +81,20 @@ struct Board: Equatable {
     /// 指定座標が踏破済みかどうかを返す
     /// - Parameter point: 調べたい座標
     /// - Returns: 踏破済みであれば true
-    func isVisited(_ point: GridPoint) -> Bool {
+    public func isVisited(_ point: GridPoint) -> Bool {
         state(at: point) == .visited
     }
 
     /// 指定座標を踏破済みに更新する
     /// - Parameter point: 更新したい座標
-    mutating func markVisited(_ point: GridPoint) {
+    public mutating func markVisited(_ point: GridPoint) {
         guard contains(point) else { return }
         tiles[point.y][point.x] = .visited
     }
 
     /// 未踏破マスの残数を計算して返す
     /// - Returns: まだ踏破していないマスの数
-    var remainingCount: Int {
+    public var remainingCount: Int {
         var count = 0
         for row in tiles {
             for tile in row where tile != .visited {
@@ -95,7 +105,7 @@ struct Board: Equatable {
     }
 
     /// 全マスを踏破済みにしたかどうかを返す
-    var isCleared: Bool {
+    public var isCleared: Bool {
         for row in tiles {
             for tile in row {
                 if tile != .visited { return false }
@@ -119,7 +129,7 @@ enum GameProgress {
 extension GridPoint: CustomStringConvertible {
     /// デバッグ出力時に座標を分かりやすく表示する
     /// - Returns: "(x, y)" 形式の文字列
-    var description: String { "(\(x),\(y))" }
+    public var description: String { "(\(x),\(y))" }
 }
 
 #if DEBUG


### PR DESCRIPTION
## Summary
- expose GridPoint, Board, and TileState so GameScene's public interface is consumable from other modules
- add public initializers and accessors needed to construct and inspect grid positions and boards from clients
- keep CustomStringConvertible visibility aligned with the new public model types

## Testing
- swift build --target Game
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf200c00c0832c89e52d63151cdedf