### PR TITLE
Ensure pause menu and settings use full-screen presentations

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -154,15 +154,15 @@ struct GameView: View {
                 mainContent(for: geometry)
             }
         )
-        // ポーズメニューをシートで表示し、ゲーム中でも設定の確認・変更ができるようにする
-        .sheet(isPresented: $isPauseMenuPresented) {
+        // ポーズメニューをフルスクリーンで重ね、端末サイズに左右されずに全項目を視認できるようにする
+        .fullScreenCover(isPresented: $isPauseMenuPresented) {
             PauseMenuView(
                 onResume: {
-                    // シートを閉じてプレイへ戻る
+                    // フルスクリーンカバーを閉じてプレイへ戻る
                     isPauseMenuPresented = false
                 },
                 onConfirmReset: {
-                    // リセット確定後はシートを閉じてから共通処理を呼び出す
+                    // リセット確定後はフルスクリーンカバーを閉じてから共通処理を呼び出す
                     isPauseMenuPresented = false
                     performMenuAction(.reset)
                 },
@@ -172,10 +172,6 @@ struct GameView: View {
                     performMenuAction(.returnToTitle)
                 }
             )
-            .presentationDetents(
-                horizontalSizeClass == .regular ? [.fraction(0.5), .large] : [.medium, .large]
-            )
-            .presentationDragIndicator(.visible)
         }
         // シートで結果画面を表示
         .sheet(isPresented: $showingResult) {
@@ -1987,7 +1983,7 @@ private struct PauseMenuView: View {
                 // MARK: - プレイ再開ボタン
                 Section {
                     Button {
-                        // シートを閉じて直ちにプレイへ戻る
+                        // フルスクリーンカバーを閉じて直ちにプレイへ戻る
                         onResume()
                         dismiss()
                     } label: {

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -164,16 +164,13 @@ struct RootView: View {
         .onChange(of: horizontalSizeClass) { _, newValue in
             debugLog("RootView.horizontalSizeClass 更新: \(String(describing: newValue))")
         }
-        // 設定シートの表示状態を監視し、意図せぬ多重表示が起きていないか把握する
+        // 設定画面の表示状態を監視し、意図せぬ多重表示が起きていないか把握する
         .onChange(of: isPresentingTitleSettings) { _, newValue in
             debugLog("RootView.isPresentingTitleSettings 更新: \(newValue)")
         }
-        // タイトル画面専用の設定シートを表示し、ゲーム外で扱う詳細項目を集約する
-        .sheet(isPresented: $isPresentingTitleSettings) {
+        // タイトル画面専用の設定をフルスクリーンカバーで開き、iPhone と iPad の双方で没入感のある編集体験にそろえる
+        .fullScreenCover(isPresented: $isPresentingTitleSettings) {
             SettingsView()
-                // iPhone・iPad いずれも初期状態から全画面で表示し、設定項目を見落とさないよう統一する
-                .presentationDetents([.large])
-                .presentationDragIndicator(.visible)
         }
     }
 }


### PR DESCRIPTION
## Summary
- switch the in-game pause menu to a full-screen cover so all controls stay visible on every device
- present the title settings view as a full-screen cover to unify the experience across iPhone and iPad

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d23ee547dc832c95356b709e12103a