### PR TITLE
Add hand order sorting option

### DIFF
--- a/Game/HandOrderMode.swift
+++ b/Game/HandOrderMode.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// 手札の並び順を制御するユーザー設定
+/// - Note: UI 側の Picker でも利用できるよう `public` に公開し、`CaseIterable` / `Identifiable` を実装する。
+public enum HandOrderMode: String, CaseIterable, Identifiable {
+    /// 山札から引いた順番をそのまま維持する（従来仕様）
+    case drawOrder
+    /// 移動方向に基づいて常にソートする新仕様
+    case directional
+
+    /// `CaseIterable` の順番を明示し、設定画面の表示順も固定する
+    public static let allCases: [HandOrderMode] = [.drawOrder, .directional]
+
+    /// `Identifiable` 準拠のための一意な識別子
+    public var id: String { rawValue }
+
+    /// 設定値を永続化する `@AppStorage` のキー名をまとめておく
+    public static let storageKey = "hand_order_mode"
+
+    /// UI に表示する説明ラベル
+    public var displayName: String {
+        switch self {
+        case .drawOrder:
+            return "引いた順のまま"
+        case .directional:
+            return "移動方向で自動整列"
+        }
+    }
+
+    /// 詳細な説明文を提供し、設定画面のフッターなどで再利用する
+    public var detailDescription: String {
+        switch self {
+        case .drawOrder:
+            return "手札は山札から引いた順番で左から並び、使用した枠に新しいカードが補充されます。"
+        case .directional:
+            return "左へ大きく移動できるカードほど手札の左側に並び、左右移動量が同じ場合は上方向へ進めるカードが優先されます。"
+        }
+    }
+}

--- a/Tests/GameTests/GameCoreTests.swift
+++ b/Tests/GameTests/GameCoreTests.swift
@@ -295,4 +295,38 @@ final class GameCoreTests: XCTestCase {
         XCTAssertEqual(core.totalMoveCount, 17, "合計手数の算出が期待値と異なる")
         XCTAssertEqual(core.score, 207, "ポイント計算が仕様と一致していない")
     }
+
+    /// 手札並べ替え設定の「移動方向で自動整列」が仕様通りにソートされるか検証
+    func testDirectionalHandOrderSortsByMovementPriority() {
+        let preset: [MoveCard] = [
+            // --- 初期手札 5 枚（意図的に左右・上下方向の組み合わせを混在させる）---
+            .kingRight,
+            .kingLeft,
+            .knightUp1Left2,
+            .knightDown1Left2,
+            .straightUp2,
+            // --- 先読み分のカード（テストの安定性のため余分に用意）---
+            .diagonalUpRight2,
+            .kingUp,
+            .straightLeft2
+        ]
+        let deck = Deck.makeTestDeck(cards: preset)
+        let core = GameCore.makeTestInstance(deck: deck)
+
+        // 既定モードではドロー順がそのまま保持されることを確認
+        let initialMoves = core.hand.map { $0.move }
+        XCTAssertEqual(initialMoves, Array(preset.prefix(core.mode.handSize)), "初期状態では引いた順番のまま並ぶべき")
+
+        // 移動方向優先モードへ切り替え、左方向が強いカードほど前方へ並ぶか検証
+        core.updateHandOrderMode(.directional)
+        let sortedMoves = core.hand.map { $0.move }
+        let expected: [MoveCard] = [
+            .knightUp1Left2,
+            .knightDown1Left2,
+            .kingLeft,
+            .straightUp2,
+            .kingRight
+        ]
+        XCTAssertEqual(sortedMoves, expected, "directional モードのソート順が仕様通りではありません")
+    }
 }

--- a/UI/SettingsView.swift
+++ b/UI/SettingsView.swift
@@ -1,3 +1,4 @@
+import Game
 import StoreKit
 import SwiftUI
 
@@ -29,6 +30,10 @@ struct SettingsView: View {
     // MARK: - ガイドモード設定
     // 盤面の移動候補ハイライトを保存し、GameView 側の @AppStorage と連動させる。
     @AppStorage("guide_mode_enabled") private var guideModeEnabled: Bool = true
+
+    // MARK: - 手札並び順設定
+    // 手札の並び方をユーザーが切り替えられるように、列挙体の RawValue を保存する。
+    @AppStorage(HandOrderMode.storageKey) private var handOrderModeRawValue: String = HandOrderMode.drawOrder.rawValue
 
     // MARK: - 戦績管理
     // ベストポイントを UserDefaults から取得・更新する。未設定時は Int.max で初期化しておく。
@@ -120,6 +125,27 @@ struct SettingsView: View {
                 } footer: {
                     // どのような効果があるかを具体的に説明し、不要ならオフにできると案内
                     Text("手札から移動できるマスを盤面上で光らせます。集中して考えたい場合はオフにできます。")
+                }
+
+                // 手札の並び順をユーザーが選べるようにするセクション
+                Section {
+                    Picker(
+                        "手札の並び順",
+                        selection: Binding<HandOrderMode>(
+                            get: { HandOrderMode(rawValue: handOrderModeRawValue) ?? .drawOrder },
+                            set: { newValue in handOrderModeRawValue = newValue.rawValue }
+                        )
+                    ) {
+                        ForEach(HandOrderMode.allCases) { mode in
+                            Text(mode.displayName)
+                                .tag(mode)
+                        }
+                    }
+                } header: {
+                    Text("手札の並べ替え")
+                } footer: {
+                    // 選択中のモードがどのように並ぶかを説明して、ユーザーが挙動を想像しやすくする
+                    Text((HandOrderMode(rawValue: handOrderModeRawValue) ?? .drawOrder).detailDescription)
                 }
 
                 // MARK: - 広告除去 IAP セクション


### PR DESCRIPTION
## Summary
- add a public HandOrderMode enum and expose storage key and labels for UI
- update GameCore/GameView to honor the new hand ordering preference
- surface the option in SettingsView and add unit coverage for directional sorting

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d1366d4fe4832c80f445ae8a84c786