### PR TITLE
Restrict spawn option binding access

### DIFF
--- a/UI/FreeModeRegulationView.swift
+++ b/UI/FreeModeRegulationView.swift
@@ -190,7 +190,8 @@ private extension FreeModeRegulationView {
     }
 
     /// 現在のスポーン設定を Picker 用のオプションへ変換する
-    var currentSpawnOption: SpawnOption {
+    /// スポーン設定の現在値を外部公開せずに参照するために private へ指定
+    private var currentSpawnOption: SpawnOption {
         switch draft.spawnRule {
         case .fixed:
             return .fixedCenter
@@ -200,7 +201,7 @@ private extension FreeModeRegulationView {
     }
 
     /// Picker と `draft.spawnRule` を結び付けるバインディング
-    var spawnOptionBinding: Binding<SpawnOption> {
+    private var spawnOptionBinding: Binding<SpawnOption> {
         Binding {
             currentSpawnOption
         } set: { newValue in


### PR DESCRIPTION
## Summary
- FreeModeRegulationView のスポーン関連プロパティを private 化してアクセス制御エラーを解消
- private 化の意図をコメントで補足

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d2021999c0832cbefd8f1f10a8d7fb