### PR TITLE
Fix extra closing brace in GameView

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -1202,7 +1202,6 @@ private struct PenaltyBannerView: View {
         "\(primaryMessage)。\(secondaryMessage)"
     }
 }
-}
 
 // MARK: - 先読みカード専用のオーバーレイ
 /// 「NEXT」「NEXT+1」などのバッジを重ね、操作不可であることを視覚的に伝える補助ビュー


### PR DESCRIPTION
## Summary
- remove an unnecessary closing brace left after `PenaltyBannerView` to restore syntactic balance

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d10f5e48b0832c9463cb83a23acc58