### PR TITLE
手札スタック管理の導入

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -261,7 +261,7 @@ extension Deck {
 
     /// プリセットしたカード列を優先的に返すテスト用デッキを生成する
     /// - Parameters:
-    ///   - cards: 先頭から消費させたいカード列（手札5枚→先読み3枚の順で利用される想定）
+    ///   - cards: 先頭から消費させたいカード列（手札スロット数ぶんを消費した後に先読みキューへ回る想定）
     ///   - configuration: 検証対象の山札設定（省略時はスタンダード）
     /// - Returns: プリセットを持った `Deck`
     static func makeTestDeck(cards: [MoveCard], configuration: Configuration = .standard) -> Deck {

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -74,7 +74,7 @@ public struct GameMode: Equatable, Identifiable {
     struct Regulation {
         /// 盤面サイズ（N×N）
         let boardSize: Int
-        /// 初期手札枚数
+        /// 手札スロット数（同時に保持できるカード種類数）
         let handSize: Int
         /// 先読み表示枚数
         let nextPreviewCount: Int
@@ -133,7 +133,7 @@ public struct GameMode: Equatable, Identifiable {
 
     /// 盤面サイズ（N×N）
     public var boardSize: Int { regulation.boardSize }
-    /// 初期手札枚数
+    /// 手札スロット数（同時に保持できるカード種類数）
     public var handSize: Int { regulation.handSize }
     /// 先読み表示枚数
     public var nextPreviewCount: Int { regulation.nextPreviewCount }
@@ -153,7 +153,7 @@ public struct GameMode: Equatable, Identifiable {
     public var deckSummaryText: String { regulation.deckConfiguration.deckSummaryText }
     /// 手札と先読み枚数をまとめた説明文
     public var handSummaryText: String {
-        "手札 \(handSize) / 先読み \(nextPreviewCount)"
+        "手札 \(handSize) 種類 / 先読み \(nextPreviewCount) 枚"
     }
     /// 手動ペナルティの説明文
     public var manualPenaltySummaryText: String {

--- a/Game/HandStack.swift
+++ b/Game/HandStack.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// 同一種類の移動カードを束ね、手札スロット単位で管理するための構造体
+/// - Note: 1 つのスタックには必ず 1 種類のカードだけが含まれ、トップカードの差し替え時には新しい `DealtCard` を採番して UI のアニメーション整合性を保つ。
+public struct HandStack: Identifiable, Equatable {
+    /// スタック自体を識別するための UUID。スロット位置が入れ替わっても安定してトラッキングできるようにする。
+    public let id: UUID
+    /// スタックに含まれるカード一覧。常に同じ種類の `MoveCard` だけが格納される。
+    public private(set) var cards: [DealtCard]
+    /// スタック内で代表となる移動カード。`cards` 配列が空にならない限り常に同一の値が維持される。
+    private let representativeMove: MoveCard
+
+    /// スタックの先頭（= UI に表示される）カード。常に `cards` の末尾要素を参照する。
+    public var topCard: DealtCard {
+        guard let last = cards.last else {
+            // スタックが空になる状況は GameCore 側でスタック自体を除去するため想定外。早期に気付けるよう致命的エラーにする。
+            fatalError("HandStack.topCard が空スタックで参照されました")
+        }
+        return last
+    }
+
+    /// スタックに含まれるカード枚数。UI のバッジ表示やテスト検証で利用する。
+    public var count: Int { cards.count }
+
+    /// スタックが保持する移動カードの種類。`topCard.move` と常に一致する。
+    public var move: MoveCard { representativeMove }
+
+    /// 内部的にスタックが空かどうかを判定するヘルパー。GameCore 側の安全確認に利用する。
+    public var isEmpty: Bool { cards.isEmpty }
+
+    /// 初期化時にカード配列を受け取り、同一種類のみで構成されているか検証する。
+    /// - Parameter cards: スタックへ格納したい `DealtCard` 配列（少なくとも 1 枚必要）
+    public init(cards: [DealtCard]) {
+        precondition(!cards.isEmpty, "HandStack には最低 1 枚のカードが必要です")
+        guard let firstMove = cards.first?.move else {
+            fatalError("HandStack 初期化時にカード種別を取得できませんでした")
+        }
+        precondition(cards.allSatisfy { $0.move == firstMove }, "HandStack には同一種類のカードのみ格納できます")
+        self.id = UUID()
+        self.cards = cards
+        self.representativeMove = firstMove
+    }
+
+    /// 既存スタックへ同種類のカードを追加する。
+    /// - Parameter card: 追加したい `DealtCard`。`representativeMove` と一致している必要がある。
+    public mutating func append(_ card: DealtCard) {
+        precondition(card.move == representativeMove, "HandStack へ異なる種類のカードは追加できません")
+        cards.append(card)
+    }
+
+    /// スタック先頭のカードを 1 枚取り除き、残りがある場合はトップ用に新しい `DealtCard` を採番する。
+    /// - Returns: 取り除いた `DealtCard`
+    @discardableResult
+    public mutating func removeTopCard() -> DealtCard {
+        let removed = cards.removeLast()
+        regenerateTopCardIdentityIfNeeded()
+        return removed
+    }
+
+    /// トップカードを新しい ID で再生成し、SwiftUI のアニメーション整合性を確保する。
+    private mutating func regenerateTopCardIdentityIfNeeded() {
+        guard !cards.isEmpty else { return }
+        cards[cards.count - 1] = DealtCard(move: representativeMove)
+    }
+}


### PR DESCRIPTION
## 概要
- 新しい HandStack 構造体を追加して手札を種類単位で管理
- GameCore をスタック対応に刷新し、盤面タップ要求や補充ロジックを更新
- GameView をスタック前提に対応させ、重複枚数バッジやアクセシビリティ文言を調整
- 手札スロット表記・テストコードをスタック仕様へ更新

## テスト
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d1e075b94c832c89dc27ecce5bd3c0