### PR TITLE
Fix access level for GameMenuActionConfirmationSheet

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -1386,7 +1386,9 @@ private extension GameView {
 
 // MARK: - レギュラー幅向けのメニュー確認シート
 /// iPad で確認文をゆったり表示するためのシートビュー
-struct GameMenuActionConfirmationSheet: View {
+// MARK: - ファイル内限定で利用する確認用シート
+/// `GameMenuAction` が fileprivate な型のため、このシートも fileprivate としておく
+fileprivate struct GameMenuActionConfirmationSheet: View {
     /// 共通配色を参照して背景色などを統一する
     private var theme = AppTheme()
     /// 現在確認中のアクション


### PR DESCRIPTION
## Summary
- mark GameMenuActionConfirmationSheet as fileprivate to align with its private enum usage
- document the rationale with a Japanese comment per repository guidelines

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d14a84240c832c8643313bca12e62a