### PR TITLE
Add configurable hand ordering strategy option

### DIFF
--- a/Game/HandOrderingStrategy.swift
+++ b/Game/HandOrderingStrategy.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// 手札カードの並び替え方法を管理するユーザー設定用の列挙体
+/// - Note: UI とゲームロジックの両方で利用するため `public` として公開する
+public enum HandOrderingStrategy: String, CaseIterable {
+    /// 山札から引いた順番をそのまま維持する従来方式
+    case insertionOrder
+    /// 移動方向の系統に基づいて常にソートする新方式
+    case directionSorted
+
+    /// UserDefaults / @AppStorage で共有するためのキー文字列
+    public static let storageKey = "hand_ordering_strategy"
+
+    /// 設定画面に表示する日本語名称
+    public var displayName: String {
+        switch self {
+        case .insertionOrder:
+            return "引いた順に並べる"
+        case .directionSorted:
+            return "移動方向で並べ替える"
+        }
+    }
+
+    /// 説明文を返し、設定フッターなどで再利用できるようにする
+    public var detailDescription: String {
+        switch self {
+        case .insertionOrder:
+            return "山札から引いた順番で手札スロットへ補充します。消費した位置へ新しいカードが入ります。"
+        case .directionSorted:
+            return "左への移動量が大きいカードほど左側に、同じ左右移動量なら上方向へ進むカードを優先して並べます。"
+        }
+    }
+}
+

--- a/Tests/GameTests/GameCoreTests.swift
+++ b/Tests/GameTests/GameCoreTests.swift
@@ -286,6 +286,68 @@ final class GameCoreTests: XCTestCase {
         XCTAssertEqual(core.progress, .playing)
     }
 
+    /// 手札の方向ソート設定が期待通りの順序へ並べ替えられるか検証
+    func testHandOrderingDirectionSortReordersHand() {
+        let deck = Deck.makeTestDeck(cards: [
+            .kingRight,
+            .diagonalUpLeft2,
+            .straightLeft2,
+            .kingUp,
+            .diagonalDownLeft2,
+            .kingLeft,
+            .straightUp2,
+            .kingDown,
+            .kingUpRight
+        ])
+        let core = GameCore.makeTestInstance(deck: deck)
+
+        // 方向ソートへ切り替えて順序が調整されるか確認
+        core.updateHandOrderingStrategy(.directionSorted)
+
+        let expected: [MoveCard] = [
+            .diagonalUpLeft2,
+            .straightLeft2,
+            .diagonalDownLeft2,
+            .kingUp,
+            .kingRight
+        ]
+        XCTAssertEqual(core.hand.map(\.move), expected, "方向ソート設定で手札が期待通りに並んでいない")
+    }
+
+    /// 方向ソート設定でカードを使用した後も新しい手札が正しい順序に保たれるか検証
+    func testHandOrderingDirectionSortAfterDraw() {
+        let deck = Deck.makeTestDeck(cards: [
+            .kingRight,
+            .diagonalUpLeft2,
+            .straightLeft2,
+            .kingUp,
+            .diagonalDownLeft2,
+            .kingLeft,
+            .straightUp2,
+            .kingDown,
+            .kingUpRight
+        ])
+        let core = GameCore.makeTestInstance(deck: deck)
+
+        core.updateHandOrderingStrategy(.directionSorted)
+
+        guard let playIndex = core.hand.firstIndex(where: { $0.move == .kingRight }) else {
+            XCTFail("想定したカードが手札に存在しません")
+            return
+        }
+
+        core.playCard(at: playIndex)
+
+        let expected: [MoveCard] = [
+            .diagonalUpLeft2,
+            .straightLeft2,
+            .diagonalDownLeft2,
+            .kingLeft,
+            .kingUp
+        ]
+        XCTAssertEqual(core.hand.map(\.move), expected, "カード使用後の方向ソート結果が期待と異なります")
+    }
+
     /// スコア計算が「手数×10 + 経過秒数」で行われることを確認
     func testScoreCalculationUsesPointsFormula() {
         let core = GameCore()

--- a/UI/SettingsView.swift
+++ b/UI/SettingsView.swift
@@ -1,3 +1,4 @@
+import Game  // 手札並び順の設定列挙体を利用するために追加
 import StoreKit
 import SwiftUI
 
@@ -29,6 +30,10 @@ struct SettingsView: View {
     // MARK: - ガイドモード設定
     // 盤面の移動候補ハイライトを保存し、GameView 側の @AppStorage と連動させる。
     @AppStorage("guide_mode_enabled") private var guideModeEnabled: Bool = true
+
+    // MARK: - 手札並び設定
+    // 手札の並び替え方式を永続化し、GameView 側の @AppStorage と同期させる。
+    @AppStorage(HandOrderingStrategy.storageKey) private var handOrderingRawValue: String = HandOrderingStrategy.insertionOrder.rawValue
 
     // MARK: - 戦績管理
     // ベストポイントを UserDefaults から取得・更新する。未設定時は Int.max で初期化しておく。
@@ -120,6 +125,26 @@ struct SettingsView: View {
                 } footer: {
                     // どのような効果があるかを具体的に説明し、不要ならオフにできると案内
                     Text("手札から移動できるマスを盤面上で光らせます。集中して考えたい場合はオフにできます。")
+                }
+
+                // 手札の並び順を切り替える設定セクション
+                Section {
+                    Picker("手札の並び順", selection: Binding<HandOrderingStrategy>(
+                        get: { HandOrderingStrategy(rawValue: handOrderingRawValue) ?? .insertionOrder },
+                        set: { handOrderingRawValue = $0.rawValue }
+                    )) {
+                        ForEach(HandOrderingStrategy.allCases, id: \.self) { strategy in
+                            Text(strategy.displayName)
+                                .tag(strategy)
+                        }
+                    }
+                } header: {
+                    Text("手札の並び")
+                } footer: {
+                    // 並び替えロジックの違いを具体的に示し、意図した使い分けができるよう説明する
+                    Text("""
+手札を引いた順番のまま維持するか、移動方向に応じて自動整列するかを選べます。方向ソートでは左への移動量が大きいカードが左側に、同じ左右移動量なら上方向のカードが優先されます。
+""")
                 }
 
                 // MARK: - 広告除去 IAP セクション


### PR DESCRIPTION
## Summary
- add a shared `HandOrderingStrategy` enum to control whether hands keep draw order or direction-based sorting, and update `GameCore` to reorder cards when needed
- surface the hand ordering preference in `SettingsView` and apply it in `GameView` so user changes immediately adjust the in-game hand layout
- cover the new sorting mode with focused `GameCore` tests to ensure initial distribution and post-draw behavior follow the expected order

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d138bd3928832cb82392acf7f79afc