### PR TITLE
Support stacked hand slots in GameCore

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -261,7 +261,7 @@ extension Deck {
 
     /// プリセットしたカード列を優先的に返すテスト用デッキを生成する
     /// - Parameters:
-    ///   - cards: 先頭から消費させたいカード列（手札スロット5枠→先読み3枚の順で利用される想定）
+    ///   - cards: 先頭から消費させたいカード列（手札スロット数ぶんを優先消費し、残りが先読みキューへ入る）
     ///   - configuration: 検証対象の山札設定（省略時はスタンダード）
     /// - Returns: プリセットを持った `Deck`
     static func makeTestDeck(cards: [MoveCard], configuration: Configuration = .standard) -> Deck {

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -133,7 +133,8 @@ public struct GameMode: Equatable, Identifiable {
 
     /// 盤面サイズ（N×N）
     public var boardSize: Int { regulation.boardSize }
-    /// 初期手札スロット数（同名カードを重ねるスタック枠の合計）
+    /// 手札スロット数（保持できるカード種類の上限を明示する）
+    /// - Note: ここでいう手札サイズは枚数ではなく「異なるカードの種類数」を指す。
     public var handSize: Int { regulation.handSize }
     /// 先読み表示枚数
     public var nextPreviewCount: Int { regulation.nextPreviewCount }

--- a/Game/HandStack.swift
+++ b/Game/HandStack.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// 手札の 1 スロットをスタック形式で管理するための構造体
+/// - Note: 同じ種類のカードを重ねて保持し、UI では常に最上段の `DealtCard` を表示する。
+public struct HandStack: Identifiable, Equatable {
+    /// スタック自体を識別するための UUID
+    public let id: UUID
+    /// スタックに積まれているカード列（末尾が最新＝表向きのカード）
+    public private(set) var cards: [DealtCard]
+
+    /// イニシャライザ
+    /// - Parameters:
+    ///   - id: 既存スタックを再構築するときに利用する識別子（省略時は自動採番）
+    ///   - cards: スタックへ積むカード配列（少なくとも 1 枚必要）
+    public init(id: UUID = UUID(), cards: [DealtCard]) {
+        // 空配列はスタックとして成立しないため、デバッグビルドでは気付きやすいようアサートを入れておく
+        assert(!cards.isEmpty, "HandStack は最低 1 枚のカードを保持する必要があります")
+        self.id = id
+        self.cards = cards
+    }
+
+    /// 先頭に表示されるカード（末尾の要素）
+    public var topCard: DealtCard? { cards.last }
+
+    /// スタックに積まれているカード枚数
+    public var count: Int { cards.count }
+
+    /// スタックが空になっているかどうか
+    public var isEmpty: Bool { cards.isEmpty }
+
+    /// 最新カードの MoveCard を取得する。スタックが空の場合は nil。
+    public var representativeMove: MoveCard? { topCard?.move }
+
+    /// 同じ種類のカードを積み増しする
+    /// - Parameter card: 追加したい `DealtCard`
+    public mutating func append(_ card: DealtCard) {
+        cards.append(card)
+    }
+
+    /// 表向きのカードを 1 枚取り除く
+    /// - Returns: 取り除いた `DealtCard`（スタックが空だった場合は nil）
+    @discardableResult
+    public mutating func removeTopCard() -> DealtCard? {
+        guard !cards.isEmpty else { return nil }
+        return cards.removeLast()
+    }
+}


### PR DESCRIPTION
## Summary
- HandStack 構造体を追加し、手札スロットをスタック単位で管理できるようにしました
- GameCore の手札ロジックを全面的にスタック前提へ刷新し、BoardTapPlayRequest や手札補充処理を更新しました
- GameView の UI/ガイド更新処理をスタック対応へ修正し、重なり枚数バッジを追加しました
- 手札関連テストを全面改修し、スタック積み増しケースの検証を追加しました

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d1e4745dc4832c823a855376931664