### PR TITLE
Adjust guide buffer clearing timing

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -218,12 +218,12 @@ struct GameView: View {
             if progress == .playing {
                 if let bufferedHand = pendingGuideHand {
                     // デッドロック解除直後は退避しておいた手札情報を使ってガイドを復元する
+                    // refreshGuideHighlights 内で .playing 復帰を確認したタイミングのみバッファが空になる
+                    // 仕組みに変更されたため、ここでは復元処理の呼び出しに専念させる
                     refreshGuideHighlights(
                         handOverride: bufferedHand,
                         currentOverride: pendingGuideCurrent
                     )
-                    pendingGuideHand = nil
-                    pendingGuideCurrent = nil
                 } else {
                     // バッファが無ければ通常通り最新状態から計算する
                     refreshGuideHighlights()


### PR DESCRIPTION
## Summary
- stop manually nil-resetting the pending guide buffers when progress returns to .playing
- document that refreshGuideHighlights is now responsible for clearing the buffers after a successful redraw

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfcd912b58832c83a502d1747ab847