### PR TITLE
Reset starts new randomized game

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -286,7 +286,9 @@ public final class GameCore: ObservableObject {
     }
 
     /// ゲームを最初からやり直す
-    public func reset() {
+    /// - Parameter startNewGame: `true` の場合は乱数シードも新規採番して完全に新しいゲームを開始する。
+    ///                           `false` の場合は同じシードを用いて同一展開を再現する。
+    public func reset(startNewGame: Bool = true) {
         board = Board()
         current = .center
         moveCount = 0
@@ -294,7 +296,13 @@ public final class GameCore: ObservableObject {
         progress = .playing
         penaltyEventID = nil
         boardTapPlayRequest = nil
-        deck.reset()
+        if startNewGame {
+            // リセット時にゲーム展開が固定化されないよう、山札そのものを作り直してシードを更新する
+            deck = Deck()
+        } else {
+            // 同じ展開をもう一度確認したいケースに備え、既存シードを使ったリセットも選べるようにする
+            deck.reset()
+        }
         // リセット時も handSize を用いて手札を補充
         hand = deck.draw(count: handSize)
         nextCards = deck.draw(count: nextPreviewCount)

--- a/Tests/GameTests/GameCoreTests.swift
+++ b/Tests/GameTests/GameCoreTests.swift
@@ -151,4 +151,31 @@ final class GameCoreTests: XCTestCase {
         core.reset()
         XCTAssertEqual(core.hand.count, 5, "リセット直後の手札枚数が 5 枚になっていない")
     }
+
+    /// 同じシードでゲームをやり直したい場合に `startNewGame: false` が利用できるか検証
+    func testResetCanReuseSameSeedWhenRequested() {
+        // 5 枚の手札と 3 枚の先読みが明確に分かるよう、連続する 8 枚のカードを用意
+        let preset: [MoveCard] = [
+            .kingUp,
+            .kingRight,
+            .kingDown,
+            .kingLeft,
+            .kingUpLeft,
+            .knightUp1Right2,
+            .knightUp2Right1,
+            .straightUp2
+        ]
+        let deck = Deck.makeTestDeck(cards: preset)
+        let core = GameCore.makeTestInstance(deck: deck)
+
+        // リセット前の手札と先読み構成を控えておき、後で比較できるようにする
+        let initialHand = core.hand.map { $0.move }
+        let initialNext = core.nextCards.map { $0.move }
+
+        // 同一シードを維持するモードでリセットし、手札が再現されるかを確認
+        core.reset(startNewGame: false)
+
+        XCTAssertEqual(core.hand.map { $0.move }, initialHand, "同一シードでのリセット時は手札構成が一致するべき")
+        XCTAssertEqual(core.nextCards.map { $0.move }, initialNext, "同一シードでのリセット時は先読み構成が一致するべき")
+    }
 }


### PR DESCRIPTION
## Summary
- allow `GameCore.reset` to create a fresh deck by default so each retry starts a new game
- keep an option to reuse the existing deck for deterministic debugging
- add a regression test that verifies the deterministic reset path when needed

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf47211694832ca42c68b9db6b66f3