### PR TITLE
Fix spawn option binding access control

### DIFF
--- a/UI/FreeModeRegulationView.swift
+++ b/UI/FreeModeRegulationView.swift
@@ -190,7 +190,8 @@ private extension FreeModeRegulationView {
     }
 
     /// 現在のスポーン設定を Picker 用のオプションへ変換する
-    var currentSpawnOption: SpawnOption {
+    /// Picker の現在値を内部のスポーン設定へ変換した結果を返す
+    private var currentSpawnOption: SpawnOption {
         switch draft.spawnRule {
         case .fixed:
             return .fixedCenter
@@ -200,7 +201,7 @@ private extension FreeModeRegulationView {
     }
 
     /// Picker と `draft.spawnRule` を結び付けるバインディング
-    var spawnOptionBinding: Binding<SpawnOption> {
+    private var spawnOptionBinding: Binding<SpawnOption> {
         Binding {
             currentSpawnOption
         } set: { newValue in


### PR DESCRIPTION
## Summary
- mark internal helpers that expose the private SpawnOption type as private
- add a Japanese comment explaining the helper that maps the picker selection

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68d2020cc840832cb547ad48aed64846