### PR TITLE
Remove redundant fileprivate modifier in RootView overlay

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -447,7 +447,7 @@ private extension RootView {
 
     /// ゲーム開始前のローディング表示を担うオーバーレイビュー
     /// - NOTE: ZStack の最上位でフェード表示するため、背景のディミングやカード風ボックスをここで完結させる
-    fileprivate struct GamePreparationOverlayView: View {
+    struct GamePreparationOverlayView: View {
         /// テーマを利用してライト/ダーク両対応の配色を適用する
         private var theme = AppTheme()
 


### PR DESCRIPTION
## Summary
- remove the redundant `fileprivate` modifier from `GamePreparationOverlayView` since the surrounding extension is already private

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d3e670d2cc832c8a6b1bee0d1efe8a