### PR TITLE
Fix Environment value type inference in GameView

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -20,7 +20,8 @@ struct GameView: View {
     /// デバイスの横幅サイズクラスを取得し、iPad などレギュラー幅でのモーダル挙動を調整する
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     /// RootView 側で挿入したトップバーの高さ。safeAreaInsets.top から減算して余分な余白を除去する
-    @Environment(\.topOverlayHeight) private var topOverlayHeight
+    /// - Note: 明示的に CGFloat 型を指定しておくことで、カスタム EnvironmentKey の推論エラーを避ける
+    @Environment(\.topOverlayHeight) private var topOverlayHeight: CGFloat
     /// 手札スロットの数（常に 5 スロット分の枠を確保してレイアウトを安定させる）
     private let handSlotCount = 5
     /// ゲームロジックを保持する ObservableObject


### PR DESCRIPTION
## Summary
- specify `CGFloat` type for the custom `topOverlayHeight` environment value in `GameView`
- add a note clarifying the explicit type avoids inference issues when accessing the environment key

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d22913d99c832ca0dd2ce2159887ec