### PR TITLE
Fix SwiftUI onChange deprecation warning

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -776,7 +776,8 @@ struct GameView: View {
                 refreshGuideHighlights()
             }
             // ジオメトリの変化に追従できるよう、SpriteKit シーンのサイズも都度更新する
-            .onChange(of: width) { newWidth in
+            .onChange(of: width) { _, newWidth in
+                // iOS 17 以降の新しいシグネチャに合わせて旧値を受け取るが、現状は利用しない
                 debugLog("SpriteBoard.width 更新: newWidth=\(newWidth)")
                 if newWidth <= 0 {
                     // レイアウト異常で幅がゼロになったケースを把握するための警告ログ


### PR DESCRIPTION
## Summary
- adopt the two-parameter onChange closure to align with the iOS 17 API
- document the unused old-value parameter for future reference

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d269dfad80832c9d2183bf25cc037d