### PR TITLE
Fix access control for RootContentView factory

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -175,7 +175,9 @@ private extension RootView {
     /// RootView 本体の `body` から切り離したメソッドで、サブビュー生成ロジックを共通化する
     /// - Parameter layoutContext: GeometryReader から構築したレイアウト情報
     /// - Returns: 依存サービスや状態をバインディングした `RootContentView`
-    func makeRootContentView(with layoutContext: RootLayoutContext) -> RootContentView {
+    /// - Note: 戻り値である `RootContentView` が private 構造体であるため、
+    ///         アクセスレベルを private へ明示して Swift 6 のアクセス制御要件を満たす
+    private func makeRootContentView(with layoutContext: RootLayoutContext) -> RootContentView {
         RootContentView(
             theme: theme,
             layoutContext: layoutContext,


### PR DESCRIPTION
## Summary
- RootContentView を返すメソッドへ private 指定を追加し、Swift 6 のアクセス制御要件を満たす
- 戻り値の構造体が private である理由を日本語コメントで明示

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d39e1459b0832c8c1bb7afa83d56f2