### PR TITLE
Fix continuation type inference in AdsService

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -300,7 +300,7 @@ private extension AdsService {
 
         let consentInfo = UMPConsentInformation.sharedInstance
 
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             consentInfo.requestConsentInfoUpdate(with: parameters) { error in
                 if let error {
                     continuation.resume(throwing: error)
@@ -348,7 +348,7 @@ private extension AdsService {
             throw error
         }
 
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             consentForm.present(from: viewController) { [weak self] error in
                 defer { self?.consentForm = nil }
                 if let error {
@@ -371,7 +371,7 @@ private extension AdsService {
             throw error
         }
 
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             UMPConsentForm.presentPrivacyOptionsForm(from: viewController) { error in
                 if let error {
                     continuation.resume(throwing: error)


### PR DESCRIPTION
## Summary
- add explicit CheckedContinuation<Void, Error> annotations for UMP continuations in AdsService

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68cf87ec4c80832caf10a41f10ddc267