### PR TITLE
フリーモード用のレギュレーション編集画面を実装

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -91,6 +91,8 @@ public final class GameCore: ObservableObject {
     private let handSize: Int
     /// 先読み表示に用いるカード枚数（NEXT 表示は 3 枚先まで）
     private let nextPreviewCount: Int
+    /// 同種カードをスタックできるかどうかの設定
+    private let allowsCardStacking: Bool
     /// 盤面情報
     @Published public private(set) var board = Board(
         size: GameMode.standard.boardSize,
@@ -160,6 +162,7 @@ public final class GameCore: ObservableObject {
         board = Board(size: mode.boardSize, initialVisitedPoints: mode.initialVisitedPoints)
         current = mode.initialSpawnPoint
         deck = Deck(configuration: mode.deckConfiguration)
+        allowsCardStacking = mode.allowsCardStacking
         progress = mode.requiresSpawnSelection ? .awaitingSpawn : .playing
         // 実際の山札と手札の構成は共通処理に集約
         configureForNewSession(regenerateDeck: false)
@@ -471,7 +474,8 @@ public final class GameCore: ObservableObject {
 
             guard let card = nextCard else { break }
 
-            if let index = handStacks.firstIndex(where: { $0.representativeMove == card.move }) {
+            if allowsCardStacking,
+               let index = handStacks.firstIndex(where: { $0.representativeMove == card.move }) {
                 var existing = handStacks[index]
                 existing.append(card)
                 handStacks[index] = existing

--- a/Game/Models.swift
+++ b/Game/Models.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// 座標を表す構造体
 /// - 備考: 原点は左下、x は右方向、y は上方向に増加する
-public struct GridPoint: Hashable {
+public struct GridPoint: Hashable, Codable {
     /// x 座標
     public let x: Int
     /// y 座標

--- a/Services/FreeModeRegulationStore.swift
+++ b/Services/FreeModeRegulationStore.swift
@@ -1,0 +1,67 @@
+import Foundation
+import SwiftUI
+import Game
+
+/// フリーモードのレギュレーションを永続化し、UI から参照・更新できるようにするストア
+/// - Note: `UserDefaults` を介して JSON として保存し、アプリ再起動後も設定を復元する
+@MainActor
+final class FreeModeRegulationStore: ObservableObject {
+    /// 保存に利用する UserDefaults のキー
+    private static let storageKey = "free_mode_regulation_v1"
+    /// 監視対象のレギュレーション（変更時にビューを更新する）
+    @Published private(set) var regulation: GameMode.Regulation
+    /// 保存先の UserDefaults
+    private let userDefaults: UserDefaults
+
+    /// 初期化時に保存済みレギュレーションを読み込み、存在しない場合はスタンダード設定を初期値とする
+    /// - Parameter userDefaults: テスト時などに差し替えたい場合の注入用引数
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        if let data = userDefaults.data(forKey: Self.storageKey) {
+            do {
+                let decoded = try JSONDecoder().decode(GameMode.Regulation.self, from: data)
+                regulation = decoded
+                debugLog("FreeModeRegulationStore: 保存済み設定を復元しました")
+            } catch {
+                regulation = GameMode.standard.regulationSnapshot
+                debugError(error, message: "FreeModeRegulationStore: 復元に失敗したためスタンダードを適用")
+            }
+        } else {
+            regulation = GameMode.standard.regulationSnapshot
+            debugLog("FreeModeRegulationStore: 保存データが無いためスタンダードを初期値に設定")
+        }
+    }
+
+    /// 現在のレギュレーションを別の値で更新し、ただちに永続化する
+    /// - Parameter newValue: ユーザーが編集した新しい設定
+    func update(_ newValue: GameMode.Regulation) {
+        guard regulation != newValue else { return }
+        regulation = newValue
+        persist()
+        debugLog("FreeModeRegulationStore: レギュレーションを更新しました")
+    }
+
+    /// 指定したプリセットモードのレギュレーションを適用し、保存する
+    /// - Parameter mode: 適用したいビルトインモード
+    func applyPreset(from mode: GameMode) {
+        update(mode.regulationSnapshot)
+        debugLog("FreeModeRegulationStore: プリセット \(mode.identifier.rawValue) を適用")
+    }
+
+    /// 現在のレギュレーションを用いた `GameMode` を生成する
+    /// - Returns: フリーモードとして利用する `GameMode`
+    func makeGameMode() -> GameMode {
+        GameMode(identifier: .freeCustom, displayName: "フリーモード", regulation: regulation)
+    }
+
+    /// 現在の設定を JSON として UserDefaults へ保存する
+    private func persist() {
+        do {
+            let data = try JSONEncoder().encode(regulation)
+            userDefaults.set(data, forKey: Self.storageKey)
+            userDefaults.synchronize()
+        } catch {
+            debugError(error, message: "FreeModeRegulationStore: 永続化に失敗")
+        }
+    }
+}

--- a/UI/FreeModeRegulationView.swift
+++ b/UI/FreeModeRegulationView.swift
@@ -1,0 +1,220 @@
+import SwiftUI
+import Game
+
+/// フリーモードのレギュレーションを編集するためのビュー
+/// - Note: Stepper や Picker を用いて、主要なパラメータを直感的に調整できるようにする
+struct FreeModeRegulationView: View {
+    /// 編集中のドラフト値
+    @State private var draft: GameMode.Regulation
+    /// 読み込み可能なプリセット一覧（スタンダードやクラシカルなど）
+    private let presets: [GameMode]
+    /// キャンセル操作時のハンドラ
+    private let onCancel: () -> Void
+    /// 保存操作時のハンドラ
+    private let onSave: (GameMode.Regulation) -> Void
+
+    /// スポーン方式を Picker で扱いやすくするための内部列挙体
+    private enum SpawnOption: String, CaseIterable, Identifiable {
+        case fixedCenter
+        case chooseAny
+
+        var id: String { rawValue }
+
+        /// 表示名（日本語ラベル）
+        var label: String {
+            switch self {
+            case .fixedCenter:
+                return "中央固定"
+            case .chooseAny:
+                return "先読み後に任意選択"
+            }
+        }
+    }
+
+    /// カスタムイニシャライザでドラフト値とコールバックを受け取る
+    /// - Parameters:
+    ///   - initialRegulation: シート表示時点のレギュレーション
+    ///   - presets: 読み込み可能なプリセット一覧
+    ///   - onCancel: キャンセルボタン押下時に呼び出すクロージャ
+    ///   - onSave: 保存ボタン押下時に呼び出すクロージャ
+    init(
+        initialRegulation: GameMode.Regulation,
+        presets: [GameMode],
+        onCancel: @escaping () -> Void,
+        onSave: @escaping (GameMode.Regulation) -> Void
+    ) {
+        _draft = State(initialValue: initialRegulation)
+        self.presets = presets
+        self.onCancel = onCancel
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        Form {
+            presetSection
+            boardSection
+            handSection
+            penaltySection
+            previewSection
+        }
+        .navigationTitle("フリーモード設定")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("キャンセル") {
+                    onCancel()
+                }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("保存") {
+                    onSave(draft)
+                }
+                .disabled(!isDraftValid)
+            }
+        }
+        // 盤面サイズが変わった際に固定スポーンも中心へ更新し、矛盾を防ぐ
+        .onChange(of: draft.boardSize) { _, newValue in
+            if currentSpawnOption == .fixedCenter {
+                draft.spawnRule = .fixed(GridPoint.center(of: newValue))
+            }
+        }
+    }
+}
+
+private extension FreeModeRegulationView {
+    /// プリセット読込セクション
+    var presetSection: some View {
+        Section {
+            ForEach(presets) { mode in
+                Button {
+                    // 選択したプリセットの内容をドラフトへ反映
+                    draft = mode.regulationSnapshot
+                } label: {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(mode.displayName)
+                            .font(.headline)
+                        Text(mode.primarySummaryText)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        } header: {
+            Text("プリセット読込")
+        } footer: {
+            Text("プリセットを読み込んでから個別の数値を微調整できます。")
+        }
+    }
+
+    /// 盤面サイズや山札プリセットを調整するセクション
+    var boardSection: some View {
+        Section {
+            Stepper(value: $draft.boardSize, in: 5...9, step: 1) {
+                Text("盤面サイズ: \(draft.boardSize) × \(draft.boardSize)")
+            }
+            Picker("初期スポーン", selection: spawnOptionBinding) {
+                ForEach(SpawnOption.allCases) { option in
+                    Text(option.label).tag(option)
+                }
+            }
+            Picker("山札構成", selection: $draft.deckPreset) {
+                ForEach(GameDeckPreset.allCases) { preset in
+                    Text(preset.displayName).tag(preset)
+                }
+            }
+            Text(draft.deckPreset.summaryText)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        } header: {
+            Text("盤面と山札")
+        } footer: {
+            Text("盤面サイズを変更すると中央固定スポーンも自動的に中心へ移動します。")
+        }
+    }
+
+    /// 手札スロットや先読み枚数を調整するセクション
+    var handSection: some View {
+        Section {
+            Stepper(value: $draft.handSize, in: 1...7, step: 1) {
+                Text("手札スロット: 最大 \(draft.handSize) 種類")
+            }
+            Stepper(value: $draft.nextPreviewCount, in: 0...5, step: 1) {
+                Text("先読み表示: \(draft.nextPreviewCount) 枚")
+            }
+            Toggle(isOn: $draft.allowsStacking) {
+                Text("同種カードのスタックを許可する")
+            }
+        } header: {
+            Text("手札と先読み")
+        } footer: {
+            Text("スタックを無効にすると同じカードは別スロットを占有します。")
+        }
+    }
+
+    /// ペナルティ関連の設定をまとめたセクション
+    var penaltySection: some View {
+        Section {
+            Stepper(value: $draft.penalties.deadlockPenaltyCost, in: 0...10, step: 1) {
+                Text("手詰まり自動ペナルティ: +\(draft.penalties.deadlockPenaltyCost)")
+            }
+            Stepper(value: $draft.penalties.manualRedrawPenaltyCost, in: 0...10, step: 1) {
+                Text("手動引き直しペナルティ: +\(draft.penalties.manualRedrawPenaltyCost)")
+            }
+            Stepper(value: $draft.penalties.revisitPenaltyCost, in: 0...10, step: 1) {
+                if draft.penalties.revisitPenaltyCost > 0 {
+                    Text("再訪ペナルティ: +\(draft.penalties.revisitPenaltyCost)")
+                } else {
+                    Text("再訪ペナルティなし")
+                }
+            }
+        } header: {
+            Text("ペナルティ")
+        } footer: {
+            Text("0 を指定すると該当ペナルティは無効になります。")
+        }
+    }
+
+    /// 現在のドラフト設定がどのようなモードかを簡易表示するセクション
+    var previewSection: some View {
+        Section {
+            let previewMode = GameMode(identifier: .freeCustom, displayName: "フリーモード", regulation: draft)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(previewMode.primarySummaryText)
+                Text(previewMode.secondarySummaryText)
+                Text(previewMode.stackingRuleDetailText)
+            }
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        } header: {
+            Text("サマリー")
+        }
+    }
+
+    /// 現在のスポーン設定を Picker 用のオプションへ変換する
+    var currentSpawnOption: SpawnOption {
+        switch draft.spawnRule {
+        case .fixed:
+            return .fixedCenter
+        case .chooseAnyAfterPreview:
+            return .chooseAny
+        }
+    }
+
+    /// Picker と `draft.spawnRule` を結び付けるバインディング
+    var spawnOptionBinding: Binding<SpawnOption> {
+        Binding {
+            currentSpawnOption
+        } set: { newValue in
+            switch newValue {
+            case .fixedCenter:
+                draft.spawnRule = .fixed(GridPoint.center(of: draft.boardSize))
+            case .chooseAny:
+                draft.spawnRule = .chooseAnyAfterPreview
+            }
+        }
+    }
+
+    /// 入力されたドラフト値が妥当かどうかを簡易判定する
+    var isDraftValid: Bool {
+        draft.boardSize >= 3 && draft.handSize >= 1
+    }
+}

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -866,10 +866,12 @@ struct GameView: View {
     /// - Note: スロット制の仕様を理解しやすいよう「種類数」とスタックの挙動を明記する。
     private var manualPenaltyAccessibilityHint: String {
         let cost = core.mode.manualRedrawPenaltyCost
+        let stackingDetail = core.mode.stackingRuleDetailText
+        let refillDescription = "手札スロットを全て空にし、新しいカードを最大 \(core.mode.handSize) 種類まで補充します。"
         if cost > 0 {
-            return "手数を\(cost)消費して手札スロットを全て空にし、新しいカードを最大 \(core.mode.handSize) 種類まで補充します。同じ種類のカードはスロット内で重なります。"
+            return "手数を\(cost)消費して\(refillDescription)\(stackingDetail)"
         } else {
-            return "手数を消費せずに手札スロットを全て空にし、新しいカードを最大 \(core.mode.handSize) 種類まで補充します。同じ種類のカードはスロット内で重なります。"
+            return "手数を消費せずに\(refillDescription)\(stackingDetail)"
         }
     }
 

--- a/UI/HowToPlayView.swift
+++ b/UI/HowToPlayView.swift
@@ -24,7 +24,7 @@ struct HowToPlayView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 // MARK: - 導入文
-                Text("MonoKnight は移動カードを使って 5×5 の盤面を踏破するパズルです。手札スロットは最大 \(referenceMode.handSize) 種類まで保持でき、同じカードはスロット内で重なります。以下の流れを押さえておけば、すぐにプレイを始められます。")
+                Text("MonoKnight は移動カードを使って 5×5 の盤面を踏破するパズルです。手札スロットは最大 \(referenceMode.handSize) 種類まで保持でき、\(referenceMode.stackingRuleDetailText)以下の流れを押さえておけば、すぐにプレイを始められます。")
                     .font(.body)
                     .padding(.bottom, 8)
 
@@ -36,7 +36,7 @@ struct HowToPlayView: View {
                     tips: [
                         "カードの矢印が示す方向に 1 マス進みます。",
                         "白い丸が現在位置、黒い丸が移動先を表します。",
-                        "同じ種類のカードは手札スロット内で重なり、消費するとまとめて補充されます。"
+                        stackingTip
                     ]
                 )
 
@@ -109,6 +109,15 @@ struct HowToPlayView: View {
 
 // MARK: - レイアウト調整用のヘルパー
 private extension HowToPlayView {
+    /// スタック仕様を説明する文言。スタンダード以外に差し替えた場合でも整合が取れるようにする
+    var stackingTip: String {
+        if referenceMode.allowsCardStacking {
+            return "同じ種類のカードは手札スロット内で重なり、消費するとまとめて補充されます。"
+        } else {
+            return "同じ種類のカードでも別スロットを占有するため、空き枠を意識した立ち回りが重要です。"
+        }
+    }
+
     /// 横幅に応じた最大コンテンツ幅を返す
     var contentMaxWidth: CGFloat? {
         horizontalSizeClass == .regular ? 640 : nil

--- a/UI/SettingsView.swift
+++ b/UI/SettingsView.swift
@@ -245,7 +245,7 @@ struct SettingsView: View {
                     Text("ヘルプ")
                 } footer: {
                     // プレイ中に迷った際の確認先を案内
-                    Text("カードの動きや勝利条件に加えて、手札スロットが最大 \(GameMode.standard.handSize) 種類で同じカードは重なって保持できる仕様も確認できます。")
+                    Text("カードの動きや勝利条件に加えて、手札スロットが最大 \(GameMode.standard.handSize) 種類で\(GameMode.standard.stackingRuleDetailText)という仕様も確認できます。")
                 }
 
                 // MARK: - 戦績セクション


### PR DESCRIPTION
## Summary
- GameMode にデッキプリセットやスタック可否を含むレギュレーションを追加し、Codable 化してカスタム設定を扱えるようにしました。
- フリーモードのレギュレーションを永続化する FreeModeRegulationStore と編集用の FreeModeRegulationView を新規実装しました。
- タイトル画面からフリーモード設定シートを開けるようにし、各種説明文やアクセシビリティテキストをスタック仕様に対応させました。

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68d1f344230c832c90ca55093efda6e6