### PR TITLE
Fix top bar preference key reference

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -703,8 +703,8 @@ fileprivate struct TopStatusInsetView: View {
         .background(
             GeometryReader { proxy in
                 Color.clear
-                    // ネストした PreferenceKey を明示的に参照し、ジェネリック推論エラーを回避する
-                    .preference(key: RootView.TopBarHeightPreferenceKey.self, value: proxy.size.height)
+                    // ファイルスコープで宣言した PreferenceKey を直接指定し、型推論を確実にする
+                    .preference(key: TopBarHeightPreferenceKey.self, value: proxy.size.height)
             }
         )
     }


### PR DESCRIPTION
## Summary
- fix the preference key reference in `TopStatusInsetView` so the generic type resolves correctly

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d39ee3f8ac832cb3b192b9d42ad0e1