### PR TITLE
Expose debug logging utilities to app services

### DIFF
--- a/Game/DebugLog.swift
+++ b/Game/DebugLog.swift
@@ -7,7 +7,7 @@ import Foundation
 ///   - line: 呼び出し元の行番号（自動で取得）
 ///   - function: 呼び出し元の関数名（自動で取得）
 /// - Note: リリースビルドでは呼び出しても何も表示されない
-func debugLog(
+public func debugLog(
     _ message: String,
     file: String = #file,
     line: Int = #line,
@@ -31,7 +31,7 @@ func debugLog(
 ///   - line: 呼び出し元の行番号（自動で取得）
 ///   - function: 呼び出し元の関数名（自動で取得）
 /// - Note: DEBUG ビルド専用。リリース時には出力されない
-func debugError(
+public func debugError(
     _ error: Error,
     message: String? = nil,
     file: String = #file,

--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -3,6 +3,8 @@ import UIKit
 import SwiftUI
 import AppTrackingTransparency
 import GoogleMobileAds
+// ログ出力ユーティリティを利用するため Game モジュールを読み込む
+import Game
 
 // MARK: - Protocol
 /// UI レイヤーからメインスレッド経由で利用する前提のため、プロトコル自体も MainActor に固定する

--- a/Services/ErrorReporter.swift
+++ b/Services/ErrorReporter.swift
@@ -1,4 +1,6 @@
 import Foundation
+// デバッグログ出力のために Game モジュールを読み込む
+import Game
 #if canImport(Darwin)
 import Darwin
 #endif

--- a/Services/GameCenterService.swift
+++ b/Services/GameCenterService.swift
@@ -2,6 +2,8 @@ import Foundation
 import GameKit
 import UIKit
 import SwiftUI // @AppStorage を利用するために追加
+// デバッグ用ログ関数を利用するため Game モジュールを読み込む
+import Game
 
 /// Game Center 操作に必要なインターフェースを定義するプロトコル
 /// - NOTE: 認証やスコア送信をテストしやすくするために利用する

--- a/Services/StoreService.swift
+++ b/Services/StoreService.swift
@@ -1,6 +1,8 @@
 import Foundation
 import StoreKit
 import SwiftUI
+// Game モジュールに定義されたデバッグ用ユーティリティを利用するために読み込む
+import Game
 
 /// StoreKit2 を用いた課金処理をまとめたサービス
 /// `remove_ads` 商品の購入・復元・状態保持を担当する


### PR DESCRIPTION
## Summary
- expose Game target debugLog/debugError helpers for other modules
- import the Game module in service files that rely on the logging utilities

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf21bbcd30832cad411f77299c8488