### PR TITLE
Adjust interstitial interval to five minutes

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -60,6 +60,8 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
 
     /// 失敗時に再読み込みを試みるまでの秒数
     private let retryDelay: TimeInterval = 30
+    /// インタースティシャル広告の最低表示間隔（秒単位で 5 分を指定）
+    private let minimumInterstitialInterval: TimeInterval = 300
 
     private override init() {
         let applicationIdentifier = (Bundle.main.object(forInfoDictionaryKey: InfoPlistKey.applicationIdentifier) as? String)?
@@ -202,7 +204,7 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
 
         // インターバルや 1 プレイ 1 回の制御に引っかかったら終了
         if !canShowByTime() {
-            debugLog("前回表示から 90 秒未満のためインタースティシャル広告を表示しません")
+            debugLog("前回表示から 5 分未満のためインタースティシャル広告を表示しません")
             return
         }
 
@@ -384,10 +386,10 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
         debugLog("インタースティシャル広告の再読み込みを \(retryDelay) 秒後にスケジュールしました")
     }
 
-    /// 最低 90 秒のインターバルを満たしているかどうか
+    /// 最低 5 分のインターバルを満たしているかどうか
     private func canShowByTime() -> Bool {
         guard let last = lastInterstitialDate else { return true }
-        return Date().timeIntervalSince(last) >= 90
+        return Date().timeIntervalSince(last) >= minimumInterstitialInterval
     }
 
     // MARK: - FullScreenContentDelegate


### PR DESCRIPTION
## Summary
- add a dedicated constant to express the five-minute minimum interval for interstitial ads
- update the timing check and related log/commentary to reference the new five-minute interval

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68d21c3ce774832c9d724d4eb589f47f