### PR TITLE
Add debug logging for guide highlight flows

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -259,6 +259,9 @@ public final class GameScene: SKScene {
         // 最新の要求内容を常に保持し、レイアウト完了後に再構成できるようにする
         pendingGuideHighlightPoints = validPoints
 
+        // SwiftUI 側からのリクエストが途絶えていないか確認するため、受け取ったマス数とレイアウト状態を記録
+        debugLog("GameScene ハイライト更新要求: 有効マス数=\(validPoints.count), レイアウト確定=\(tileSize > 0)")
+
         // タイルサイズが未確定（0 または負数）の場合はノード生成を保留し、後で再試行する
         guard tileSize > 0 else { return }
 


### PR DESCRIPTION
## Summary
- add detailed debug logging in `GameView` to report guide highlights status, hand updates, and progress transitions
- record the number of highlight targets when SwiftUI triggers updates on the SpriteKit scene

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cfd235eee0832c8e935bb318c81d83