### PR TITLE
Fix confirmation dialog binding in pause menu

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -2009,7 +2009,7 @@ private struct PauseMenuView: View {
             .background(theme.backgroundPrimary)
         }
         // 破壊的操作の確認ダイアログ
-        .confirmationDialog("操作の確認", presenting: pendingAction, actions: { action in
+        .confirmationDialog("操作の確認", item: $pendingAction, actions: { action in
             Button(action.confirmationButtonTitle, role: .destructive) {
                 handleConfirmation(action)
             }


### PR DESCRIPTION
## Summary
- fix the pause menu confirmation dialog to use the binding-based overload

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d223658ac4832cbd1d173ca71c255a