### PR TITLE
Clear pending guide highlights after rebuild

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -387,6 +387,8 @@ public final class GameScene: SKScene {
         guard isLayoutReady else { return }
 
         rebuildGuideHighlightNodes(using: validPoints)
+        // レイアウト確定後に最新情報で再構成できたため、保留集合はここで必ず消費しておく
+        pendingGuideHighlightPoints.removeAll()
     }
 
     /// 指定された集合に合わせてハイライトノード群を再生成する
@@ -528,6 +530,8 @@ public final class GameScene: SKScene {
     private func applyPendingGuideHighlightsIfNeeded() {
         guard isLayoutReady, !pendingGuideHighlightPoints.isEmpty else { return }
         rebuildGuideHighlightNodes(using: pendingGuideHighlightPoints)
+        // `flushPendingUpdatesIfNeeded` から呼び出された際も、再構成が完了した時点で保留分をクリアする
+        pendingGuideHighlightPoints.removeAll()
     }
 
     /// レイアウト確定後に盤面・駒・ガイドの保留更新をまとめて反映する


### PR DESCRIPTION
## Summary
- clear the cached pending guide highlight points once highlight nodes are rebuilt
- ensure flushPendingUpdatesIfNeeded also drains pending guide highlights after application

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68d0f0926ef8832cb01888daa7557465