### PR TITLE
Support configurable board size in GameScene

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -135,7 +135,11 @@ struct GameView: View {
         _core = StateObject(wrappedValue: core)
 
         // GameScene は再利用したいのでローカルで準備し、最後に State プロパティへ格納する
-        let preparedScene = GameScene()
+        // モードに応じた盤面サイズ・初期訪問マスを指定して GameScene を生成し、サイズ変更時も中央が正しく選ばれるようにする
+        let preparedScene = GameScene(
+            initialBoardSize: mode.boardSize,
+            initialVisitedPoints: mode.initialVisitedPoints
+        )
         preparedScene.scaleMode = .resizeFill
         // GameScene から GameCore へタップイベントを伝えるため参照を渡す
         // StateObject へ格納した同一インスタンスを直接渡し、wrappedValue へ触れず安全に保持する


### PR DESCRIPTION
## Summary
- add stored configuration for initial board size and visited tiles in GameScene so different board sizes initialize correctly
- reuse the shared setup routine from new designated initializer and coder initializer to avoid hard-coded 5×5 assumptions
- create GameScene instances from GameView with the mode's board size and initial visited tiles to keep SpriteKit layout in sync

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68d3df023884832c934cc8ffc16868a6