### PR TITLE
Fix preference key reference in TopStatusInsetView

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -576,7 +576,8 @@ fileprivate struct TopStatusInsetView: View {
         .background(
             GeometryReader { proxy in
                 Color.clear
-                    .preference(key: TopBarHeightPreferenceKey.self, value: proxy.size.height)
+                    // ネストした PreferenceKey を明示的に参照し、ジェネリック推論エラーを回避する
+                    .preference(key: RootView.TopBarHeightPreferenceKey.self, value: proxy.size.height)
             }
         )
     }


### PR DESCRIPTION
## Summary
- ensure the top bar height preference uses the nested RootView key explicitly
- document the reason for the change to avoid future inference issues

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d312d668d0832c92d560c20d9aa5cd