### PR TITLE
Fix TopBarHeightPreferenceKey reference usage

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -703,8 +703,8 @@ fileprivate struct TopStatusInsetView: View {
         .background(
             GeometryReader { proxy in
                 Color.clear
-                    // ネストした PreferenceKey を明示的に参照し、ジェネリック推論エラーを回避する
-                    .preference(key: RootView.TopBarHeightPreferenceKey.self, value: proxy.size.height)
+                    // 取得した高さを PreferenceKey へ伝達し、親ビューのレイアウト調整に利用する
+                    .preference(key: TopBarHeightPreferenceKey.self, value: proxy.size.height)
             }
         )
     }


### PR DESCRIPTION
## Summary
- update the preference assignment in `TopStatusInsetView` to use the existing top-level `TopBarHeightPreferenceKey`
- adjust the accompanying comment to describe the purpose of the preference update

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68d39ef3ab20832cb543203456649495