### PR TITLE
Fix PauseMenuView initializer accessibility

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -1887,6 +1887,22 @@ private struct PauseMenuView: View {
     /// タイトルへ戻る確定時の処理
     let onConfirmReturnToTitle: () -> Void
 
+    /// GameView 側から利用できるようアクセスレベルを内部公開にしたカスタムイニシャライザ
+    /// - Parameters:
+    ///   - onResume: ポーズ解除時に実行するクロージャ
+    ///   - onConfirmReset: ゲームリセット確定時に実行するクロージャ
+    ///   - onConfirmReturnToTitle: タイトル復帰確定時に実行するクロージャ
+    /// - Note: `private struct` では自動生成イニシャライザが private になるため、ここで明示的に定義する
+    init(
+        onResume: @escaping () -> Void,
+        onConfirmReset: @escaping () -> Void,
+        onConfirmReturnToTitle: @escaping () -> Void
+    ) {
+        self.onResume = onResume
+        self.onConfirmReset = onConfirmReset
+        self.onConfirmReturnToTitle = onConfirmReturnToTitle
+    }
+
     /// シートを閉じるための環境ディスミス
     @Environment(\.dismiss) private var dismiss
     /// テーマ設定の永続化キー


### PR DESCRIPTION
## Summary
- add an explicit initializer to `PauseMenuView` so GameView can present it with injected actions

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d222bd0d0c832c94870d53030ff8b4