### PR TITLE
Ensure guide highlight nodes reconnect after SKView recreation

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -277,6 +277,11 @@ public final class GameScene: SKScene {
         // 必要なマスへハイライトを再構成
         for point in points {
             if let node = guideHighlightNodes[point] {
+                // 既存ノードを再利用する際は親子関係が途切れていないか必ず確認する
+                if node.parent !== self {
+                    // SKView の再生成時に親を失ったノードを確実に再接続するため
+                    addChild(node)
+                }
                 configureGuideHighlightNode(node, for: point)
             } else {
                 let node = SKShapeNode()


### PR DESCRIPTION
## Summary
- 既存のガイドハイライトノードを再利用する際に親子関係を確認し、切断されていればシーンへ再接続するように修正
- SKView の再生成時にノードを再接続する意図を日本語コメントで明記

## Testing
- 手動確認が必要なガイドモード表示・シーン再表示でのハイライト残存については実機環境がないため未実施

------
https://chatgpt.com/codex/tasks/task_e_68cf3baf63a4832c82f5fced87d11f75