### PR TITLE
Adjust game controls layout spacing

### DIFF
--- a/UI/Environment+TopOverlayHeight.swift
+++ b/UI/Environment+TopOverlayHeight.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// 画面上部に挿入するオーバーレイ（トップバーなど）の高さを子ビューへ伝搬するための EnvironmentKey
+/// - Note: RootView 側で安全領域を拡張した際、GameView では元の safeAreaInsets.top から減算した値を使いたいため
+///         明示的にトップバーの高さを共有できる仕組みを用意する。
+struct TopOverlayHeightEnvironmentKey: EnvironmentKey {
+    /// デフォルト値は 0。トップバーが存在しない構成でも従来どおり動作させる
+    static let defaultValue: CGFloat = 0
+}
+
+extension EnvironmentValues {
+    /// 画面上部の追加オーバーレイの高さを保持するプロパティ
+    /// - Note: RootView から GameView へ伝搬し、safeAreaInsets.top から差し引く用途で参照する
+    var topOverlayHeight: CGFloat {
+        get { self[TopOverlayHeightEnvironmentKey.self] }
+        set { self[TopOverlayHeightEnvironmentKey.self] = newValue }
+    }
+}
+

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -84,6 +84,8 @@ struct RootView: View {
                             }
                         )
                         .id(gameSessionID)
+                        // トップバーの高さを Environment 経由で伝搬し、GameView 側で safe area 調整に利用する
+                        .environment(\.topOverlayHeight, topBarHeight)
                         // タイトル解除直後やローディング中は盤面を非表示にし、描画途中のチラつきを防ぐ
                         .opacity(isPreparingGame ? 0 : 1)
                         // ローディングが完了するまではユーザー操作を受け付けないようにする


### PR DESCRIPTION
## Summary
- add an environment value to share the top overlay height with the game screen
- compensate GameView safe-area calculations with the injected height to remove the unused top gap
- rework the board control row so the statistics and buttons stack onto two lines when horizontal space is tight

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68d2275a5c50832c8e1320743b6a4c67