### PR TITLE
Show title screen on launch

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -14,8 +14,9 @@ struct RootView: View {
     /// - Note: 認証後はラベル表示に切り替える
     @State private var isAuthenticated: Bool
     /// ゲームタブでタイトル画面を表示するかどうかのフラグ
-    /// - NOTE: メニューからタイトルへ戻る操作を受けて切り替える
-    @State private var isShowingTitleScreen: Bool = false
+    /// - NOTE: アプリ起動直後にタイトルを先に表示したいので初期値は `true`
+    ///         メニューからタイトルへ戻る操作でもこのフラグを再度 `true` に切り替える
+    @State private var isShowingTitleScreen: Bool = true
 
     /// 依存サービスを外部から注入可能にする初期化処理
     /// - Parameters:


### PR DESCRIPTION
## Summary
- 初期状態でタイトル画面を表示するよう `RootView` の状態管理を調整

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf4baf35b0832ca5f4ab280fee7240