### PR TITLE
Adjust guide highlight stroke to dark gray

### DIFF
--- a/Game/GameScenePalette.swift
+++ b/Game/GameScenePalette.swift
@@ -54,7 +54,8 @@ public extension GameScenePalette {
         boardTileVisited: SKColor(white: 0.75, alpha: 1.0),
         boardTileUnvisited: SKColor(white: 0.98, alpha: 1.0),
         boardKnight: SKColor(white: 0.1, alpha: 1.0),
-        boardGuideHighlight: SKColor(white: 0.4, alpha: 0.6)
+        // NOTE: SpriteKit 側も SwiftUI と同様に濃いグレーを採用し、ダークテーマへの切替前でも過度なコントラストにならないよう配慮する
+        boardGuideHighlight: SKColor(white: 0.2, alpha: 0.45)
     )
 
     /// ダークテーマ適用前後でのデバッグ確認用のフォールバック

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -407,8 +407,10 @@ struct AppTheme: DynamicProperty {
             // ダークテーマでは boardGridLine（白 75%）を基準にしつつ、視認性を確保するため透過率をやや高める
             return boardGridLine.opacity(0.5)
         default:
-            // ライトテーマでは boardGridLine（黒 65%）に近いグレーを薄く敷き、主張しすぎないハイライトにする
-            return boardGridLine.opacity(0.3)
+            // ライトテーマでは純粋な黒だと輪郭が強すぎるため、少しだけ明度を持たせた濃いグレーを採用する
+            // NOTE: `Color(white: 0.2)` で RGB(51,51,51) 相当の色味を用意し、透過度で軽やかさを調整する
+            let guideStrokeBase = Color(white: 0.2)
+            return guideStrokeBase.opacity(0.45)
         }
     }
 


### PR DESCRIPTION
## Summary
- adjust the light theme guide frame color to use a dark gray base instead of pure black for softer contrast
- align the SpriteKit fallback palette with the new gray stroke so guide highlights stay consistent during initialization

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cfc23c4c38832ca2c4079cb5f4da7f