### PR TITLE
Expose Game module APIs for SwiftUI integration

### DIFF
--- a/Game/DealtCard.swift
+++ b/Game/DealtCard.swift
@@ -2,17 +2,18 @@ import Foundation
 
 /// 山札から配られたカードを UI で一意に識別するための薄いラッパー構造体
 /// - Note: アニメーションや SwiftUI の `Identifiable` に準拠させるため、UUID を別途付与する。
-struct DealtCard: Identifiable, Equatable {
+/// SwiftUI モジュールからも利用するため `public` を付与する
+public struct DealtCard: Identifiable, Equatable {
     /// SwiftUI の差分計算とアニメーションで利用する一意な識別子
-    let id: UUID
+    public let id: UUID
     /// これまでのロジックが扱っていた移動カード本体
-    let move: MoveCard
+    public let move: MoveCard
 
     /// 新しいカードを生成する
     /// - Parameters:
     ///   - id: 既存カードからラップし直す場合に利用する識別子（省略時は新規採番）
     ///   - move: 実際の移動ロジックを担う `MoveCard`
-    init(id: UUID = UUID(), move: MoveCard) {
+    public init(id: UUID = UUID(), move: MoveCard) {
         self.id = id
         self.move = move
     }

--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -3,11 +3,13 @@ import Foundation
 import Combine
 #else
 /// Linux など Combine が存在しない環境向けの簡易定義
-protocol ObservableObject {}
+public protocol ObservableObject {}
 @propertyWrapper
-struct Published<Value> {
-    var wrappedValue: Value
-    init(wrappedValue: Value) { self.wrappedValue = wrappedValue }
+public struct Published<Value> {
+    /// ラップされている実際の値
+    public var wrappedValue: Value
+    /// 初期化で保持する値を受け取る
+    public init(wrappedValue: Value) { self.wrappedValue = wrappedValue }
 }
 #endif
 #if canImport(UIKit)
@@ -16,39 +18,43 @@ import UIKit
 
 /// ゲーム進行を統括するクラス
 /// - 盤面操作・手札管理・ペナルティ処理・スコア計算を担当する
-final class GameCore: ObservableObject {
+/// - SwiftUI 側から直接利用するため `public` として公開する
+public final class GameCore: ObservableObject {
     /// 手札枚数を統一的に扱うための定数（今回は 5 枚で固定）
     private let handSize: Int = 5
     /// 先読み表示に用いるカード枚数（NEXT 表示は 3 枚先まで）
     private let nextPreviewCount: Int = 3
     /// 盤面情報
-    @Published private(set) var board = Board()
+    @Published public private(set) var board = Board()
     /// 駒の現在位置
-    @Published private(set) var current = GridPoint.center
+    @Published public private(set) var current = GridPoint.center
     /// 手札（常に 5 枚保持）。UI での識別用に `DealtCard` へラップする
-    @Published private(set) var hand: [DealtCard] = []
+    @Published public private(set) var hand: [DealtCard] = []
     /// 次に引かれるカード群（先読み 3 枚分を保持）
-    @Published private(set) var nextCards: [DealtCard] = []
+    @Published public private(set) var nextCards: [DealtCard] = []
     /// ゲームの進行状態
-    @Published private(set) var progress: GameProgress = .playing
+    @Published public private(set) var progress: GameProgress = .playing
     /// 手詰まりペナルティが発生したことを UI 側へ伝えるイベント識別子
     /// - Note: Optional とすることで初期化直後の誤通知を防ぎ、実際にペナルティが起きたタイミングで UUID を更新する
-    @Published private(set) var penaltyEventID: UUID?
+    @Published public private(set) var penaltyEventID: UUID?
 
     /// 実際に移動した回数（UI へ即時反映させるため @Published を付与）
-    @Published private(set) var moveCount: Int = 0
+    @Published public private(set) var moveCount: Int = 0
     /// ペナルティによる加算手数（手詰まり通知に利用するため公開）
-    @Published private(set) var penaltyCount: Int = 0
+    @Published public private(set) var penaltyCount: Int = 0
     /// 合計スコア（小さいほど良い）
-    var score: Int { moveCount + penaltyCount }
+    /// 合計スコアを UI 側でも参照できるよう公開する
+    public var score: Int { moveCount + penaltyCount }
     /// 未踏破マスの残り数を UI へ公開する計算プロパティ
-    var remainingTiles: Int { board.remainingCount }
+    /// 残りマス数を UI 側に公開する
+    public var remainingTiles: Int { board.remainingCount }
 
     /// 山札管理（`Deck.swift` に定義された重み付き無限山札を使用）
     private var deck = Deck()
 
     /// 初期化時に手札と次カードを用意
-    init() {
+    /// 外部モジュールからも初期化できるよう公開イニシャライザを用意
+    public init() {
         // 定数 handSize を用いて初期手札を引き切る
         hand = deck.draw(count: handSize)
         nextCards = deck.draw(count: nextPreviewCount)
@@ -63,7 +69,8 @@ final class GameCore: ObservableObject {
 
     /// 指定インデックスのカードで駒を移動させる
     /// - Parameter index: 手札配列の位置（0〜4）
-    func playCard(at index: Int) {
+    /// SwiftUI 側でカードをタップした際に呼び出すため公開する
+    public func playCard(at index: Int) {
         // クリア済みや手詰まり中は操作不可
         guard progress == .playing else { return }
         // インデックスが範囲内か確認（0〜4 の範囲を想定）
@@ -143,7 +150,7 @@ final class GameCore: ObservableObject {
 
     /// UI 側から手動でペナルティを支払い、手札を引き直すための公開メソッド
     /// - Note: 既にゲームが終了している場合や、ペナルティ中は何もしない
-    func applyManualPenaltyRedraw() {
+    public func applyManualPenaltyRedraw() {
         // クリア済み・ペナルティ処理中は無視し、進行中のみ受け付ける
         guard progress == .playing else { return }
 
@@ -209,7 +216,7 @@ final class GameCore: ObservableObject {
     }
 
     /// ゲームを最初からやり直す
-    func reset() {
+    public func reset() {
         board = Board()
         current = .center
         moveCount = 0
@@ -262,7 +269,7 @@ final class GameCore: ObservableObject {
 extension GameCore: GameCoreProtocol {
     /// 盤面上のマスがタップされた際に呼び出される
     /// - Parameter point: タップされたマスの座標
-    func handleTap(at point: GridPoint) {
+    public func handleTap(at point: GridPoint) {
         // ゲーム進行中でなければ入力を無視
         guard progress == .playing else { return }
 

--- a/Game/Models.swift
+++ b/Game/Models.swift
@@ -116,7 +116,8 @@ public struct Board: Equatable {
 }
 
 /// ゲーム全体の進行状態
-enum GameProgress {
+/// - SwiftUI 側の状態監視でも利用するため公開する
+public enum GameProgress {
     /// プレイ続行中
     case playing
     /// 全マス踏破でクリア

--- a/Game/MoveCard.swift
+++ b/Game/MoveCard.swift
@@ -2,7 +2,8 @@ import Foundation
 
 /// 駒を移動させるカードの種類を定義する列挙型
 /// - Note: 周囲 1 マスのキング型 8 種、ナイト型 8 種、距離 2 の直線/斜め 8 種の計 24 種をサポート
-enum MoveCard: CaseIterable {
+/// - SwiftUI モジュールからも扱うため `public` とする
+public enum MoveCard: CaseIterable {
     // MARK: - ケース定義
     /// キング型: 上に 1
     case kingUp
@@ -58,7 +59,7 @@ enum MoveCard: CaseIterable {
 
     // MARK: - 移動量
     /// x 方向の移動量
-    var dx: Int {
+    public var dx: Int {
         switch self {
         case .kingUp: return 0
         case .kingUpRight: return 1
@@ -88,7 +89,7 @@ enum MoveCard: CaseIterable {
     }
 
     /// y 方向の移動量
-    var dy: Int {
+    public var dy: Int {
         switch self {
         case .kingUp: return 1
         case .kingUpRight: return 1
@@ -119,7 +120,7 @@ enum MoveCard: CaseIterable {
 
     // MARK: - UI 表示名
     /// UI に表示する日本語の名前
-    var displayName: String {
+    public var displayName: String {
         switch self {
         case .kingUp:
             // キング型: 上方向へ 1 マス移動
@@ -167,7 +168,7 @@ enum MoveCard: CaseIterable {
     // MARK: - 属性判定
     /// 王将型（キング型）に該当するかを判定するフラグ
     /// - Note: デッキ構築時の配分調整に利用する
-    var isKingType: Bool {
+    public var isKingType: Bool {
         switch self {
         case .kingUp,
              .kingUpRight,
@@ -185,7 +186,7 @@ enum MoveCard: CaseIterable {
 
     /// ナイト型カードかどうかを判定するフラグ
     /// - Note: 山札内で桂馬カードの重み付けを計算するために利用する
-    var isKnightType: Bool {
+    public var isKnightType: Bool {
         switch self {
         case .knightUp2Right1,
              .knightUp2Left1,
@@ -203,7 +204,7 @@ enum MoveCard: CaseIterable {
 
     /// 斜め 2 マス（マンハッタン距離 4）の長距離斜めカードかどうかを判定する
     /// - Note: 山札の重み調整（桂馬カードの半分の排出確率）に利用する
-    var isDiagonalDistanceFour: Bool {
+    public var isDiagonalDistanceFour: Bool {
         switch self {
         case .diagonalUpRight2,
              .diagonalDownRight2,
@@ -219,7 +220,7 @@ enum MoveCard: CaseIterable {
     /// 指定した座標からこのカードが使用可能か判定する
     /// - Parameter from: 現在位置
     /// - Returns: 盤内に移動できる場合は true
-    func canUse(from: GridPoint) -> Bool {
+    public func canUse(from: GridPoint) -> Bool {
         let destination = from.offset(dx: dx, dy: dy)
         return destination.isInside
     }
@@ -228,7 +229,7 @@ enum MoveCard: CaseIterable {
 // MARK: - デバッグ用表示名
 extension MoveCard: CustomStringConvertible {
     /// デバッグログでカード名をわかりやすくするため displayName を返す
-    var description: String { displayName }
+    public var description: String { displayName }
 }
 
 // MARK: - Identifiable への適合
@@ -237,6 +238,6 @@ extension MoveCard: Identifiable {
     /// ここでは単純に UUID を生成して返す
     /// - Note: 山札で同種カードが複数枚存在するため
     ///         各カードインスタンスを区別する目的で利用する
-    var id: UUID { UUID() }
+    public var id: UUID { UUID() }
 }
 


### PR DESCRIPTION
## Summary
- make `GameCore` public and expose published game state so SwiftUI UI targets can instantiate and observe the core logic
- mark `MoveCard`, `DealtCard`, and `GameProgress` as public so UI code can inspect card data and progress without access errors
- adjust the Combine fallback wrapper to be public for Linux builds

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68cf2341bdd0832c9aa525d5750d2255