### PR TITLE
Fix argument label when applying GameView observers

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -127,7 +127,7 @@ struct GameView: View {
     }
 
     var body: some View {
-        applyGameViewObservers(
+        applyGameViewObservers(to:
             GeometryReader { geometry in
                 // 専用メソッドへ委譲し、レイアウト計算と描画処理の責務を明示的に分離する
                 mainContent(for: geometry)


### PR DESCRIPTION
## 概要
- `applyGameViewObservers` 呼び出し時に不足していた引数ラベル `to:` を付与し、ビルドエラーを解消

## テスト
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68d148237840832cb36c45348edb23ab