### PR TITLE
Refactor GameCore penalties into dedicated extension

### DIFF
--- a/Game/BoardTapPlayRequest.swift
+++ b/Game/BoardTapPlayRequest.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// 盤面タップでカードを再生するときに UI へ伝える要求内容
+/// - Note: SwiftUI 側でアニメーションを開始し、完了後に `playCard` を呼び出すための情報をまとめる
+public struct BoardTapPlayRequest: Identifiable, Equatable {
+    /// 要求ごとに一意な識別子を払い出して、複数回のタップでも確実に区別できるようにする
+    public let id: UUID
+    /// 盤面タップ時に対象となった手札スタックの識別子
+    public let stackID: UUID
+    /// `GameCore.playCard(at:)` に渡すスタックインデックス
+    public let stackIndex: Int
+    /// アニメーションで参照する先頭カード情報
+    public let topCard: DealtCard
+
+    /// UI 側で参照しやすいよう公開イニシャライザを用意
+    /// - Parameters:
+    ///   - id: 外部で識別子を指定したい場合に使用（省略時は自動採番）
+    ///   - stackID: 手札スタックの識別子
+    ///   - stackIndex: タップ時点でのスタック位置
+    ///   - topCard: 盤面タップと対応する先頭カード
+    public init(id: UUID = UUID(), stackID: UUID, stackIndex: Int, topCard: DealtCard) {
+        self.id = id
+        self.stackID = stackID
+        self.stackIndex = stackIndex
+        self.topCard = topCard
+    }
+
+    /// Equatable は識別子のみで比較し、カード更新が挟まってもリクエスト自体は同一とみなす
+    public static func == (lhs: BoardTapPlayRequest, rhs: BoardTapPlayRequest) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/Game/HandOrderingStrategy.swift
+++ b/Game/HandOrderingStrategy.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// 手札の並べ替え方法を管理するユーザー設定用の列挙体
+/// - Note: GameCore からも UI からも利用するためここで定義し、ビルドターゲット差異による読込漏れを防ぐ
+public enum HandOrderingStrategy: String, CaseIterable {
+    /// 山札から引いた順番をそのまま保持する従来方式
+    case insertionOrder
+    /// 移動方向に基づいて常にソートする方式
+    case directionSorted
+
+    /// UserDefaults / @AppStorage で共有するためのキー
+    public static let storageKey = "hand_ordering_strategy"
+
+    /// 設定画面などに表示する日本語名称
+    public var displayName: String {
+        switch self {
+        case .insertionOrder:
+            return "引いた順に並べる"
+        case .directionSorted:
+            return "移動方向で並べ替える"
+        }
+    }
+
+    /// 詳細説明文。フッター表示などで再利用する
+    public var detailDescription: String {
+        switch self {
+        case .insertionOrder:
+            return "山札から引いた順番で手札スロットへ補充します。消費した位置へ新しいカードが入ります。"
+        case .directionSorted:
+            return "左への移動量が大きいカードほど左側に、同じ左右移動量なら上方向へ進むカードを優先して並べます。"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move the hand ordering strategy enum and board tap play request struct into their own source files for reuse
- extract penalty, discard, and VoiceOver handling into a dedicated `GameCore` extension and add focused helpers to keep the core loop lean
- expose internal helpers so the penalty extension can rebuild hands while preserving the public API surface

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d3defce03c832c861a70580f8aeb8d