### PR TITLE
Add test leaderboards for standard and classical modes

### DIFF
--- a/Services/ServiceMocks.swift
+++ b/Services/ServiceMocks.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import Game   // GameMode.Identifier を扱うために追加
 import UIKit
 import SwiftUI
 
@@ -14,10 +15,10 @@ final class MockGameCenterService: GameCenterServiceProtocol {
     }
 
     /// スコア送信は行わないダミー実装
-    func submitScore(_ score: Int) {}
+    func submitScore(_ score: Int, for modeIdentifier: GameMode.Identifier) {}
 
     /// ランキング表示も行わないダミー実装
-    func showLeaderboard() {}
+    func showLeaderboard(for modeIdentifier: GameMode.Identifier) {}
 }
 
 /// インタースティシャル広告をダミー表示する UI テスト用モック

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -148,6 +148,7 @@ struct GameView: View {
                 moveCount: core.moveCount,
                 penaltyCount: core.penaltyCount,
                 elapsedSeconds: core.elapsedSeconds,
+                modeIdentifier: mode.identifier,
                 onRetry: {
                     // リトライ時はゲームを初期状態に戻して再開する
                     core.reset()
@@ -293,7 +294,8 @@ struct GameView: View {
             // progress が .cleared へ変化したタイミングで結果画面を表示
             .onChange(of: core.progress) { _, newValue in
                 guard newValue == .cleared else { return }
-                gameCenterService.submitScore(core.score)
+                // ゲームモードごとのテスト用リーダーボードへスコアを送信できるように識別子を渡す
+                gameCenterService.submitScore(core.score, for: mode.identifier)
                 showingResult = true
             }
 

--- a/UI/ResultView.swift
+++ b/UI/ResultView.swift
@@ -1,3 +1,4 @@
+import Game  // GameMode.Identifier を扱うために追加
 import SwiftUI
 import UIKit  // ハプティクス用フレームワーク
 
@@ -13,6 +14,9 @@ struct ResultView: View {
 
     /// クリアまでに要した秒数
     let elapsedSeconds: Int
+
+    /// スコア送信・ランキング表示に利用するゲームモード識別子
+    let modeIdentifier: GameMode.Identifier
 
     /// 再戦処理を外部から受け取るクロージャ
     let onRetry: () -> Void
@@ -44,12 +48,14 @@ struct ResultView: View {
         moveCount: Int,
         penaltyCount: Int,
         elapsedSeconds: Int,
+        modeIdentifier: GameMode.Identifier,
         onRetry: @escaping () -> Void
     ) {
         self.init(
             moveCount: moveCount,
             penaltyCount: penaltyCount,
             elapsedSeconds: elapsedSeconds,
+            modeIdentifier: modeIdentifier,
             onRetry: onRetry,
             gameCenterService: GameCenterService.shared,
             adsService: AdsService.shared
@@ -60,6 +66,7 @@ struct ResultView: View {
         moveCount: Int,
         penaltyCount: Int,
         elapsedSeconds: Int,
+        modeIdentifier: GameMode.Identifier,
         onRetry: @escaping () -> Void,
 
         gameCenterService: GameCenterServiceProtocol,
@@ -75,6 +82,7 @@ struct ResultView: View {
         self.moveCount = moveCount
         self.penaltyCount = penaltyCount
         self.elapsedSeconds = elapsedSeconds
+        self.modeIdentifier = modeIdentifier
         self.onRetry = onRetry
         self.gameCenterService = resolvedGameCenterService
         self.adsService = resolvedAdsService
@@ -150,7 +158,8 @@ struct ResultView: View {
                     if hapticsEnabled {
                         UINotificationFeedbackGenerator().notificationOccurred(.success)
                     }
-                    gameCenterService.showLeaderboard()
+                    // 直前にプレイしていたモードに対応するテスト用リーダーボードを開く
+                    gameCenterService.showLeaderboard(for: modeIdentifier)
                 }) {
                     Text("ランキング")
                         .frame(maxWidth: .infinity)
@@ -363,6 +372,7 @@ struct ResultView_Previews: PreviewProvider {
             moveCount: 24,
             penaltyCount: 6,
             elapsedSeconds: 132,
+            modeIdentifier: .standard5x5,
             onRetry: {},
             gameCenterService: GameCenterService.shared,
             adsService: AdsService.shared
@@ -372,5 +382,11 @@ struct ResultView_Previews: PreviewProvider {
 
 
 #Preview {
-    ResultView(moveCount: 24, penaltyCount: 6, elapsedSeconds: 132, onRetry: {})
+    ResultView(
+        moveCount: 24,
+        penaltyCount: 6,
+        elapsedSeconds: 132,
+        modeIdentifier: .standard5x5,
+        onRetry: {}
+    )
 }

--- a/docs/game-center-leaderboards.md
+++ b/docs/game-center-leaderboards.md
@@ -1,0 +1,22 @@
+# Game Center リーダーボード管理表
+
+MonoKnight で利用する Game Center リーダーボードの参照名と Leaderboard ID を一覧化したドキュメント。
+テスト段階のリーダーボードを明示することで、App Store Connect 上の設定とコードの整合性を確認しやすくする。
+正式リリース時に本番用のリーダーボードへ移行する場合は、本表と `GameCenterService` 内の `GameCenterLeaderboardCatalog`
+定義を同時に更新すること。
+
+## テスト運用中のリーダーボード
+
+| 対応モード | ステータス | リファレンス名 (Reference Name) | Leaderboard ID | 備考 |
+| --- | --- | --- | --- | --- |
+| スタンダードモード (5x5) | テスト | `[TEST] Standard Leaderboard` | `test_standard_moves_v1` | スタンダードモードのプレイ結果を送信。正式版では本番 ID へ差し替える。 |
+| クラシカルチャレンジ | テスト | `[TEST] Classical Challenge Leaderboard` | `test_classical_moves_v1` | クラシカルチャレンジ専用の桂馬デッキ向けランキング。正式リリース時に本番 ID へ切り替え予定。 |
+
+### 運用メモ
+
+- 上記リファレンス名は App Store Connect の Game Center 設定画面で入力する値と一致させること。
+- Leaderboard ID はアプリのバイナリから送信する ID と完全一致していないとスコアが反映されない。
+- 新しいモードを追加してテスト用リーダーボードが必要になった場合は、上表と `GameCenterLeaderboardCatalog`
+  にエントリを追加し、必要に応じて `GameView` / `ResultView` の送信ロジックを拡張する。
+- テスト用リーダーボードから正式名称へ切り替える際は、旧 ID の送信状況を `resetSubmittedFlag(for:)` でリセットし、
+  ユーザーの再送信を促すことを推奨する。


### PR DESCRIPTION
## Summary
- add a catalog of test leaderboards so Game Center submissions can select the correct board per mode
- update GameView and ResultView to submit and present rankings using each mode's identifier
- document the test leaderboard reference names and IDs for App Store Connect coordination

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d21a5ecad4832c85c70c059b62cde4