### PR TITLE
Fix missing argument label in RootView

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -47,7 +47,7 @@ struct RootView: View {
 
     var body: some View {
         attachRootStateObservers(
-            GeometryReader { geometry in
+            to: GeometryReader { geometry in
                 // MARK: - GeometryReader が提供するサイズや safe area を専用コンテキストへまとめ、下層ビューへシンプルに引き渡す
                 let layoutContext = makeLayoutContext(from: geometry)
 


### PR DESCRIPTION
## Summary
- add the required `to:` argument label when calling `attachRootStateObservers`
- ensure the RootView body compiles correctly by matching the helper signature

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d39efc70b4832c82006ef5dd3e0a06