### PR TITLE
Fix GameCenterService logging dependency

### DIFF
--- a/Services/GameCenterService.swift
+++ b/Services/GameCenterService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Game      // debugLog / debugError などゲームロジック側のデバッグユーティリティを利用するために追加
 import GameKit
 import UIKit
 import SwiftUI // @AppStorage を利用するために追加


### PR DESCRIPTION
## Summary
- import the Game package in GameCenterService so debugLog/debugError remain available when building the app target

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf21b1bf68832c9be2a908d072f3ec