### PR TITLE
Fix TopBarHeightPreferenceKey scope

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -523,13 +523,18 @@ private extension RootView {
         static let gamePreparationMinimumDelay: Double = 0.35
     }
 
-    /// トップバーの高さを親ビューへ伝えるための PreferenceKey
-    struct TopBarHeightPreferenceKey: PreferenceKey {
-        static var defaultValue: CGFloat = 0
+}
 
-        static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-            value = nextValue()
-        }
+/// RootView 専用のトップバー高さを伝達する PreferenceKey
+/// - NOTE: `TopStatusInsetView` などファイル内の複数ビューから利用するため、
+///         ファイルスコープで `fileprivate` として宣言し、スコープエラーを防ぐ
+fileprivate struct TopBarHeightPreferenceKey: PreferenceKey {
+    /// GeometryReader から受け取る高さのデフォルト値（未計測時は 0）
+    static var defaultValue: CGFloat = 0
+
+    /// Preference の更新処理。最新値だけを必要とするため常に `nextValue()` で上書きする
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 


### PR DESCRIPTION
## Summary
- move the TopBarHeightPreferenceKey declaration to file scope so auxiliary views can access it
- document the preference key usage and keep Japanese comments for clarity

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d312c948f0832cb512c1b0585a5979