### PR TITLE
クラシカルチャレンジモードのUI／ロジックを仕上げ

### DIFF
--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// ゲームルール一式をまとめたモード設定
+/// - Note: 盤サイズや山札構成、ペナルティ量などをまとめて扱うことで、新モード追加時の分岐を最小限に抑える。
+public struct GameMode: Equatable, Identifiable {
+    /// 識別子。UI や永続化でも使用しやすいよう文字列 RawValue を採用する
+    public enum Identifier: String, CaseIterable {
+        case standard5x5
+        case classicalChallenge
+    }
+
+    /// 初期スポーンの扱い
+    public enum SpawnRule: Equatable {
+        /// 固定座標へスポーン
+        case fixed(GridPoint)
+        /// プレイヤーが任意のマスを選択してスポーン
+        case chooseAnyAfterPreview
+    }
+
+    /// 一意な識別子
+    public let identifier: Identifier
+    /// 表示名（タイトル画面などで利用）
+    public let displayName: String
+    /// 盤面サイズ（N×N）
+    public let boardSize: Int
+    /// 初期手札枚数
+    public let handSize: Int
+    /// 先読み表示枚数
+    public let nextPreviewCount: Int
+    /// 山札構成設定（ゲームモジュール内部で使用）
+    let deckConfiguration: Deck.Configuration
+    /// スポーンルール
+    public let spawnRule: SpawnRule
+    /// 自動ペナルティ（手詰まり引き直し）で加算する手数
+    public let deadlockPenaltyCost: Int
+    /// 手動ペナルティで加算する手数
+    public let manualRedrawPenaltyCost: Int
+    /// 既踏マスへ再訪した際に加算する手数
+    public let revisitPenaltyCost: Int
+
+    /// `Identifiable` 準拠用
+    public var id: Identifier { identifier }
+
+    /// スポーン選択が必要かどうか
+    public var requiresSpawnSelection: Bool {
+        if case .chooseAnyAfterPreview = spawnRule { return true }
+        return false
+    }
+
+    /// 初期位置（固定スポーンの場合のみ）
+    public var initialSpawnPoint: GridPoint? {
+        switch spawnRule {
+        case .fixed(let point):
+            return point
+        case .chooseAnyAfterPreview:
+            return nil
+        }
+    }
+
+    /// 初期状態で踏破済みにしておくマス集合
+    public var initialVisitedPoints: [GridPoint] {
+        switch spawnRule {
+        case .fixed(let point):
+            return [point]
+        case .chooseAnyAfterPreview:
+            return []
+        }
+    }
+
+    /// スタンダードモード（既存仕様）
+    public static let standard: GameMode = GameMode(
+        identifier: .standard5x5,
+        displayName: "スタンダード",
+        boardSize: 5,
+        handSize: 5,
+        nextPreviewCount: 3,
+        deckConfiguration: .standard,
+        spawnRule: .fixed(GridPoint.center(of: 5)),
+        deadlockPenaltyCost: 5,
+        manualRedrawPenaltyCost: 5,
+        revisitPenaltyCost: 0
+    )
+
+    /// クラシカルチャレンジモード
+    public static let classicalChallenge: GameMode = GameMode(
+        identifier: .classicalChallenge,
+        displayName: "クラシカルチャレンジ",
+        boardSize: 8,
+        handSize: 5,
+        nextPreviewCount: 3,
+        deckConfiguration: .classicalChallenge,
+        spawnRule: .chooseAnyAfterPreview,
+        deadlockPenaltyCost: 2,
+        manualRedrawPenaltyCost: 2,
+        revisitPenaltyCost: 1
+    )
+
+    /// 利用可能な全モードを列挙した配列
+    /// - Note: タイトル画面のモード選択など UI 側で繰り返し利用するため、順序付きの一覧を提供する
+    public static let allModes: [GameMode] = Identifier.allCases.map { identifier in
+        mode(for: identifier)
+    }
+
+    /// 識別子から対応するモード定義を取り出すヘルパー
+    /// - Parameter identifier: 利用したいモードの識別子
+    /// - Returns: `identifier` に対応する `GameMode`
+    public static func mode(for identifier: Identifier) -> GameMode {
+        switch identifier {
+        case .standard5x5:
+            return .standard
+        case .classicalChallenge:
+            return .classicalChallenge
+        }
+    }
+
+    /// Equatable 準拠。識別子が一致すれば同一モードとみなす
+    public static func == (lhs: GameMode, rhs: GameMode) -> Bool {
+        lhs.identifier == rhs.identifier
+    }
+}

