### PR TITLE
Add stacked hand presentation in GameView

### DIFF
--- a/MonoKnightAppUITests/MonoKnightAppUITests.swift
+++ b/MonoKnightAppUITests/MonoKnightAppUITests.swift
@@ -22,20 +22,36 @@ final class MonoKnightAppUITests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
+    /// 手札スロットのアクセシビリティ情報がスタック仕様に更新されているかを検証する
     @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
+    func testHandSlotsExposeStackAccessibility() throws {
         let app = XCUIApplication()
         app.launch()
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
+        // 手札スロット 5 つそれぞれに識別子とラベルが設定されているか確認する
+        for index in 0..<5 {
+            let identifier = "hand_slot_\(index)"
+            let slot = app.descendants(matching: .any)[identifier]
 
-    @MainActor
-    func testLaunchPerformance() throws {
-        // This measures how long it takes to launch your application.
-        measure(metrics: [XCTApplicationLaunchMetric()]) {
-            XCUIApplication().launch()
+            XCTAssertTrue(slot.waitForExistence(timeout: 5), "手札スロット \(index) が表示されていません")
+
+            // ラベルは「方向名、残り X 枚」の形式を想定するため、「残り」と「枚」が含まれているかを検証する
+            XCTAssertTrue(slot.label.contains("残り"), "スロット \(index) のラベルに残枚数が含まれていません: \(slot.label)")
+            XCTAssertTrue(slot.label.contains("枚"), "スロット \(index) のラベルに枚数表現がありません: \(slot.label)")
+
+            // ヒントではスタック仕様や使用可否を案内しているため、代表的なキーワードのいずれかを含むことを確認する
+            if let hint = slot.accessibilityHintText {
+                let containsExpectedKeyword = hint.contains("重なっています") || hint.contains("ダブルタップ") || hint.contains("使用できません")
+                XCTAssertTrue(containsExpectedKeyword, "スロット \(index) のヒントがスタック仕様を説明していません: \(hint)")
+            }
         }
+    }
+}
+
+// MARK: - UI テスト専用ヘルパー
+private extension XCUIElement {
+    /// VoiceOver ヒント文をリフレクション経由で取得し、テスト検証に利用できるようにする
+    var accessibilityHintText: String? {
+        value(forKey: "accessibilityHint") as? String
     }
 }


### PR DESCRIPTION
## Summary
- introduce a local HandStack representation in `GameView` and update guide calculation, board tap handling, and play animations to always reference the stackのトップカード
- render each hand slot with the new `HandStackCardView`, show layered cards with an ×n badge, and refresh VoiceOver strings to explain remaining枚数やスタック仕様
- add a UI test that asserts the `hand_slot_*` accessibility labels and hints now expose the stack format

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d1e077dbb4832c87006ceba23305e6