### PR TITLE
Use GADSimulatorID for simulator test device configuration

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -85,12 +85,12 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
 
 #if targetEnvironment(simulator)
         // シミュレータではテストデバイス ID を明示することで、常にテスト広告が返るようにする
-        // Google Mobile Ads SDK v11 からは `RequestConfiguration.TestDeviceIdentifier.simulator` が正式に提供されたため、
-        // 廃止予定だった `GADSimulatorID` を参照せず最新 API へ統一する。
+        // Google Mobile Ads SDK が公開している `GADSimulatorID` を利用することで、SDK 側の互換性更新が入っても
+        // シミュレータ判定の仕組みが変わる心配を減らせるため、安全側に寄せた設定とする。
         mobileAds.requestConfiguration.testDeviceIdentifiers = [
-            RequestConfiguration.TestDeviceIdentifier.simulator
+            GADSimulatorID
         ]
-        debugLog("シミュレータ向けにテストデバイス ID を登録しました")
+        debugLog("シミュレータ向けにテストデバイス ID (GADSimulatorID) を登録しました")
 #endif
 
         // Swift 6 では completionHandler に nil を渡すと型推論ができずビルドエラーになるため、


### PR DESCRIPTION
## Summary
- update the simulator-only configuration in `AdsService` to register the Google-provided `GADSimulatorID` string constant
- refresh inline comments to clarify why the explicit simulator identifier is used for safer compatibility

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68d0f641fd10832ca2e0360b9a362f5e