### PR TITLE
Update simulator test device identifier for Google Mobile Ads v11

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -85,7 +85,11 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
 
 #if targetEnvironment(simulator)
         // シミュレータではテストデバイス ID を明示することで、常にテスト広告が返るようにする
-        mobileAds.requestConfiguration.testDeviceIdentifiers = [GADSimulatorID]
+        // Google Mobile Ads SDK v11 からは `RequestConfiguration.TestDeviceIdentifiers.simulator` が正式に提供されたため、
+        // 廃止予定だった `GADSimulatorID` を参照せず最新 API へ統一する。
+        mobileAds.requestConfiguration.testDeviceIdentifiers = [
+            RequestConfiguration.TestDeviceIdentifiers.simulator
+        ]
         debugLog("シミュレータ向けにテストデバイス ID を登録しました")
 #endif
 


### PR DESCRIPTION
## Summary
- replace the deprecated `GADSimulatorID` constant with `RequestConfiguration.TestDeviceIdentifiers.simulator` for simulator test ads
- update inline comments to note the Google Mobile Ads SDK v11 API change

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68d0f2f0bea4832c80da7b9b67fe6d85