--- a/Game/MoveCard.swift
+++ b/Game/MoveCard.swift
@@ -247,12 +247,14 @@ public enum MoveCard: CaseIterable {
 
     // MARK: - 利用判定
     /// 指定した座標からこのカードが使用可能か判定する
-    /// - Parameter from: 現在位置
+    /// - Parameters:
+    ///   - from: 現在位置
+    ///   - boardSize: 判定対象となる盤面サイズ
     /// - Returns: 盤内に移動できる場合は true
-    public func canUse(from: GridPoint) -> Bool {
+    public func canUse(from: GridPoint, boardSize: Int) -> Bool {
         // 現在位置に移動量を加算し、盤内かどうかを評価する
         let destination = from.offset(dx: dx, dy: dy)
-        return destination.isInside
+        return destination.isInside(boardSize: boardSize)
     }
 }
 

--- a/Tests/GameTests/BoardClearTests.swift
+++ b/Tests/GameTests/BoardClearTests.swift
@@ -5,10 +5,11 @@ import XCTest
 final class BoardClearTests: XCTestCase {
     /// 全マスを踏破すると `isCleared` が true になるか
     func testBoardClear() {
-        var board = Board()
+        let boardSize = 5
+        var board = Board(size: boardSize)
         // 盤面全ての座標を順番に踏破済みにする
-        for x in GridPoint.range {
-            for y in GridPoint.range {
+        for x in 0..<boardSize {
+            for y in 0..<boardSize {
                 board.markVisited(GridPoint(x: x, y: y))
             }
         }
@@ -18,7 +19,9 @@ final class BoardClearTests: XCTestCase {
 
     /// 途中まで踏破した場合に false となるか
     func testBoardNotClear() {
-        let board = Board()
+        let boardSize = 5
+        let center = GridPoint.center(of: boardSize)
+        let board = Board(size: boardSize, initialVisitedPoints: [center])
         // 中央以外は踏破していないため false のはず
         XCTAssertFalse(board.isCleared)
     }

--- a/Tests/GameTests/BoardMovementTests.swift
+++ b/Tests/GameTests/BoardMovementTests.swift
@@ -5,18 +5,20 @@ import XCTest
 final class BoardMovementTests: XCTestCase {
     /// 中央から盤外へ出る移動が正しく検出されるか
     func testOutOfBoundsMove() {
-        let origin = GridPoint.center
+        let boardSize = 5
+        let origin = GridPoint.center(of: boardSize)
         // 盤の外へ 3 マス右に移動
         let outside = origin.offset(dx: 3, dy: 0)
         // 範囲外なので `isInside` は false になるべき
-        XCTAssertFalse(outside.isInside)
+        XCTAssertFalse(outside.isInside(boardSize: boardSize))
     }
 
     /// 盤内の移動が有効と判定されるか
     func testInsideMove() {
-        let origin = GridPoint.center
+        let boardSize = 5
+        let origin = GridPoint.center(of: boardSize)
         // 1 マス右は盤内
         let inside = origin.offset(dx: 1, dy: 0)
-        XCTAssertTrue(inside.isInside)
+        XCTAssertTrue(inside.isInside(boardSize: boardSize))
     }
 }

--- a/Tests/GameTests/DeckTests.swift
+++ b/Tests/GameTests/DeckTests.swift
@@ -72,6 +72,19 @@ final class DeckTests: XCTestCase {
         XCTAssertTrue(kingMoves.isSubset(of: allCasesSet))
     }
 
+    /// クラシカルチャレンジ設定では桂馬カードのみが配られるか検証する
+    func testClassicalChallengeDeckDrawsOnlyKnightMoves() {
+        var deck = Deck(seed: 2024, configuration: .classicalChallenge)
+        let sampleCount = 200
+        for _ in 0..<sampleCount {
+            guard let card = deck.draw()?.move else {
+                XCTFail("クラシカルチャレンジのデッキで nil が返却されました")
+                return
+            }
+            XCTAssertTrue(card.isKnightType, "桂馬以外のカードが出現: \(card)")
+        }
+    }
+
     /// makeTestDeck で指定した配列が優先的に返され、reset() で再利用できるか確認
     func testMakeTestDeckUsesPresetSequence() {
         let preset: [MoveCard] = [

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Game
 
 /// ゲーム画面と設定画面を切り替えるルートビュー
 /// `TabView` を用いて 2 つのタブを提供する
@@ -17,6 +18,18 @@ struct RootView: View {
     /// - NOTE: アプリ起動直後にタイトルを先に表示したいので初期値は `true`
     ///         メニューからタイトルへ戻る操作でもこのフラグを再度 `true` に切り替える
     @State private var isShowingTitleScreen: Bool = true
+    /// 実際にゲームへ適用しているモード
+    @State private var activeMode: GameMode = .standard
+    /// タイトル画面で選択中のモード（開始ボタン押下で activeMode に反映する）
+    @State private var selectedModeForTitle: GameMode = .standard
+    /// GameView の再生成に利用するセッション ID（モードが変わるたびに更新する）
+    @State private var gameSessionID = UUID()
+    /// 実際に GameView へ渡しているモード
+    @State private var activeMode: GameMode = .standard
+    /// タイトル画面で選択中のモード（開始ボタン押下で activeMode に反映する）
+    @State private var selectedModeForTitle: GameMode = .standard
+    /// GameView の再生成を強制するための識別子（モード変更時に更新）
+    @State private var gameSessionID = UUID()
 
     /// 依存サービスを外部から注入可能にする初期化処理
     /// - Parameters:
@@ -70,23 +83,29 @@ struct RootView: View {
                 ZStack {
                     // MARK: - メインのゲーム画面
                     GameView(
+                        mode: activeMode,
                         gameCenterService: gameCenterService,
                         adsService: adsService,
                         onRequestReturnToTitle: {
                             // メニューからの通知でタイトル画面を表示
                             withAnimation(.easeInOut(duration: 0.25)) {
                                 isShowingTitleScreen = true
+                                // タイトルに戻った際は選択中のモードを現在のプレイ内容で初期化する
+                                selectedModeForTitle = activeMode
                             }
                         }
                     )
+                    .id(gameSessionID)
                     .opacity(isShowingTitleScreen ? 0 : 1)
                     .allowsHitTesting(!isShowingTitleScreen)
 
                     // MARK: - タイトル画面のオーバーレイ
                     if isShowingTitleScreen {
-                        TitleScreenView {
+                        TitleScreenView(selectedMode: $selectedModeForTitle) { mode in
                             // タイトルからゲーム開始を選んだら元に戻す
                             withAnimation(.easeInOut(duration: 0.25)) {
+                                activeMode = mode
+                                gameSessionID = UUID()
                                 isShowingTitleScreen = false
                             }
                         }
@@ -119,8 +138,10 @@ struct RootView: View {
 // MARK: - タイトル画面（簡易版）
 // fileprivate にすることで同ファイル内の RootView から初期化可能にする
 fileprivate struct TitleScreenView: View {
+    /// タイトル画面で選択中のモード
+    @Binding var selectedMode: GameMode
     /// ゲーム開始ボタンが押された際の処理
-    let onStart: () -> Void
+    let onStart: (GameMode) -> Void
 
     /// カラーテーマを用いてライト/ダーク両対応の配色を提供する
     private var theme = AppTheme()
@@ -130,8 +151,11 @@ fileprivate struct TitleScreenView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     /// `@State` プロパティを保持したまま、外部（同ファイル内の RootView）から初期化できるようにするカスタムイニシャライザ
-    /// - Parameter onStart: ゲーム開始ボタンが押下された際に呼び出されるクロージャ
-    init(onStart: @escaping () -> Void) {
+    /// - Parameters:
+    ///   - selectedMode: 選択中モードを共有するバインディング
+    ///   - onStart: ゲーム開始ボタンが押下された際に呼び出されるクロージャ
+    init(selectedMode: Binding<GameMode>, onStart: @escaping (GameMode) -> Void) {
+        self._selectedMode = selectedMode
         // `let` プロパティである onStart を代入するための明示的な初期化処理
         self.onStart = onStart
         // `@State` の初期値を明示しておくことで、将来的な初期値変更にも対応しやすくする
@@ -158,9 +182,12 @@ fileprivate struct TitleScreenView: View {
                     .frame(maxWidth: 320)
             }
 
+            // MARK: - モード選択セクション
+            modeSelectionSection
+
             // MARK: - ゲーム開始ボタン
-            Button(action: onStart) {
-                Label("ゲームを開始", systemImage: "play.fill")
+            Button(action: { onStart(selectedMode) }) {
+                Label("\(selectedMode.displayName)で開始", systemImage: "play.fill")
                     .font(.system(size: 18, weight: .semibold, design: .rounded))
                     .frame(maxWidth: .infinity)
             }
@@ -170,6 +197,10 @@ fileprivate struct TitleScreenView: View {
             .foregroundColor(theme.accentOnPrimary)
             .controlSize(.large)
             .accessibilityIdentifier("title_start_button")
+
+            Text("手札 \(selectedMode.handSize) 枚 / 先読み \(selectedMode.nextPreviewCount) 枚")
+                .font(.system(size: 13, weight: .medium, design: .rounded))
+                .foregroundColor(theme.textSecondary)
 
             // MARK: - 遊び方シートを開くボタン
             Button {
@@ -208,6 +239,88 @@ fileprivate struct TitleScreenView: View {
             )
             .presentationDragIndicator(.visible)
         }
+    }
+
+    /// モード選択の一覧を描画するセクション
+    private var modeSelectionSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("ゲームモード")
+                .font(.system(size: 18, weight: .semibold, design: .rounded))
+                .foregroundColor(theme.textPrimary)
+
+            ForEach(GameMode.allModes) { mode in
+                modeSelectionButton(for: mode)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// モードを選択するためのボタンレイアウト
+    /// - Parameter mode: 表示対象のゲームモード
+    private func modeSelectionButton(for mode: GameMode) -> some View {
+        let isSelected = mode == selectedMode
+
+        return Button {
+            selectedMode = mode
+        } label: {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text(mode.displayName)
+                        .font(.system(size: 17, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.textPrimary)
+                    Spacer(minLength: 0)
+                    if isSelected {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(theme.accentPrimary)
+                            .font(.system(size: 18, weight: .bold))
+                    }
+                }
+                Text(primaryDescription(for: mode))
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundColor(theme.textSecondary)
+                Text(secondaryDescription(for: mode))
+                    .font(.system(size: 12, weight: .regular, design: .rounded))
+                    .foregroundColor(theme.textSecondary.opacity(0.85))
+            }
+            .padding(.vertical, 14)
+            .padding(.horizontal, 16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(theme.backgroundElevated.opacity(isSelected ? 0.95 : 0.75))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .stroke(isSelected ? theme.accentPrimary : theme.statisticBadgeBorder, lineWidth: isSelected ? 2 : 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("\(mode.displayName): \(primaryDescription(for: mode))"))
+        .accessibilityHint(Text(secondaryDescription(for: mode)))
+    }
+
+    /// 各モードの主要な特徴を短文で返す
+    private func primaryDescription(for mode: GameMode) -> String {
+        let spawnText = mode.requiresSpawnSelection ? "任意スポーン" : "固定スポーン"
+        switch mode.identifier {
+        case .standard5x5:
+            return "\(mode.boardSize)×\(mode.boardSize) ・ \(spawnText) ・ 標準デッキ"
+        case .classicalChallenge:
+            return "\(mode.boardSize)×\(mode.boardSize) ・ \(spawnText) ・ 桂馬カードのみ"
+        }
+    }
+
+    /// ペナルティ量などの補足情報を返す
+    private func secondaryDescription(for mode: GameMode) -> String {
+        let manualPenalty = "引き直し +\(mode.manualRedrawPenaltyCost)"
+        let revisitText: String
+        if mode.revisitPenaltyCost > 0 {
+            revisitText = "再訪 +\(mode.revisitPenaltyCost)"
+        } else {
+            revisitText = "再訪ペナルティなし"
+        }
+        return "手札 \(mode.handSize) / 先読み \(mode.nextPreviewCount) / \(manualPenalty) / \(revisitText)"
     }
 }
 

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -280,6 +280,38 @@ struct AppTheme: DynamicProperty {
         }
     }
 
+    // MARK: - スポーン選択オーバーレイ
+
+    /// スポーン案内の背景色。ライトモードでは白ベース、ダークモードでは黒ベースで適度に透過させる
+    var spawnOverlayBackground: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            return Color.black.opacity(0.82)
+        default:
+            return Color.white.opacity(0.92)
+        }
+    }
+
+    /// スポーン案内の枠線色。背景とのコントラストが強すぎないよう控えめな値に調整
+    var spawnOverlayBorder: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            return Color.white.opacity(0.25)
+        default:
+            return Color.black.opacity(0.15)
+        }
+    }
+
+    /// スポーン案内ボックスのドロップシャドウ色
+    var spawnOverlayShadow: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            return Color.black.opacity(0.7)
+        default:
+            return Color.black.opacity(0.25)
+        }
+    }
+
     // MARK: - ペナルティバナー／先読みオーバーレイ
 
     /// ペナルティバナーの背景色


### PR DESCRIPTION
## Summary
- add mode configuration struct so the core can reference classical challenge rules (board size, penalties, deck setup)
- update GameScene, GameView, and RootView to handle optional knight spawn, mode selection UI, and spawn guidance overlays
- refresh unit tests to adopt the new APIs and cover classical challenge behaviours (spawn, revisit penalty, manual redraw)

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d0f08d6138832c99fccf2a9cce47a9