### PR TITLE
Adjust RootView snapshot state access control

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -111,7 +111,9 @@ final class RootViewStateStore: ObservableObject {
         }
     }
     /// 直近に出力したレイアウトスナップショット
-    @Published var lastLoggedLayoutSnapshot: RootView.RootLayoutSnapshot?
+    /// - NOTE: `RootLayoutSnapshot` が `fileprivate` 扱いで定義されているため、
+    ///         アクセスレベルを合わせて `fileprivate` に揃え、ビルドエラーを避ける
+    @Published fileprivate var lastLoggedLayoutSnapshot: RootView.RootLayoutSnapshot?
     /// タイトル設定シートの表示状態
     @Published var isPresentingTitleSettings: Bool {
         didSet {


### PR DESCRIPTION
## Summary
- align the access level of the layout snapshot state with the fileprivate snapshot type to resolve the compiler error
- add a Japanese comment documenting the reasoning for the fileprivate state property

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68d39de01ab8832c913a5abc9c994afd