### PR TITLE
Update UMP consent singleton usage

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -113,7 +113,7 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
             // 同意状態に応じて NPA フラグを更新し、広告リクエストへ反映させる
             applyConsentStatusAndReloadIfNeeded()
 
-            let consentInfo = UMPConsentInformation.sharedInstance
+            let consentInfo = UMPConsentInformation.shared
             // 同意フォームが利用可能な場合のみロードと表示を行う
             guard consentInfo.formStatus == .available else { return }
 
@@ -141,7 +141,7 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
             try await requestConsentInfoUpdate()
             applyConsentStatusAndReloadIfNeeded()
 
-            let consentInfo = UMPConsentInformation.sharedInstance
+            let consentInfo = UMPConsentInformation.shared
             guard consentInfo.formStatus == .available else { return }
 
             // 設定画面などから呼び出された際は Privacy Options を直接表示する
@@ -201,7 +201,7 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
     /// インタースティシャル広告を読み込むヘルパー
     private func loadInterstitial() {
         guard hasValidAdConfiguration,
-              UMPConsentInformation.sharedInstance.canRequestAds,
+              UMPConsentInformation.shared.canRequestAds,
               !adsDisabled,
               !removeAds,
               !isLoadingAd,
@@ -298,7 +298,7 @@ private extension AdsService {
         parameters.debugSettings = debugSettings
 #endif
 
-        let consentInfo = UMPConsentInformation.sharedInstance
+        let consentInfo = UMPConsentInformation.shared
 
         try await withCheckedThrowingContinuation { continuation in
             consentInfo.requestConsentInfoUpdate(with: parameters) { error in
@@ -384,7 +384,7 @@ private extension AdsService {
 
     /// 現在の同意ステータスを見て NPA フラグを更新し、必要に応じて広告を再読み込みする
     func applyConsentStatusAndReloadIfNeeded() {
-        let consentInfo = UMPConsentInformation.sharedInstance
+        let consentInfo = UMPConsentInformation.shared
         // 取得済み or 規制対象外の場合のみパーソナライズを許可し、それ以外は安全側として NPA を指定する
         let newShouldUseNPA: Bool
         switch consentInfo.consentStatus {


### PR DESCRIPTION
## Summary
- update Google UMP consent accessors to use the new `UMPConsentInformation.shared`
- keep consent handling logic and downstream checks intact

## Testing
- not run (platform limitation)

------
https://chatgpt.com/codex/tasks/task_e_68cf87e6f014832c8fba9fcebdebbaef