### PR TITLE
Add explicit initializer for GameMenuActionConfirmationSheet

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -1396,6 +1396,22 @@ struct GameMenuActionConfirmationSheet: View {
     /// キャンセル時に状態をリセットするクロージャ
     let onCancel: () -> Void
 
+    /// 明示的なイニシャライザを用意し、`GameMenuAction` が `private` スコープでも呼び出せるようにする
+    /// - Parameters:
+    ///   - action: 確認対象のメニューアクション
+    ///   - onConfirm: 決定時に呼び出すクロージャ
+    ///   - onCancel: キャンセル時に呼び出すクロージャ
+    fileprivate init(
+        action: GameMenuAction,
+        onConfirm: @escaping (GameMenuAction) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        // メンバーごとに代入し、従来通りの挙動を維持する
+        self.action = action
+        self.onConfirm = onConfirm
+        self.onCancel = onCancel
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 32) {
             // MARK: - 見出しと詳細説明


### PR DESCRIPTION
## Summary
- GameMenuActionConfirmationSheet に明示的なイニシャライザを追加し、private 型でも呼び出せるように修正
- 既存のプロパティへ代入するのみで挙動が変わらないことをコメントで補足

## Testing
- Not run (iOS 向けコードのため Linux 環境でビルド不可)


------
https://chatgpt.com/codex/tasks/task_e_68d14a7d7cfc832cabca91b141b83ec7