### PR TITLE
Add UI automation for title flow

### DIFF
--- a/MonoKnightAppUITests/MonoKnightAppUITests.swift
+++ b/MonoKnightAppUITests/MonoKnightAppUITests.swift
@@ -9,32 +9,42 @@ import XCTest
 
 final class MonoKnightAppUITests: XCTestCase {
 
+    /// 各テストで再利用するアプリケーションインスタンス
+    private var app: XCUIApplication!
+
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
+        // 1 テストで失敗したら即座に中断し、以降の操作が副作用を生まないようにする
         continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        // テストごとにクリーンなアプリインスタンスを生成し、前テストの状態が残らないように初期化する
+        app = XCUIApplication()
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        // 後続テストに前回のインスタンスが残らないよう明示的に破棄する
+        app = nil
     }
 
     @MainActor
     func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
+        // アプリを起動し、タイトル画面が最初に表示されることを前提とした基本状態を整える
         app.launch()
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // アプリタイトルのラベルが表示されているか検証し、起動直後にタイトル画面へ留まっていることを確かめる
+        let titleLabel = app.staticTexts["MonoKnight"]
+        XCTAssertTrue(titleLabel.waitForExistence(timeout: 5), "起動直後にタイトルラベルが表示されること")
+
+        // ゲーム開始ボタンがタップ可能な状態で存在するか確認し、ユーザーがすぐに操作できる導線を担保する
+        let startButton = app.buttons["title_start_button"]
+        XCTAssertTrue(startButton.exists, "タイトル画面にゲーム開始ボタンが配置されていること")
+
+        // 遊び方ボタンも同時に表示されているか確認し、ヘルプ導線の欠落を防ぐ
+        let howToPlayButton = app.buttons["title_how_to_play_button"]
+        XCTAssertTrue(howToPlayButton.waitForExistence(timeout: 5), "タイトル画面で遊び方ボタンにアクセスできること")
     }
 
     @MainActor
     func testHandSlotAccessibilityReflectsStackState() throws {
         // ゲーム画面を起動し、初期状態の手札スロットを取得する
-        let app = XCUIApplication()
         app.launch()
 
         let firstSlot = app.otherElements["hand_slot_0"]
@@ -58,5 +68,25 @@ final class MonoKnightAppUITests: XCTestCase {
         measure(metrics: [XCTApplicationLaunchMetric()]) {
             XCUIApplication().launch()
         }
+    }
+
+    @MainActor
+    func testTitleToGameTransitionDisplaysHandSlots() throws {
+        // タイトル画面からゲーム開始までを自動操作し、基本的な遷移が成立するか検証する
+        app.launch()
+
+        // ゲーム開始ボタンが表示されるまで待機し、確実にタップできる状態を捉える
+        let startButton = app.buttons["title_start_button"]
+        XCTAssertTrue(startButton.waitForExistence(timeout: 5), "ゲーム開始ボタンが表示されること")
+
+        // 開始ボタンをタップしてプレイ画面への遷移を進める
+        startButton.tap()
+
+        // ローディング解除後に手札スロットが表示されることを確認し、実際にゲーム画面へ移ったと判断する
+        let firstHandSlot = app.otherElements["hand_slot_0"]
+        XCTAssertTrue(firstHandSlot.waitForExistence(timeout: 5), "ゲーム画面で最初の手札スロットが表示されること")
+
+        // タイトル用の開始ボタンが非表示になっていることを確認し、重ね表示による誤タップの可能性を排除する
+        XCTAssertFalse(startButton.exists, "ゲーム遷移後はタイトルの開始ボタンが残っていないこと")
     }
 }


### PR DESCRIPTION
## Summary
- replace the default UI test template with checks that validate the title screen layout
- share the `XCUIApplication` instance across UI tests for consistent launch handling
- add a regression test that drives the title-to-game transition and verifies the hand slot UI appears

## Testing
- not run (requires Xcode UI test runner on macOS)


------
https://chatgpt.com/codex/tasks/task_e_68d2409c9298832ca69ccc18070fcb86