### PR TITLE
Refactor game mode setup for easier regulation additions

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -21,6 +21,35 @@ struct Deck {
         let reducedWeightMultiplier: Int
         /// 抑制状態を維持するターン数
         let reductionDuration: Int
+        /// UI やモード説明で利用する山札の要約テキスト
+        let deckSummaryText: String
+
+        /// メンバーごとに初期化できるよう明示的なイニシャライザを用意
+        /// - Parameters:
+        ///   - allowedMoves: 抽選対象とするカード配列
+        ///   - baseWeights: 各カードの基礎重み辞書
+        ///   - shouldApplyProbabilityReduction: 連続排出抑制の有無
+        ///   - normalWeightMultiplier: 通常時に掛ける重み倍率
+        ///   - reducedWeightMultiplier: 抑制時に掛ける重み倍率
+        ///   - reductionDuration: 抑制効果を持続させるターン数
+        ///   - deckSummaryText: UI 表示用の簡易説明
+        init(
+            allowedMoves: [MoveCard],
+            baseWeights: [MoveCard: Int],
+            shouldApplyProbabilityReduction: Bool,
+            normalWeightMultiplier: Int,
+            reducedWeightMultiplier: Int,
+            reductionDuration: Int,
+            deckSummaryText: String
+        ) {
+            self.allowedMoves = allowedMoves
+            self.baseWeights = baseWeights
+            self.shouldApplyProbabilityReduction = shouldApplyProbabilityReduction
+            self.normalWeightMultiplier = normalWeightMultiplier
+            self.reducedWeightMultiplier = reducedWeightMultiplier
+            self.reductionDuration = reductionDuration
+            self.deckSummaryText = deckSummaryText
+        }
 
         /// スタンダードモード向け設定
         static let standard: Configuration = {
@@ -47,7 +76,8 @@ struct Deck {
                 shouldApplyProbabilityReduction: true,
                 normalWeightMultiplier: 4,
                 reducedWeightMultiplier: 3,
-                reductionDuration: 5
+                reductionDuration: 5,
+                deckSummaryText: "標準デッキ"
             )
         }()
 
@@ -61,7 +91,8 @@ struct Deck {
                 shouldApplyProbabilityReduction: false,
                 normalWeightMultiplier: 1,
                 reducedWeightMultiplier: 1,
-                reductionDuration: 0
+                reductionDuration: 0,
+                deckSummaryText: "桂馬カードのみ"
             )
         }()
     }

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -16,6 +16,17 @@ public struct GameMode: Equatable, Identifiable {
         /// プレイヤーが任意のマスを選択してスポーン
         case chooseAnyAfterPreview
 
+        /// UI 表示用にルールの説明テキストを返す
+        /// - Note: モード追加時に文字列を個別で管理しなくても済むよう、ここで共通化しておく
+        public var summaryText: String {
+            switch self {
+            case .fixed:
+                return "固定スポーン"
+            case .chooseAnyAfterPreview:
+                return "任意スポーン"
+            }
+        }
+
         /// Equatable のカスタム実装
         /// - Note: 固定座標スポーンは座標の一致を厳密に比較し、自由選択スポーンは同一ケースであれば常に等価とみなす。
         public static func == (lhs: SpawnRule, rhs: SpawnRule) -> Bool {
@@ -33,29 +44,137 @@ public struct GameMode: Equatable, Identifiable {
         }
     }
 
+    /// ペナルティ関連のルールをまとめた設定構造体
+    struct PenaltySettings {
+        /// 手詰まり自動検出による引き直し時の加算手数
+        let deadlockPenaltyCost: Int
+        /// プレイヤーが任意に引き直しを行った際の加算手数
+        let manualRedrawPenaltyCost: Int
+        /// 既踏マスに再訪した際の加算手数
+        let revisitPenaltyCost: Int
+
+        /// メンバーごとに設定できるように明示的なイニシャライザを用意
+        /// - Parameters:
+        ///   - deadlockPenaltyCost: 自動ペナルティで加算する手数
+        ///   - manualRedrawPenaltyCost: 手動ペナルティで加算する手数
+        ///   - revisitPenaltyCost: 再訪時のペナルティ手数
+        init(
+            deadlockPenaltyCost: Int,
+            manualRedrawPenaltyCost: Int,
+            revisitPenaltyCost: Int
+        ) {
+            self.deadlockPenaltyCost = deadlockPenaltyCost
+            self.manualRedrawPenaltyCost = manualRedrawPenaltyCost
+            self.revisitPenaltyCost = revisitPenaltyCost
+        }
+    }
+
+    /// ゲームモードの根幹となるレギュレーション設定
+    /// - Note: 盤面サイズや山札構成、手札枚数などを一括で扱い、新しいモードを追加しやすくする。
+    struct Regulation {
+        /// 盤面サイズ（N×N）
+        let boardSize: Int
+        /// 初期手札枚数
+        let handSize: Int
+        /// 先読み表示枚数
+        let nextPreviewCount: Int
+        /// 適用する山札構成
+        let deckConfiguration: Deck.Configuration
+        /// 初期スポーンの扱い
+        let spawnRule: SpawnRule
+        /// ペナルティ設定一式
+        let penalties: PenaltySettings
+
+        /// レギュレーションを組み立てるためのイニシャライザ
+        /// - Parameters:
+        ///   - boardSize: 盤面サイズ
+        ///   - handSize: 手札枚数
+        ///   - nextPreviewCount: 先読み表示枚数
+        ///   - deckConfiguration: 使用する山札設定
+        ///   - spawnRule: 初期スポーンルール
+        ///   - penalties: ペナルティ設定
+        init(
+            boardSize: Int,
+            handSize: Int,
+            nextPreviewCount: Int,
+            deckConfiguration: Deck.Configuration,
+            spawnRule: SpawnRule,
+            penalties: PenaltySettings
+        ) {
+            self.boardSize = boardSize
+            self.handSize = handSize
+            self.nextPreviewCount = nextPreviewCount
+            self.deckConfiguration = deckConfiguration
+            self.spawnRule = spawnRule
+            self.penalties = penalties
+        }
+    }
+
     /// 一意な識別子
     public let identifier: Identifier
     /// 表示名（タイトル画面などで利用）
     public let displayName: String
-    /// 盤面サイズ（N×N）
-    public let boardSize: Int
-    /// 初期手札枚数
-    public let handSize: Int
-    /// 先読み表示枚数
-    public let nextPreviewCount: Int
-    /// 山札構成設定（ゲームモジュール内部で使用）
-    let deckConfiguration: Deck.Configuration
-    /// スポーンルール
-    public let spawnRule: SpawnRule
-    /// 自動ペナルティ（手詰まり引き直し）で加算する手数
-    public let deadlockPenaltyCost: Int
-    /// 手動ペナルティで加算する手数
-    public let manualRedrawPenaltyCost: Int
-    /// 既踏マスへ再訪した際に加算する手数
-    public let revisitPenaltyCost: Int
+    /// レギュレーション設定一式
+    private let regulation: Regulation
 
     /// `Identifiable` 準拠用
     public var id: Identifier { identifier }
+
+    /// メンバーをまとめて設定するためのプライベートイニシャライザ
+    /// - Parameters:
+    ///   - identifier: モードを識別するための ID
+    ///   - displayName: UI で表示する名称
+    ///   - regulation: 盤面やペナルティを含むレギュレーション設定
+    init(identifier: Identifier, displayName: String, regulation: Regulation) {
+        self.identifier = identifier
+        self.displayName = displayName
+        self.regulation = regulation
+    }
+
+    /// 盤面サイズ（N×N）
+    public var boardSize: Int { regulation.boardSize }
+    /// 初期手札枚数
+    public var handSize: Int { regulation.handSize }
+    /// 先読み表示枚数
+    public var nextPreviewCount: Int { regulation.nextPreviewCount }
+    /// スポーンルール
+    public var spawnRule: SpawnRule { regulation.spawnRule }
+    /// ペナルティ設定一式
+    var penalties: PenaltySettings { regulation.penalties }
+    /// 自動ペナルティ（手詰まり引き直し）で加算する手数
+    public var deadlockPenaltyCost: Int { penalties.deadlockPenaltyCost }
+    /// 手動ペナルティで加算する手数
+    public var manualRedrawPenaltyCost: Int { penalties.manualRedrawPenaltyCost }
+    /// 既踏マスへ再訪した際に加算する手数
+    public var revisitPenaltyCost: Int { penalties.revisitPenaltyCost }
+    /// 山札構成設定（ゲームモジュール内部で使用）
+    var deckConfiguration: Deck.Configuration { regulation.deckConfiguration }
+    /// UI で表示する山札の要約
+    public var deckSummaryText: String { regulation.deckConfiguration.deckSummaryText }
+    /// 手札と先読み枚数をまとめた説明文
+    public var handSummaryText: String {
+        "手札 \(handSize) / 先読み \(nextPreviewCount)"
+    }
+    /// 手動ペナルティの説明文
+    public var manualPenaltySummaryText: String {
+        "引き直し +\(manualRedrawPenaltyCost)"
+    }
+    /// 再訪ペナルティの説明文
+    public var revisitPenaltySummaryText: String {
+        if revisitPenaltyCost > 0 {
+            return "再訪 +\(revisitPenaltyCost)"
+        } else {
+            return "再訪ペナルティなし"
+        }
+    }
+    /// 盤面サイズ・スポーン・山札をまとめた要約文
+    public var primarySummaryText: String {
+        "\(boardSize)×\(boardSize) ・ \(spawnRule.summaryText) ・ \(deckSummaryText)"
+    }
+    /// 手札・先読み・ペナルティ情報をまとめた詳細文
+    public var secondarySummaryText: String {
+        "\(handSummaryText) / \(manualPenaltySummaryText) / \(revisitPenaltySummaryText)"
+    }
 
     /// スポーン選択が必要かどうか
     public var requiresSpawnSelection: Bool {
@@ -83,54 +202,81 @@ public struct GameMode: Equatable, Identifiable {
         }
     }
 
+    /// モード識別子と定義を結び付けたレジストリ
+    /// - Note: 新しいモードを追加する際は `buildXXXMode()` を増やし、この配列にまとめて登録するだけで良い。
+    private static let registry: [Identifier: GameMode] = {
+        let modes: [GameMode] = [
+            buildStandardMode(),
+            buildClassicalChallengeMode()
+        ]
+        return Dictionary(uniqueKeysWithValues: modes.map { ($0.identifier, $0) })
+    }()
+
     /// スタンダードモード（既存仕様）
-    public static let standard: GameMode = GameMode(
-        identifier: .standard5x5,
-        displayName: "スタンダード",
-        boardSize: 5,
-        handSize: 5,
-        nextPreviewCount: 3,
-        deckConfiguration: .standard,
-        spawnRule: .fixed(GridPoint.center(of: 5)),
-        deadlockPenaltyCost: 5,
-        manualRedrawPenaltyCost: 5,
-        revisitPenaltyCost: 0
-    )
+    public static let standard: GameMode = {
+        guard let mode = registry[.standard5x5] else {
+            fatalError("標準モードのレジストリ登録に失敗しました")
+        }
+        return mode
+    }()
 
     /// クラシカルチャレンジモード
-    public static let classicalChallenge: GameMode = GameMode(
-        identifier: .classicalChallenge,
-        displayName: "クラシカルチャレンジ",
-        boardSize: 8,
-        handSize: 5,
-        nextPreviewCount: 3,
-        deckConfiguration: .classicalChallenge,
-        spawnRule: .chooseAnyAfterPreview,
-        deadlockPenaltyCost: 2,
-        manualRedrawPenaltyCost: 2,
-        revisitPenaltyCost: 1
-    )
+    public static let classicalChallenge: GameMode = {
+        guard let mode = registry[.classicalChallenge] else {
+            fatalError("クラシカルチャレンジのレジストリ登録に失敗しました")
+        }
+        return mode
+    }()
 
     /// 利用可能な全モードを列挙した配列
     /// - Note: タイトル画面のモード選択など UI 側で繰り返し利用するため、順序付きの一覧を提供する
-    public static let allModes: [GameMode] = Identifier.allCases.map { identifier in
-        mode(for: identifier)
+    public static let allModes: [GameMode] = Identifier.allCases.compactMap { identifier in
+        registry[identifier]
     }
 
     /// 識別子から対応するモード定義を取り出すヘルパー
     /// - Parameter identifier: 利用したいモードの識別子
     /// - Returns: `identifier` に対応する `GameMode`
     public static func mode(for identifier: Identifier) -> GameMode {
-        switch identifier {
-        case .standard5x5:
-            return .standard
-        case .classicalChallenge:
-            return .classicalChallenge
-        }
+        registry[identifier] ?? standard
     }
 
     /// Equatable 準拠。識別子が一致すれば同一モードとみなす
     public static func == (lhs: GameMode, rhs: GameMode) -> Bool {
         lhs.identifier == rhs.identifier
+    }
+
+    /// スタンダードモードの定義を生成する
+    private static func buildStandardMode() -> GameMode {
+        let regulation = Regulation(
+            boardSize: 5,
+            handSize: 5,
+            nextPreviewCount: 3,
+            deckConfiguration: .standard,
+            spawnRule: .fixed(GridPoint.center(of: 5)),
+            penalties: PenaltySettings(
+                deadlockPenaltyCost: 5,
+                manualRedrawPenaltyCost: 5,
+                revisitPenaltyCost: 0
+            )
+        )
+        return GameMode(identifier: .standard5x5, displayName: "スタンダード", regulation: regulation)
+    }
+
+    /// クラシカルチャレンジモードの定義を生成する
+    private static func buildClassicalChallengeMode() -> GameMode {
+        let regulation = Regulation(
+            boardSize: 8,
+            handSize: 5,
+            nextPreviewCount: 3,
+            deckConfiguration: .classicalChallenge,
+            spawnRule: .chooseAnyAfterPreview,
+            penalties: PenaltySettings(
+                deadlockPenaltyCost: 2,
+                manualRedrawPenaltyCost: 2,
+                revisitPenaltyCost: 1
+            )
+        )
+        return GameMode(identifier: .classicalChallenge, displayName: "クラシカルチャレンジ", regulation: regulation)
     }
 }

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -576,25 +576,14 @@ fileprivate struct TitleScreenView: View {
 
     /// 各モードの主要な特徴を短文で返す
     private func primaryDescription(for mode: GameMode) -> String {
-        let spawnText = mode.requiresSpawnSelection ? "任意スポーン" : "固定スポーン"
-        switch mode.identifier {
-        case .standard5x5:
-            return "\(mode.boardSize)×\(mode.boardSize) ・ \(spawnText) ・ 標準デッキ"
-        case .classicalChallenge:
-            return "\(mode.boardSize)×\(mode.boardSize) ・ \(spawnText) ・ 桂馬カードのみ"
-        }
+        // GameMode 側で共通ロジックを用意したため、ここでは単純に参照するだけで済む
+        return mode.primarySummaryText
     }
 
     /// ペナルティ量などの補足情報を返す
     private func secondaryDescription(for mode: GameMode) -> String {
-        let manualPenalty = "引き直し +\(mode.manualRedrawPenaltyCost)"
-        let revisitText: String
-        if mode.revisitPenaltyCost > 0 {
-            revisitText = "再訪 +\(mode.revisitPenaltyCost)"
-        } else {
-            revisitText = "再訪ペナルティなし"
-        }
-        return "手札 \(mode.handSize) / 先読み \(mode.nextPreviewCount) / \(manualPenalty) / \(revisitText)"
+        // 手札・先読み・ペナルティの表記も GameMode 側で統一管理する
+        return mode.secondarySummaryText
     }
 }
 


### PR DESCRIPTION
## Summary
- add descriptive metadata to deck configurations for reuse in mode summaries
- reorganize GameMode around a regulation/penalty struct with a registry so new modes only require a single definition
- update the title view to consume the new GameMode summary helpers instead of duplicating text logic

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d1b94cef28832c9222fb640a15a51c