### PR TITLE
Fix pause menu confirmation dialog message compatibility

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -2010,14 +2010,14 @@ private struct PauseMenuView: View {
         }
         // 破壊的操作の確認ダイアログ
         .confirmationDialog("操作の確認", item: $pendingAction, actions: { action in
+            // ダイアログ冒頭に操作内容の説明を表示する（iOS16互換のため message クロージャは使用しない）
+            Text(action.message)
             Button(action.confirmationButtonTitle, role: .destructive) {
                 handleConfirmation(action)
             }
             Button("キャンセル", role: .cancel) {
                 pendingAction = nil
             }
-        }, message: { action in
-            Text(action.message)
         })
     }
 


### PR DESCRIPTION
## Summary
- ensure the pause menu confirmation dialog shows its message text without relying on the unavailable `message` closure
- add an inline note explaining the fallback for iOS 16 compatibility

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d224e1bb0c832cb8f39a98e71d683a