### PR TITLE
Refactor ads service into coordinators

### DIFF
--- a/MonoKnightAppTests/AdsConsentCoordinatorTests.swift
+++ b/MonoKnightAppTests/AdsConsentCoordinatorTests.swift
@@ -1,0 +1,180 @@
+import SwiftUI
+import UIKit
+import Testing
+import UserMessagingPlatform
+@testable import MonoKnightApp
+
+// MARK: - スタブ定義
+@MainActor
+private final class StubAdsConsentEnvironment: AdsConsentEnvironment {
+    /// UMP 側の consentStatus をテストから書き換えやすく保持
+    var consentStatus: ConsentStatus = .unknown
+    /// フォームの利用可否をテストシナリオ毎に指定
+    var formStatus: FormStatus = .unknown
+    /// canRequestAds を外部から操作し、ロード条件を切り替える
+    var canRequestAds: Bool = false
+    /// requestConsentInfoUpdate が呼ばれた回数
+    private(set) var requestUpdateCallCount: Int = 0
+    /// loadConsentFormPresenter が呼ばれた回数
+    private(set) var loadFormCallCount: Int = 0
+    /// makePrivacyOptionsPresenter が呼ばれた回数
+    private(set) var makePrivacyOptionsCallCount: Int = 0
+
+    /// 更新時に追加で実行したい処理（例: consentStatus の差し替え）
+    var requestUpdateHandler: (() -> Void)?
+    /// フォーム表示用クロージャを差し替えるためのプロパティ
+    var presenterFactory: (() -> ConsentFormPresenter)?
+    /// プライバシーオプション表示用クロージャを差し替えるためのプロパティ
+    var privacyPresenterFactory: (() -> PrivacyOptionsPresenter)?
+
+    func requestConsentInfoUpdate(with parameters: RequestParameters) async throws {
+        requestUpdateCallCount += 1
+        requestUpdateHandler?()
+    }
+
+    func loadConsentFormPresenter() async throws -> ConsentFormPresenter {
+        loadFormCallCount += 1
+        if let presenterFactory {
+            return presenterFactory()
+        }
+        return { _, completion in completion(nil) }
+    }
+
+    func makePrivacyOptionsPresenter() -> PrivacyOptionsPresenter {
+        makePrivacyOptionsCallCount += 1
+        if let privacyPresenterFactory {
+            return privacyPresenterFactory()
+        }
+        return { _, completion in completion(nil) }
+    }
+}
+
+@MainActor
+private final class StubConsentPresentationDelegate: AdsConsentCoordinatorPresenting {
+    /// 同意フォーム表示要求の回数
+    private(set) var presentConsentFormCallCount: Int = 0
+    /// プライバシーオプション表示要求の回数
+    private(set) var presentPrivacyOptionsCallCount: Int = 0
+    /// 直近で受け取った presenter（検証用）
+    private(set) var lastConsentPresenter: ConsentFormPresenter?
+    /// 直近で受け取ったプライバシー presenter
+    private(set) var lastPrivacyPresenter: PrivacyOptionsPresenter?
+
+    func presentConsentForm(using presenter: @escaping ConsentFormPresenter) async throws {
+        presentConsentFormCallCount += 1
+        lastConsentPresenter = presenter
+        presenter(UIViewController()) { _ in }
+    }
+
+    func presentPrivacyOptions(using presenter: @escaping PrivacyOptionsPresenter) async throws {
+        presentPrivacyOptionsCallCount += 1
+        lastPrivacyPresenter = presenter
+        presenter(UIViewController()) { _ in }
+    }
+}
+
+@MainActor
+private final class StubConsentStateDelegate: AdsConsentCoordinatorStateDelegate {
+    /// 状態更新の履歴（shouldReload フラグも保持）
+    private(set) var recordedStates: [(state: AdsConsentState, shouldReload: Bool)] = []
+
+    func adsConsentCoordinator(_ coordinator: AdsConsentCoordinating, didUpdate state: AdsConsentState, shouldReloadAds: Bool) {
+        recordedStates.append((state, shouldReloadAds))
+    }
+}
+
+// MARK: - テスト本体
+struct AdsConsentCoordinatorTests {
+    /// requestConsentIfNeeded が必須同意の際にフォームを表示し、最終的に NPA フラグが false へ戻ることを検証
+    @MainActor
+    @Test func requestConsentIfNeeded_showsFormWhenRequired() async throws {
+        UserDefaults.standard.removeObject(forKey: "ads_should_use_npa")
+
+        let environment = StubAdsConsentEnvironment()
+        environment.consentStatus = .required
+        environment.formStatus = .available
+        environment.canRequestAds = false
+        environment.requestUpdateHandler = {
+            environment.canRequestAds = true
+        }
+        environment.presenterFactory = {
+            return { _, completion in
+                environment.consentStatus = .obtained
+                environment.canRequestAds = true
+                completion(nil)
+            }
+        }
+
+        let presenter = StubConsentPresentationDelegate()
+        let stateDelegate = StubConsentStateDelegate()
+        let coordinator = AdsConsentCoordinator(hasValidAdConfiguration: true, environment: environment)
+        coordinator.presentationDelegate = presenter
+        coordinator.stateDelegate = stateDelegate
+
+        await coordinator.requestConsentIfNeeded()
+
+        #expect(environment.requestUpdateCallCount == 1)
+        #expect(environment.loadFormCallCount == 1)
+        #expect(presenter.presentConsentFormCallCount == 1)
+        #expect(stateDelegate.recordedStates.count >= 2)
+
+        if let last = stateDelegate.recordedStates.last {
+            #expect(last.state.shouldUseNPA == false)
+            #expect(last.state.canRequestAds == true)
+        }
+        #expect(UserDefaults.standard.bool(forKey: "ads_should_use_npa") == false)
+    }
+
+    /// refreshConsentStatus がプライバシーオプション表示を要求することを確認
+    @MainActor
+    @Test func refreshConsentStatus_showsPrivacyOptions() async throws {
+        UserDefaults.standard.removeObject(forKey: "ads_should_use_npa")
+
+        let environment = StubAdsConsentEnvironment()
+        environment.consentStatus = .obtained
+        environment.formStatus = .available
+        environment.canRequestAds = true
+        environment.privacyPresenterFactory = {
+            return { _, completion in
+                environment.consentStatus = .required
+                environment.canRequestAds = false
+                completion(nil)
+            }
+        }
+
+        let presenter = StubConsentPresentationDelegate()
+        let stateDelegate = StubConsentStateDelegate()
+        let coordinator = AdsConsentCoordinator(hasValidAdConfiguration: true, environment: environment)
+        coordinator.presentationDelegate = presenter
+        coordinator.stateDelegate = stateDelegate
+
+        await coordinator.refreshConsentStatus()
+
+        #expect(environment.requestUpdateCallCount == 1)
+        #expect(environment.makePrivacyOptionsCallCount == 1)
+        #expect(presenter.presentPrivacyOptionsCallCount == 1)
+        #expect(!stateDelegate.recordedStates.isEmpty)
+    }
+
+    /// Info.plist の設定が不完全な場合、環境側の処理が呼ばれないことを保証
+    @MainActor
+    @Test func coordinator_skipsOperations_whenConfigurationIsInvalid() async throws {
+        let environment = StubAdsConsentEnvironment()
+        let presenter = StubConsentPresentationDelegate()
+        let stateDelegate = StubConsentStateDelegate()
+        let coordinator = AdsConsentCoordinator(hasValidAdConfiguration: false, environment: environment)
+        coordinator.presentationDelegate = presenter
+        coordinator.stateDelegate = stateDelegate
+
+        await coordinator.requestConsentIfNeeded()
+        await coordinator.refreshConsentStatus()
+        await coordinator.synchronizeOnLaunch()
+
+        #expect(environment.requestUpdateCallCount == 0)
+        #expect(environment.loadFormCallCount == 0)
+        #expect(environment.makePrivacyOptionsCallCount == 0)
+        #expect(presenter.presentConsentFormCallCount == 0)
+        #expect(presenter.presentPrivacyOptionsCallCount == 0)
+        #expect(stateDelegate.recordedStates.isEmpty)
+    }
+}

--- a/MonoKnightAppTests/AdsServiceCoordinatorIntegrationTests.swift
+++ b/MonoKnightAppTests/AdsServiceCoordinatorIntegrationTests.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import Testing
+import GoogleMobileAds
+
+@testable import MonoKnightApp
+
+// MARK: - スタブ群
+@MainActor
+private final class StubAdsConsentCoordinator: AdsConsentCoordinating {
+    var presentationDelegate: AdsConsentCoordinatorPresenting?
+    var stateDelegate: AdsConsentCoordinatorStateDelegate?
+    var currentState: AdsConsentState = AdsConsentState(shouldUseNPA: false, canRequestAds: false)
+
+    private(set) var synchronizeCallCount: Int = 0
+    private(set) var requestCallCount: Int = 0
+    private(set) var refreshCallCount: Int = 0
+
+    func synchronizeOnLaunch() async {
+        synchronizeCallCount += 1
+    }
+
+    func requestConsentIfNeeded() async {
+        requestCallCount += 1
+    }
+
+    func refreshConsentStatus() async {
+        refreshCallCount += 1
+    }
+}
+
+@MainActor
+private final class StubInterstitialAdController: InterstitialAdControlling {
+    var delegate: InterstitialAdControllerDelegate?
+    var areAdsDisabled: Bool = false
+
+    private(set) var beginInitialLoadCallCount: Int = 0
+    private(set) var showCallCount: Int = 0
+    private(set) var resetCallCount: Int = 0
+    private(set) var disableCallCount: Int = 0
+    private(set) var receivedConsentUpdates: [(AdsConsentState, Bool)] = []
+    private(set) var removeAdsProvider: (() -> Bool)?
+
+    func beginInitialLoad() {
+        beginInitialLoadCallCount += 1
+    }
+
+    func showInterstitial() {
+        showCallCount += 1
+    }
+
+    func resetPlayFlag() {
+        resetCallCount += 1
+    }
+
+    func disableAds() {
+        disableCallCount += 1
+        areAdsDisabled = true
+    }
+
+    func updateRemoveAdsProvider(_ provider: @escaping () -> Bool) {
+        removeAdsProvider = provider
+    }
+
+    func adsConsentCoordinator(_ coordinator: AdsConsentCoordinating, didUpdate state: AdsConsentState, shouldReloadAds: Bool) {
+        receivedConsentUpdates.append((state, shouldReloadAds))
+    }
+
+    // FullScreenContentDelegate 要件（テストでは利用しないため空実装）
+    func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {}
+    func adWillPresentFullScreenContent(_ ad: FullScreenPresentingAd) {}
+    func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {}
+}
+
+private final class StubMobileAdsController: MobileAdsControlling {
+    private(set) var startCallCount: Int = 0
+
+    func start(completion: @escaping () -> Void) {
+        startCallCount += 1
+        completion()
+    }
+}
+
+// MARK: - テスト本体
+struct AdsServiceCoordinatorIntegrationTests {
+    /// AdsService が依存注入された協調クラスへ処理を委譲していることを確認
+    @MainActor
+    @Test func adsService_delegatesToInjectedComponents() async throws {
+        UserDefaults.standard.removeObject(forKey: "remove_ads_mk")
+        UserDefaults.standard.removeObject(forKey: "ads_should_use_npa")
+
+        let consent = StubAdsConsentCoordinator()
+        let interstitial = StubInterstitialAdController()
+        let mobileAds = StubMobileAdsController()
+        let configuration = AdsServiceConfiguration(interstitialAdUnitID: "test", hasValidAdConfiguration: true)
+
+        let service = AdsService(
+            configuration: configuration,
+            consentCoordinator: consent,
+            interstitialController: interstitial,
+            mobileAdsController: mobileAds
+        )
+
+        // 非同期タスクが実行される猶予を与える
+        await Task.yield()
+        await Task.yield()
+
+        #expect(mobileAds.startCallCount == 1)
+        #expect(interstitial.beginInitialLoadCallCount == 1)
+        #expect(consent.synchronizeCallCount == 1)
+        #expect((consent.presentationDelegate as AnyObject?) === service)
+        #expect(consent.stateDelegate === interstitial)
+
+        await service.requestConsentIfNeeded()
+        await service.refreshConsentStatus()
+        service.showInterstitial()
+        service.resetPlayFlag()
+        service.disableAds()
+
+        #expect(consent.requestCallCount == 1)
+        #expect(consent.refreshCallCount == 1)
+        #expect(interstitial.showCallCount == 1)
+        #expect(interstitial.resetCallCount == 1)
+        #expect(interstitial.disableCallCount == 1)
+    }
+}

--- a/MonoKnightAppTests/InterstitialAdControllerTests.swift
+++ b/MonoKnightAppTests/InterstitialAdControllerTests.swift
@@ -1,0 +1,135 @@
+import UIKit
+import Testing
+import GoogleMobileAds
+
+@testable import MonoKnightApp
+
+// MARK: - テスト用スタブ
+@MainActor
+private final class DummyAdsConsentCoordinator: AdsConsentCoordinating {
+    var presentationDelegate: AdsConsentCoordinatorPresenting?
+    var stateDelegate: AdsConsentCoordinatorStateDelegate?
+    var currentState: AdsConsentState = AdsConsentState(shouldUseNPA: false, canRequestAds: false)
+
+    func synchronizeOnLaunch() async {}
+    func requestConsentIfNeeded() async {}
+    func refreshConsentStatus() async {}
+}
+
+@MainActor
+private final class StubInterstitialAdLoader: InterstitialAdLoading {
+    /// load 呼び出し回数
+    private(set) var loadCallCount: Int = 0
+    /// 直近の completion を保持し、任意タイミングで結果を差し込めるようにする
+    private(set) var lastCompletion: ((InterstitialAdPresentable?, Error?) -> Void)?
+    /// 直近のリクエスト内容（NPA 判定検証用）
+    private(set) var capturedRequests: [GoogleMobileAds.Request] = []
+
+    func load(adUnitID: String, request: GoogleMobileAds.Request, completion: @escaping (InterstitialAdPresentable?, Error?) -> Void) {
+        loadCallCount += 1
+        capturedRequests.append(request)
+        lastCompletion = completion
+    }
+}
+
+@MainActor
+private final class StubInterstitialAd: InterstitialAdPresentable {
+    var fullScreenContentDelegate: FullScreenContentDelegate?
+    /// present が呼ばれた回数
+    private(set) var presentCallCount: Int = 0
+
+    func present(from viewController: UIViewController) {
+        presentCallCount += 1
+        fullScreenContentDelegate?.adWillPresentFullScreenContent(self)
+    }
+}
+
+@MainActor
+private final class StubInterstitialDelegate: InterstitialAdControllerDelegate {
+    var rootViewController: UIViewController? = UIViewController()
+    /// Root VC 取得の呼び出し回数
+    private(set) var rootRequestCount: Int = 0
+    /// ハプティクス要求回数
+    private(set) var hapticCallCount: Int = 0
+
+    func rootViewControllerForPresentation(_ controller: InterstitialAdControlling) -> UIViewController? {
+        rootRequestCount += 1
+        return rootViewController
+    }
+
+    func interstitialAdControllerShouldPlayWarningHaptic(_ controller: InterstitialAdControlling) {
+        hapticCallCount += 1
+    }
+}
+
+// MARK: - テスト本体
+struct InterstitialAdControllerTests {
+    /// 初期ロードが行われ、showInterstitial で広告が表示されることを確認
+    @MainActor
+    @Test func beginInitialLoad_andShowInterstitial_presentAd() async throws {
+        let loader = StubInterstitialAdLoader()
+        let controller = InterstitialAdController(
+            adUnitID: "test",
+            hasValidAdConfiguration: true,
+            initialConsentState: AdsConsentState(shouldUseNPA: false, canRequestAds: true),
+            loader: loader,
+            retryDelay: 0,
+            minimumInterval: 0
+        )
+        let delegate = StubInterstitialDelegate()
+        controller.delegate = delegate
+
+        controller.beginInitialLoad()
+        #expect(loader.loadCallCount == 1)
+        let ad = StubInterstitialAd()
+        loader.lastCompletion?(ad, nil)
+        #expect(loader.capturedRequests.count == 1)
+
+        controller.showInterstitial()
+        #expect(ad.presentCallCount == 1)
+        #expect(delegate.hapticCallCount == 1)
+    }
+
+    /// 同意状態の更新で shouldReload が true の場合に再読込が走ることを検証
+    @MainActor
+    @Test func consentUpdate_withReloadForcesNewLoad() async throws {
+        let loader = StubInterstitialAdLoader()
+        let controller = InterstitialAdController(
+            adUnitID: "test",
+            hasValidAdConfiguration: true,
+            initialConsentState: AdsConsentState(shouldUseNPA: false, canRequestAds: true),
+            loader: loader,
+            retryDelay: 0,
+            minimumInterval: 0
+        )
+        controller.delegate = StubInterstitialDelegate()
+
+        controller.beginInitialLoad()
+        #expect(loader.loadCallCount == 1)
+
+        controller.adsConsentCoordinator(DummyAdsConsentCoordinator(), didUpdate: AdsConsentState(shouldUseNPA: true, canRequestAds: true), shouldReloadAds: true)
+        #expect(loader.loadCallCount == 2)
+    }
+
+    /// disableAds 後は表示要求が無視されることを確認
+    @MainActor
+    @Test func disableAds_blocksPresentation() async throws {
+        let loader = StubInterstitialAdLoader()
+        let controller = InterstitialAdController(
+            adUnitID: "test",
+            hasValidAdConfiguration: true,
+            initialConsentState: AdsConsentState(shouldUseNPA: false, canRequestAds: true),
+            loader: loader,
+            retryDelay: 0,
+            minimumInterval: 0
+        )
+        let delegate = StubInterstitialDelegate()
+        controller.delegate = delegate
+
+        controller.disableAds()
+        controller.beginInitialLoad()
+        #expect(loader.loadCallCount == 0)
+        controller.showInterstitial()
+        #expect(delegate.hapticCallCount == 0)
+    }
+}

--- a/Services/AdsConsentCoordinator.swift
+++ b/Services/AdsConsentCoordinator.swift
@@ -1,0 +1,258 @@
+import Foundation
+import SwiftUI
+import UIKit
+import UserMessagingPlatform
+
+// MARK: - 同意状態の表現
+/// UMP の情報を中継しつつアプリ側で扱いやすいようにした構造体
+/// - Note: `shouldUseNPA` は広告リクエストへ直結するため、テストからも直接参照できるようプロパティとして公開している
+struct AdsConsentState {
+    /// 非パーソナライズ広告を要求すべきかどうか
+    let shouldUseNPA: Bool
+    /// Google Mobile Ads へ広告リクエストを送ってよい状態か
+    let canRequestAds: Bool
+}
+
+/// 同意フォーム表示用クロージャの型定義
+/// - Parameter viewController: 表示に利用する最前面の ViewController
+/// - Parameter completion: 表示完了後に UMP から渡されるエラー（成功時は `nil`）
+typealias ConsentFormPresenter = (_ viewController: UIViewController, _ completion: @escaping (Error?) -> Void) -> Void
+
+/// プライバシーオプション表示用クロージャの型定義
+typealias PrivacyOptionsPresenter = (_ viewController: UIViewController, _ completion: @escaping (Error?) -> Void) -> Void
+
+// MARK: - プロトコル定義
+/// AdsConsentCoordinator が UI へ委譲する際のプレゼンター
+@MainActor
+protocol AdsConsentCoordinatorPresenting: AnyObject {
+    /// UMP の同意フォームを提示するためのクロージャを受け取り、UI 表示を担う
+    func presentConsentForm(using presenter: @escaping ConsentFormPresenter) async throws
+    /// UMP の Privacy Options を提示するためのクロージャを受け取り、UI 表示を担う
+    func presentPrivacyOptions(using presenter: @escaping PrivacyOptionsPresenter) async throws
+}
+
+/// 同意状況の変化を受け取るデリゲート
+@MainActor
+protocol AdsConsentCoordinatorStateDelegate: AnyObject {
+    /// shouldUseNPA や canRequestAds の更新結果を通知し、必要に応じて広告キャッシュの更新を促す
+    func adsConsentCoordinator(_ coordinator: AdsConsentCoordinating, didUpdate state: AdsConsentState, shouldReloadAds: Bool)
+}
+
+/// 同意周りの処理を提供するプロトコル
+@MainActor
+protocol AdsConsentCoordinating: AnyObject {
+    var presentationDelegate: AdsConsentCoordinatorPresenting? { get set }
+    var stateDelegate: AdsConsentCoordinatorStateDelegate? { get set }
+    var currentState: AdsConsentState { get }
+
+    func synchronizeOnLaunch() async
+    func requestConsentIfNeeded() async
+    func refreshConsentStatus() async
+}
+
+/// UMP SDK の操作を抽象化した環境依存プロトコル
+@MainActor
+protocol AdsConsentEnvironment: AnyObject {
+    var consentStatus: ConsentStatus { get }
+    var formStatus: FormStatus { get }
+    var canRequestAds: Bool { get }
+
+    func requestConsentInfoUpdate(with parameters: RequestParameters) async throws
+    func loadConsentFormPresenter() async throws -> ConsentFormPresenter
+    func makePrivacyOptionsPresenter() -> PrivacyOptionsPresenter
+}
+
+// MARK: - デフォルト環境
+/// 実機動作用に UMP SDK を直接呼び出す実装
+@MainActor
+final class DefaultAdsConsentEnvironment: AdsConsentEnvironment {
+    func requestConsentInfoUpdate(with parameters: RequestParameters) async throws {
+        let consentInfo = ConsentInformation.shared
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            consentInfo.requestConsentInfoUpdate(with: parameters) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+
+    var consentStatus: ConsentStatus {
+        ConsentInformation.shared.consentStatus
+    }
+
+    var formStatus: FormStatus {
+        ConsentInformation.shared.formStatus
+    }
+
+    var canRequestAds: Bool {
+        ConsentInformation.shared.canRequestAds
+    }
+
+    func loadConsentFormPresenter() async throws -> ConsentFormPresenter {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<ConsentFormPresenter, Error>) in
+            ConsentForm.load { form, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+
+                guard let form else {
+                    let unexpected = NSError(
+                        domain: "MonoKnight.AdsConsentCoordinator",
+                        code: -10,
+                        userInfo: [NSLocalizedDescriptionKey: "同意フォームが取得できませんでした"]
+                    )
+                    continuation.resume(throwing: unexpected)
+                    return
+                }
+
+                // presenter 内で強参照が残り続けると二重表示の原因になるため、ローカル変数で管理しておく
+                var storedForm: ConsentForm? = form
+                let presenter: ConsentFormPresenter = { viewController, completion in
+                    guard let storedForm else {
+                        let error = NSError(
+                            domain: "MonoKnight.AdsConsentCoordinator",
+                            code: -11,
+                            userInfo: [NSLocalizedDescriptionKey: "同意フォームが破棄済みのため再表示できません"]
+                        )
+                        completion(error)
+                        return
+                    }
+                    storedForm.present(from: viewController) { error in
+                        storedForm = nil
+                        completion(error)
+                    }
+                }
+                continuation.resume(returning: presenter)
+            }
+        }
+    }
+
+    func makePrivacyOptionsPresenter() -> PrivacyOptionsPresenter {
+        return { viewController, completion in
+            ConsentForm.presentPrivacyOptionsForm(from: viewController) { error in
+                completion(error)
+            }
+        }
+    }
+}
+
+// MARK: - Coordinator 本体
+@MainActor
+final class AdsConsentCoordinator: AdsConsentCoordinating {
+    weak var presentationDelegate: AdsConsentCoordinatorPresenting?
+    weak var stateDelegate: AdsConsentCoordinatorStateDelegate?
+
+    /// UMP の処理を抽象化した環境
+    private let environment: AdsConsentEnvironment
+    /// Info.plist に必要な値が揃っているかどうか
+    private let hasValidAdConfiguration: Bool
+    /// AppStorage 経由で NPA 判定を永続化する
+    @AppStorage("ads_should_use_npa") private var shouldUseNPA: Bool = false
+
+    init(hasValidAdConfiguration: Bool, environment: AdsConsentEnvironment = DefaultAdsConsentEnvironment()) {
+        self.hasValidAdConfiguration = hasValidAdConfiguration
+        self.environment = environment
+    }
+
+    var currentState: AdsConsentState {
+        AdsConsentState(shouldUseNPA: shouldUseNPA, canRequestAds: environment.canRequestAds)
+    }
+
+    func synchronizeOnLaunch() async {
+        guard hasValidAdConfiguration else { return }
+
+        do {
+            await MainActor.run {
+                debugLog("アプリ起動直後の UMP 同意情報を同期します")
+            }
+            try await requestConsentUpdateAndNotify()
+        } catch {
+            await MainActor.run {
+                debugError(error, message: "起動時の UMP 同期に失敗")
+            }
+        }
+    }
+
+    func requestConsentIfNeeded() async {
+        guard hasValidAdConfiguration else { return }
+
+        do {
+            debugLog("Google UMP の同意取得フローを開始します")
+            try await requestConsentUpdateAndNotify()
+
+            guard environment.formStatus == .available else { return }
+
+            let presenter = try await environment.loadConsentFormPresenter()
+            if environment.consentStatus == .required || environment.consentStatus == .unknown {
+                try await presentationDelegate?.presentConsentForm(using: presenter)
+                applyConsentStatusAndNotify()
+            }
+            debugLog("Google UMP の同意取得フローが完了しました (status: \(String(describing: environment.consentStatus)))")
+        } catch {
+            debugError(error, message: "Google UMP の同意取得に失敗")
+        }
+    }
+
+    func refreshConsentStatus() async {
+        guard hasValidAdConfiguration else { return }
+
+        do {
+            debugLog("Google UMP の同意ステータス更新を開始します")
+            try await requestConsentUpdateAndNotify()
+
+            guard environment.formStatus == .available else { return }
+
+            let presenter = environment.makePrivacyOptionsPresenter()
+            try await presentationDelegate?.presentPrivacyOptions(using: presenter)
+            applyConsentStatusAndNotify()
+            debugLog("Google UMP の同意ステータス更新が完了しました (status: \(String(describing: environment.consentStatus)))")
+        } catch {
+            debugError(error, message: "Google UMP の同意状態更新に失敗")
+        }
+    }
+
+    /// DEBUG/リリース共通で ConsentInformation の更新と通知まで行う共通処理
+    private func requestConsentUpdateAndNotify() async throws {
+        let parameters = makeRequestParameters()
+        try await environment.requestConsentInfoUpdate(with: parameters)
+        applyConsentStatusAndNotify()
+    }
+
+    /// UMP の結果に応じて shouldUseNPA を更新し、デリゲートへ状態を伝える
+    @discardableResult
+    private func applyConsentStatusAndNotify() -> AdsConsentState {
+        let newShouldUseNPA: Bool
+        switch environment.consentStatus {
+        case .obtained, .notRequired:
+            newShouldUseNPA = false
+        default:
+            newShouldUseNPA = true
+        }
+
+        let hasChanged = newShouldUseNPA != shouldUseNPA
+        shouldUseNPA = newShouldUseNPA
+
+        let state = AdsConsentState(shouldUseNPA: newShouldUseNPA, canRequestAds: environment.canRequestAds)
+        stateDelegate?.adsConsentCoordinator(self, didUpdate: state, shouldReloadAds: hasChanged)
+        debugLog("UMP の同意結果を反映しました (shouldUseNPA: \(newShouldUseNPA), canRequestAds: \(state.canRequestAds))")
+        return state
+    }
+
+    /// RequestParameters を生成するヘルパー
+    private func makeRequestParameters() -> RequestParameters {
+        let parameters = RequestParameters()
+        parameters.tagForUnderAgeOfConsent = false
+
+        #if DEBUG
+        let debugSettings = DebugSettings()
+        debugSettings.geography = .EEA
+        parameters.debugSettings = debugSettings
+        #endif
+
+        return parameters
+    }
+}

--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -1,9 +1,8 @@
 import Foundation
-import UIKit
 import SwiftUI
+import UIKit
 import AppTrackingTransparency
 import GoogleMobileAds
-import UserMessagingPlatform
 // ログ出力ユーティリティを利用するため Game モジュールを読み込む
 import Game
 
@@ -19,9 +18,28 @@ protocol AdsServiceProtocol: AnyObject {
     func refreshConsentStatus() async
 }
 
+// MARK: - 補助的な依存関係
+/// Google Mobile Ads SDK の初期化処理を差し替えやすくするためのプロトコル
+protocol MobileAdsControlling {
+    func start(completion: @escaping () -> Void)
+}
+
+/// 実機用の初期化ラッパー
+struct DefaultMobileAdsController: MobileAdsControlling {
+    func start(completion: @escaping () -> Void) {
+        MobileAds.shared.start { _ in completion() }
+    }
+}
+
+/// Info.plist 由来の設定値をまとめる構造体
+struct AdsServiceConfiguration {
+    let interstitialAdUnitID: String
+    let hasValidAdConfiguration: Bool
+}
+
 // MARK: - Google Mobile Ads 実装
 @MainActor
-final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScreenContentDelegate {
+final class AdsService: NSObject, ObservableObject, AdsServiceProtocol {
     /// Info.plist に定義するキー名をまとめる
     private enum InfoPlistKey {
         static let applicationIdentifier = "GADApplicationIdentifier"
@@ -33,37 +51,107 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
 
     @AppStorage("remove_ads_mk") private var removeAdsMK: Bool = false
     @AppStorage("haptics_enabled") private var hapticsEnabled: Bool = true
-    /// UMP の同意結果から非パーソナライズ広告を求めるかどうか
-    @AppStorage("ads_should_use_npa") private var shouldUseNPA: Bool = false
 
-    /// インタースティシャル広告のキャッシュ
-    private var interstitial: InterstitialAd?
-    /// 直近に広告を表示した日時（頻度制御用）
-    private var lastInterstitialDate: Date?
-    /// 1プレイ1回の制御フラグ
-    private var hasShownInCurrentPlay: Bool = false
-    /// 重複読み込みを避けるためのフラグ
-    private var isLoadingAd: Bool = false
-    /// 広告表示要求を受けたものの未ロードだった場合に備え、再読み込み完了後に自動表示するためのフラグ
-    private var isWaitingForPresentation: Bool = false
-    /// リトライを後続に送るための Task
-    private var retryTask: Task<Void, Never>?
-    /// 広告自体を停止するフラグ（IAP などで利用）
-    private var adsDisabled: Bool = false
-    /// UMP の同意フォームを保持する参照
-    private var consentForm: ConsentForm?
+    private let consentCoordinator: AdsConsentCoordinating
+    private let interstitialController: InterstitialAdControlling
+    private let mobileAdsController: MobileAdsControlling
+    private let configuration: AdsServiceConfiguration
 
-    /// Info.plist から読み取ったインタースティシャル広告ユニット ID（空文字ならロードしない）
-    private let interstitialAdUnitID: String
-    /// アプリ ID と広告ユニット ID が両方揃っているかどうか
-    private let hasValidAdConfiguration: Bool
+    /// 生成直後に依存関係を注入できるよう DI 対応したイニシャライザを用意する
+    init(
+        configuration: AdsServiceConfiguration? = nil,
+        consentCoordinator: AdsConsentCoordinating? = nil,
+        interstitialController: InterstitialAdControlling? = nil,
+        mobileAdsController: MobileAdsControlling = DefaultMobileAdsController()
+    ) {
+        let resolvedConfiguration = configuration ?? AdsService.makeConfiguration()
+        let resolvedConsentCoordinator = consentCoordinator ?? AdsConsentCoordinator(
+            hasValidAdConfiguration: resolvedConfiguration.hasValidAdConfiguration
+        )
+        let resolvedInterstitialController = interstitialController ?? InterstitialAdController(
+            adUnitID: resolvedConfiguration.interstitialAdUnitID,
+            hasValidAdConfiguration: resolvedConfiguration.hasValidAdConfiguration,
+            initialConsentState: resolvedConsentCoordinator.currentState
+        )
 
-    /// 失敗時に再読み込みを試みるまでの秒数
-    private let retryDelay: TimeInterval = 30
-    /// インタースティシャル広告の最低表示間隔（秒単位で 5 分を指定）
-    private let minimumInterstitialInterval: TimeInterval = 300
+        self.configuration = resolvedConfiguration
+        self.consentCoordinator = resolvedConsentCoordinator
+        self.interstitialController = resolvedInterstitialController
+        self.mobileAdsController = mobileAdsController
+        super.init()
 
-    private override init() {
+        // デリゲートを接続して UI 連携と状態同期を AdsService 側で担う
+        self.interstitialController.delegate = self
+        self.interstitialController.updateRemoveAdsProvider { [weak self] in
+            self?.removeAdsMK ?? false
+        }
+        self.consentCoordinator.presentationDelegate = self
+        self.consentCoordinator.stateDelegate = self.interstitialController
+
+        // IAP による広告除去が永続化されている場合は、初期化直後から広告のロードを完全に停止する
+        if removeAdsMK {
+            self.interstitialController.disableAds()
+            debugLog("広告除去オプションが有効なため AdMob SDK のロード処理をスキップします")
+        }
+
+        guard self.configuration.hasValidAdConfiguration else { return }
+        guard !self.interstitialController.areAdsDisabled else { return }
+
+        // SDK 初期化。v11 以降では `GADMobileAds` が `MobileAds` に改名されたため、shared プロパティから最新 API を取得する。
+        // （名称変更に追従しつつ、将来的な API 差分を把握しやすくする意図で明示的にコメントを残している）
+        mobileAdsController.start { [weak self] in
+            guard let self else { return }
+            debugLog("Google Mobile Ads SDK の初期化が完了しました")
+        }
+
+        // 初期化直後から広告読み込みを開始（非同期で走らせる）
+        Task { [weak self] in
+            await self?.interstitialController.beginInitialLoad()
+        }
+
+        // 起動直後は UMP の同意情報と shouldUseNPA の値がずれている恐れがあるため、明示的に同期処理を差し込む
+        Task { [weak self] in
+            await self?.consentCoordinator.synchronizeOnLaunch()
+        }
+    }
+
+    /// シングルトン利用時は Info.plist から設定を取得する
+    private override convenience init() {
+        self.init(
+            configuration: nil,
+            consentCoordinator: nil,
+            interstitialController: nil,
+            mobileAdsController: DefaultMobileAdsController()
+        )
+    }
+
+    func showInterstitial() {
+        interstitialController.showInterstitial()
+    }
+
+    func resetPlayFlag() {
+        interstitialController.resetPlayFlag()
+    }
+
+    func disableAds() {
+        interstitialController.disableAds()
+    }
+
+    func requestTrackingAuthorization() async {
+        guard ATTrackingManager.trackingAuthorizationStatus == .notDetermined else { return }
+        _ = await ATTrackingManager.requestTrackingAuthorization()
+    }
+
+    func requestConsentIfNeeded() async {
+        await consentCoordinator.requestConsentIfNeeded()
+    }
+
+    func refreshConsentStatus() async {
+        await consentCoordinator.refreshConsentStatus()
+    }
+
+    /// Info.plist を読み取り、広告設定が揃っているかどうかを返す
+    private static func makeConfiguration() -> AdsServiceConfiguration {
         let applicationIdentifier = (Bundle.main.object(forInfoDictionaryKey: InfoPlistKey.applicationIdentifier) as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if applicationIdentifier.isEmpty {
@@ -76,424 +164,15 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol, FullScre
             assertionFailure("Info.plist に GADInterstitialAdUnitID が設定されていません。Config/Local.xcconfig で本番値を指定してください。")
         }
 
-        self.interstitialAdUnitID = interstitialIdentifier
-        self.hasValidAdConfiguration = !applicationIdentifier.isEmpty && !interstitialIdentifier.isEmpty
-        super.init()
-
-        // IAP による広告除去が永続化されている場合は、初期化直後から広告のロードを完全に停止する
-        if removeAdsMK {
-            adsDisabled = true
-            debugLog("広告除去オプションが有効なため AdMob SDK のロード処理をスキップします")
-        }
-
-        guard hasValidAdConfiguration else { return }
-        guard !adsDisabled else { return }
-
-        // SDK 初期化。v11 以降では `GADMobileAds` が `MobileAds` に改名されたため、shared プロパティから最新 API を取得する。
-        // （名称変更に追従しつつ、将来的な API 差分を把握しやすくする意図で明示的にコメントを残している）
-        let mobileAds = MobileAds.shared
-
-        // シミュレータでは Info.plist 側でテスト広告用のユニット ID を設定して動作確認する運用とし、
-        // ここでは SDK の定数や動的判定に依存したテストデバイス登録を行わない。
-        // 将来的に `GADSimulatorID` などのシンボル変更でビルドエラーになるリスクを避ける目的。
-
-        // Swift 6 では completionHandler に nil を渡すと型推論ができずビルドエラーになるため、
-        // ここでは何もしない空クロージャを渡して初期化を完了させる。
-        mobileAds.start { _ in
-            // 現時点では初期化結果を利用しないが、将来的にログ出力やイベント送信を追加できるよう空実装としておく。
-            debugLog("Google Mobile Ads SDK の初期化が完了しました")
-        }
-
-        // 初期化直後から広告読み込みを開始（非同期で走らせる）
-        Task { [weak self] in
-            await MainActor.run { self?.loadInterstitial() }
-        }
-
-        // 起動直後は UMP の同意情報と shouldUseNPA の値がずれている恐れがあるため、明示的に同期処理を差し込む
-        Task { [weak self] in
-            guard let self else { return }
-            do {
-                await MainActor.run {
-                    // アプリ起動タイミングで最新の同意状況を必ず取得しておき、ログからも同期のタイミングを追跡できるようにする
-                    debugLog("アプリ起動直後に Google UMP の同意情報を同期します")
-                }
-                try await self.requestConsentInfoUpdate()
-            } catch {
-                await MainActor.run {
-                    // 同意情報の取得に失敗した場合でも後続の評価が走るようログだけ残して処理を継続する
-                    debugError(error, message: "アプリ起動時の Google UMP 同意情報更新に失敗")
-                }
-            }
-
-            await MainActor.run {
-                // 最新化した同意情報を反映し、NPA 判定とキャッシュの状態をそろえる
-                self.applyConsentStatusAndReloadIfNeeded()
-
-                let consentInfo = ConsentInformation.shared
-                // canRequestAds = true でキャッシュが空なら、同意済みユーザーでも起動直後に読み込みが走るよう明示的にトリガーする
-                if consentInfo.canRequestAds && self.interstitial == nil && !self.isLoadingAd {
-                    debugLog("起動時の同意同期後に広告キャッシュが空だったため読み込みを再開します")
-                    self.loadInterstitial()
-                }
-            }
-        }
-    }
-
-    deinit {
-        // Task がぶら下がったままだと不要なリトライが残るため解放
-        retryTask?.cancel()
-    }
-
-    func requestTrackingAuthorization() async {
-        guard ATTrackingManager.trackingAuthorizationStatus == .notDetermined else { return }
-        _ = await ATTrackingManager.requestTrackingAuthorization()
-    }
-
-    func requestConsentIfNeeded() async {
-        // Info.plist 側の設定が揃っていない場合はフォーム表示を行わない
-        guard hasValidAdConfiguration else { return }
-
-        do {
-            debugLog("Google UMP の同意取得フローを開始します")
-            // まずは地域規制の判定を最新化
-            try await requestConsentInfoUpdate()
-            // 同意状態に応じて NPA フラグを更新し、広告リクエストへ反映させる
-            applyConsentStatusAndReloadIfNeeded()
-
-            let consentInfo = ConsentInformation.shared
-            // 同意フォームが利用可能な場合のみロードと表示を行う
-            guard consentInfo.formStatus == .available else { return }
-
-            // 最新のフォームをロード
-            consentForm = try await loadConsentForm()
-
-            // 規制対象地域かつ同意が未取得の場合はフォームを提示
-            if consentInfo.consentStatus == .required || consentInfo.consentStatus == .unknown {
-                try await presentLoadedConsentForm()
-                // 表示後に同意内容が更新されるため再評価する
-                applyConsentStatusAndReloadIfNeeded()
-            }
-            debugLog("Google UMP の同意取得フローが完了しました (status: \(String(describing: consentInfo.consentStatus)))")
-        } catch {
-            // UMP 周りの失敗は広告表示を止めつつ、デバッグしやすいようログに残す
-            debugError(error, message: "Google UMP の同意取得に失敗")
-        }
-    }
-
-    func refreshConsentStatus() async {
-        // Info.plist の設定が不足している場合は処理しない
-        guard hasValidAdConfiguration else { return }
-
-        do {
-            debugLog("Google UMP の同意ステータス更新を開始します")
-            // 現在の同意状況を最新化
-            try await requestConsentInfoUpdate()
-            applyConsentStatusAndReloadIfNeeded()
-
-            let consentInfo = ConsentInformation.shared
-            guard consentInfo.formStatus == .available else { return }
-
-            // 設定画面などから呼び出された際は Privacy Options を直接表示する
-            try await presentPrivacyOptions()
-            // ユーザー操作後の状態を反映する
-            applyConsentStatusAndReloadIfNeeded()
-            debugLog("Google UMP の同意ステータス更新が完了しました (status: \(String(describing: consentInfo.consentStatus)))")
-        } catch {
-            debugError(error, message: "Google UMP の同意状態更新に失敗")
-        }
-    }
-
-    func showInterstitial() {
-        // IAP や設定で完全に無効化されている場合は何もしない
-        if adsDisabled || removeAdsMK {
-            debugLog("広告が無効化されているため表示処理をスキップしました (adsDisabled: \(adsDisabled), removeAdsMK: \(removeAdsMK))")
-            return
-        }
-
-        // インターバルや 1 プレイ 1 回の制御に引っかかったら終了
-        if !canShowByTime() {
-            debugLog("前回表示から 5 分未満のためインタースティシャル広告を表示しません")
-            return
-        }
-
-        if hasShownInCurrentPlay {
-            debugLog("同一プレイで既に広告を表示済みのためスキップしました")
-            return
-        }
-
-        guard let root = rootViewController() else {
-            // RootViewController が取得できなかった場合も次の読み込みだけは仕掛ける
-            debugLog("RootViewController の取得に失敗したため、読み込みのみ再実行します")
-            Task { [weak self] in
-                await MainActor.run { self?.loadInterstitial() }
-            }
-            return
-        }
-
-        guard let interstitial else {
-            // キャッシュが無ければ表示待機フラグを立てて再読み込みを開始
-            debugLog("広告が未ロードのため表示待機フラグを設定し再読み込みします")
-            isWaitingForPresentation = true
-            Task { [weak self] in
-                await MainActor.run { self?.loadInterstitial() }
-            }
-            return
-        }
-
-        debugLog("インタースティシャル広告の表示を開始します")
-        presentInterstitial(interstitial, from: root)
-    }
-
-    func resetPlayFlag() {
-        hasShownInCurrentPlay = false
-        debugLog("プレイ開始に合わせて広告表示フラグをリセットしました")
-    }
-
-    func disableAds() {
-        // 既に停止済みの場合でも呼び出されるため、冪等性を確保して余分な処理を避ける
-        guard !adsDisabled else {
-            debugLog("広告機能は既に無効化済みのため追加処理を行いません")
-            return
-        }
-        debugLog("広告機能を無効化しました。今後のリクエストを停止します")
-        adsDisabled = true
-        isWaitingForPresentation = false
-        interstitial = nil
-        retryTask?.cancel()
-        retryTask = nil
-    }
-
-    /// インタースティシャル広告を読み込むヘルパー
-    private func loadInterstitial() {
-        guard hasValidAdConfiguration else {
-            debugLog("Info.plist の広告設定が不足しているためインタースティシャル広告の読み込みを行いません")
-            return
-        }
-
-        let consentInfo = ConsentInformation.shared
-        guard consentInfo.canRequestAds else {
-            debugLog("Google UMP の状態により広告リクエストが許可されていません (status: \(String(describing: consentInfo.consentStatus)))")
-            return
-        }
-
-        guard !adsDisabled else {
-            debugLog("adsDisabled フラグが立っているため広告読み込みをスキップしました")
-            return
-        }
-
-        guard !removeAdsMK else {
-            debugLog("広告削除オプションが有効なため広告読み込みをスキップしました")
-            return
-        }
-
-        guard !isLoadingAd else {
-            debugLog("インタースティシャル広告を読み込み中のため二重リクエストを防ぎました")
-            return
-        }
-
-        guard interstitial == nil else {
-            debugLog("既にキャッシュ済みのインタースティシャルが存在するため新規読み込みを行いません")
-            return
-        }
-
-        debugLog("インタースティシャル広告の読み込みを開始します (NPA: \(shouldUseNPA))")
-        isLoadingAd = true
-
-        // Google Mobile Ads SDK v11 以降では `GADRequest` が `Request` に改名されたため、明示的に名前空間を付けて生成する
-        // （同名型との衝突を避け、将来の API 変更にも備える目的で `GoogleMobileAds.Request()` を利用）
-        let request = GoogleMobileAds.Request()
-        if shouldUseNPA {
-            // UMP の結果に従い非パーソナライズ広告をリクエスト
-            let extras = Extras()
-            extras.additionalParameters = ["npa": "1"]
-            request.register(extras)
-        }
-
-        InterstitialAd.load(with: interstitialAdUnitID, request: request) { [weak self] ad, error in
-            Task { [weak self] in
-                await MainActor.run {
-                    guard let self else { return }
-                    self.isLoadingAd = false
-
-                    if let error {
-                        // DEBUG ビルドでは原因を追いやすいようログ出力
-                        debugError(error, message: "インタースティシャル広告の読み込みに失敗")
-                        self.scheduleRetry()
-                        return
-                    }
-
-                    guard !self.adsDisabled, !self.removeAdsMK else { return }
-                    self.interstitial = ad
-                    self.interstitial?.fullScreenContentDelegate = self
-                    // 成功したのでリトライは不要
-                    self.retryTask?.cancel()
-                    self.retryTask = nil
-                    debugLog("インタースティシャル広告の読み込みが完了しました")
-                    // ロード完了時点で表示待機フラグが立っていれば、ここで表示処理をまとめて行う
-                    self.presentInterstitialIfNeededAfterLoad()
-                }
-            }
-        }
-    }
-
-    /// 共通化したインタースティシャル広告の表示処理
-    private func presentInterstitial(_ interstitial: InterstitialAd, from root: UIViewController) {
-        // 表示を試みる前に待機状態を解除し、同じインスタンスを再利用しないよう破棄する
-        isWaitingForPresentation = false
-        self.interstitial = nil
-
-        // 実際の表示は FullScreenContentDelegate からの成功通知を受けて状態を更新するため、ここでは副作用を最小限に留める
-        interstitial.present(from: root)
-        if hapticsEnabled {
-            // 結果画面遷移と同様に警告ハプティクスを鳴らし、ユーザーへのフィードバックを統一
-            UINotificationFeedbackGenerator().notificationOccurred(.warning)
-        }
-        debugLog("インタースティシャル広告の表示処理をトリガーしました")
-    }
-
-    /// ロード完了時に広告表示待機フラグが立っていれば、直ちに表示を試みる
-    private func presentInterstitialIfNeededAfterLoad() {
-        guard isWaitingForPresentation else { return }
-        debugLog("読み込み完了後の自動表示処理を開始します")
-        // 既に広告を無効化している場合は表示を諦め、待機フラグのみ解除する
-        guard !adsDisabled, !removeAdsMK else {
-            isWaitingForPresentation = false
-            interstitial = nil
-            debugLog("広告が無効化されているため自動表示を取りやめました")
-            return
-        }
-        guard let interstitial else {
-            // 非同期処理の間にキャッシュが解放されていた場合は再度ロードして次の機会に備える
-            debugLog("インタースティシャル広告の表示待機中に広告インスタンスが破棄されたため、再読み込みを実行します")
-            loadInterstitial()
-            return
-        }
-        guard let root = rootViewController() else {
-            // 表示に必要な RootViewController を取得できないときは原因調査のためログを残し、改めてロードを行う
-            debugLog("インタースティシャル広告の表示待機中でしたが RootViewController が取得できませんでした。再読み込みして次回に備えます")
-            self.interstitial = nil
-            loadInterstitial()
-            return
-        }
-
-        debugLog("読み込み完了直後にインタースティシャル広告を自動表示します")
-        presentInterstitial(interstitial, from: root)
-    }
-
-    /// 再読み込みを一定時間後に行う
-    private func scheduleRetry() {
-        guard !adsDisabled else { return }
-        retryTask?.cancel()
-        retryTask = Task { [weak self] in
-            // Task 実行時点で self が解放されていないことを確認し、以降は強参照で扱う
-            guard let self else { return }
-
-            // 秒数からナノ秒に変換し、一定時間後に再読み込みを試みる
-            let delay = UInt64(self.retryDelay * 1_000_000_000)
-            try? await Task.sleep(nanoseconds: delay)
-
-            // MainActor 上でインタースティシャルの読み込みを再開
-            await MainActor.run { self.loadInterstitial() }
-        }
-        debugLog("インタースティシャル広告の再読み込みを \(retryDelay) 秒後にスケジュールしました")
-    }
-
-    /// 最低 5 分のインターバルを満たしているかどうか
-    private func canShowByTime() -> Bool {
-        guard let last = lastInterstitialDate else { return true }
-        return Date().timeIntervalSince(last) >= minimumInterstitialInterval
-    }
-
-    // MARK: - FullScreenContentDelegate
-
-    func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
-        // 閉じたタイミングで次の広告を読み込む
-        Task { [weak self] in
-            await MainActor.run { self?.loadInterstitial() }
-        }
-        debugLog("インタースティシャル広告を閉じたため次の読み込みを開始します")
-    }
-
-    func adWillPresentFullScreenContent(_ ad: FullScreenPresentingAd) {
-        // 広告が表示される直前のタイミングでインターバルと 1 プレイ制限を更新する
-        // v11 以降では adDidPresentFullScreenContent が利用できなくなったため、
-        // 代わりに adWillPresentFullScreenContent で同様の処理を行う。
-        // 表示準備段階で制御フラグを更新しておくことで、
-        // ユーザー体験は従来と変えずに最新 SDK の仕様へ追従する。
-        lastInterstitialDate = Date()
-        hasShownInCurrentPlay = true
-        debugLog("インタースティシャル広告の表示準備が完了したためインターバル制御を更新しました")
-    }
-
-    func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
-        debugError(error, message: "インタースティシャル広告の表示に失敗")
-        interstitial = nil
-        // 表示に失敗した場合は同一プレイ内の表示済みフラグを解除し、再読み込み後の自動表示に備えて待機状態へ戻す
-        hasShownInCurrentPlay = false
-        isWaitingForPresentation = !adsDisabled && !removeAdsMK
-        scheduleRetry()
+        let hasValid = !applicationIdentifier.isEmpty && !interstitialIdentifier.isEmpty
+        return AdsServiceConfiguration(interstitialAdUnitID: interstitialIdentifier, hasValidAdConfiguration: hasValid)
     }
 }
 
-// MARK: - UMP 関連のヘルパー
-
-private extension AdsService {
-    /// UMP の同意情報を最新化する
-    func requestConsentInfoUpdate() async throws {
-        // 未成年向けコンテンツではないため、isTaggedForUnderAgeOfConsent を false に固定する
-        let parameters = RequestParameters()
-        parameters.isTaggedForUnderAgeOfConsent = false
-
-#if DEBUG
-        // テスト中は常に EEA として扱い、フォームを確認しやすくする
-        let debugSettings = DebugSettings()
-        debugSettings.geography = .EEA
-        parameters.debugSettings = debugSettings
-#endif
-
-        let consentInfo = ConsentInformation.shared
-
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            consentInfo.requestConsentInfoUpdate(with: parameters) { error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(returning: ())
-                }
-            }
-        }
-    }
-
-    /// 同意フォームをロードする
-    func loadConsentForm() async throws -> ConsentForm {
-        // Swift 6 ではジェネリクスの型推論が厳しくなっているため、CheckedContinuation の型を明示してビルドエラーを回避する
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<ConsentForm, Error>) in
-            ConsentForm.load { [weak self] form, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else if let form {
-                    continuation.resume(returning: form)
-                } else {
-                    // フォームもエラーも返らないケースは想定外のため、明示的にエラーを生成する
-                    let error = NSError(
-                        domain: "MonoKnight.AdsService",
-                        code: -1,
-                        userInfo: [NSLocalizedDescriptionKey: "UMP 同意フォームのロード結果が不正"]
-                    )
-                    continuation.resume(throwing: error)
-                }
-
-                // 参照が不要になったフォームは明示的に破棄する
-                if self?.consentForm != nil && form == nil {
-                    self?.consentForm = nil
-                }
-            }
-        }
-    }
-
-    /// ロード済みフォームを現在の RootViewController から表示する
-    func presentLoadedConsentForm() async throws {
-        guard let viewController = rootViewController(), let consentForm else {
+// MARK: - AdsConsentCoordinatorPresenting
+extension AdsService: AdsConsentCoordinatorPresenting {
+    func presentConsentForm(using presenter: @escaping ConsentFormPresenter) async throws {
+        guard let viewController = rootViewController() else {
             let error = NSError(
                 domain: "MonoKnight.AdsService",
                 code: -2,
@@ -503,8 +182,7 @@ private extension AdsService {
         }
 
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            consentForm.present(from: viewController) { [weak self] error in
-                defer { self?.consentForm = nil }
+            presenter(viewController) { error in
                 if let error {
                     continuation.resume(throwing: error)
                 } else {
@@ -514,8 +192,7 @@ private extension AdsService {
         }
     }
 
-    /// プライバシーオプションを直接表示する
-    func presentPrivacyOptions() async throws {
+    func presentPrivacyOptions(using presenter: @escaping PrivacyOptionsPresenter) async throws {
         guard let viewController = rootViewController() else {
             let error = NSError(
                 domain: "MonoKnight.AdsService",
@@ -525,11 +202,8 @@ private extension AdsService {
             throw error
         }
 
-
-
-        // こちらも上記と同様に Void 戻り値であることを明示し、Swift 6 の型推論エラーを防ぐ
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            ConsentForm.presentPrivacyOptionsForm(from: viewController) { error in
+            presenter(viewController) { error in
                 if let error {
                     continuation.resume(throwing: error)
                 } else {
@@ -538,38 +212,22 @@ private extension AdsService {
             }
         }
     }
+}
 
-    /// 現在の同意ステータスを見て NPA フラグを更新し、必要に応じて広告を再読み込みする
-    func applyConsentStatusAndReloadIfNeeded() {
-        let consentInfo = ConsentInformation.shared
-        // 取得済み or 規制対象外の場合のみパーソナライズを許可し、それ以外は安全側として NPA を指定する
-        let newShouldUseNPA: Bool
-        switch consentInfo.consentStatus {
-        case .obtained, .notRequired:
-            newShouldUseNPA = false
-        default:
-            newShouldUseNPA = true
-        }
-
-        let hasChanged = newShouldUseNPA != shouldUseNPA
-        shouldUseNPA = newShouldUseNPA
-        debugLog("Google UMP の結果を反映しました (shouldUseNPA: \(shouldUseNPA))")
-
-        if hasChanged {
-            // shouldUseNPA の変化に合わせて既存キャッシュを破棄し、新しい設定を反映したリクエストを作り直す
-            debugLog("同意内容の変化を検知したため、広告キャッシュを破棄して再読み込みします")
-            interstitial = nil
-            loadInterstitial()
-            return
-        }
-
-        // shouldUseNPA が変わらないケースでも、canRequestAds が true かつキャッシュが空なら読み込み漏れを防ぐ
-        if consentInfo.canRequestAds && interstitial == nil && !isLoadingAd {
-            debugLog("同意内容に変化はありませんがキャッシュが空のためインタースティシャル広告の読み込みを再開します")
-            loadInterstitial()
-        }
+// MARK: - InterstitialAdControllerDelegate
+extension AdsService: InterstitialAdControllerDelegate {
+    func rootViewControllerForPresentation(_ controller: InterstitialAdControlling) -> UIViewController? {
+        rootViewController()
     }
 
+    func interstitialAdControllerShouldPlayWarningHaptic(_ controller: InterstitialAdControlling) {
+        guard hapticsEnabled else { return }
+        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+    }
+}
+
+// MARK: - 共通ヘルパー
+private extension AdsService {
     /// 最前面の ViewController を取得する
     func rootViewController() -> UIViewController? {
         // シーン階層が取得できないケースでは即座に nil を返し、呼び出し元でリトライさせる

--- a/Services/InterstitialAdController.swift
+++ b/Services/InterstitialAdController.swift
@@ -1,0 +1,323 @@
+import Foundation
+import SwiftUI
+import UIKit
+import GoogleMobileAds
+
+// MARK: - インタースティシャル制御用のプロトコル
+/// AdsService が UI 側の責務を担いつつ、広告ロード/表示ロジックのみを委譲できるようにする
+@MainActor
+protocol InterstitialAdControllerDelegate: AnyObject {
+    /// 表示に利用する最前面の ViewController を返す
+    func rootViewControllerForPresentation(_ controller: InterstitialAdControlling) -> UIViewController?
+    /// 表示時にユーザーへ警告ハプティクスを鳴らすかどうかを委譲する
+    func interstitialAdControllerShouldPlayWarningHaptic(_ controller: InterstitialAdControlling)
+}
+
+/// インタースティシャル広告の振る舞いを統一するためのインターフェース
+@MainActor
+protocol InterstitialAdControlling: AnyObject, FullScreenContentDelegate, AdsConsentCoordinatorStateDelegate {
+    var delegate: InterstitialAdControllerDelegate? { get set }
+    var areAdsDisabled: Bool { get }
+
+    func beginInitialLoad()
+    func showInterstitial()
+    func resetPlayFlag()
+    func disableAds()
+    func updateRemoveAdsProvider(_ provider: @escaping () -> Bool)
+}
+
+/// GoogleMobileAds.InterstitialAd をテスト可能にするための薄い抽象化
+protocol InterstitialAdPresentable: AnyObject, FullScreenPresentingAd {
+    var fullScreenContentDelegate: FullScreenContentDelegate? { get set }
+    func present(from viewController: UIViewController)
+}
+
+extension InterstitialAd: InterstitialAdPresentable {}
+
+/// インタースティシャル広告のロード処理を差し替え可能にする
+protocol InterstitialAdLoading {
+    func load(adUnitID: String, request: GoogleMobileAds.Request, completion: @escaping (InterstitialAdPresentable?, Error?) -> Void)
+}
+
+/// 実機用の標準ローダー
+struct DefaultInterstitialAdLoader: InterstitialAdLoading {
+    func load(adUnitID: String, request: GoogleMobileAds.Request, completion: @escaping (InterstitialAdPresentable?, Error?) -> Void) {
+        InterstitialAd.load(withAdUnitID: adUnitID, request: request) { ad, error in
+            completion(ad, error)
+        }
+    }
+}
+
+// MARK: - 本体実装
+@MainActor
+final class InterstitialAdController: NSObject, InterstitialAdControlling {
+    weak var delegate: InterstitialAdControllerDelegate?
+
+    private let adUnitID: String
+    private let hasValidAdConfiguration: Bool
+    private var consentState: AdsConsentState
+    private let loader: InterstitialAdLoading
+    private let retryDelay: TimeInterval
+    private let minimumInterval: TimeInterval
+    private var removeAdsProvider: () -> Bool = { false }
+
+    private var interstitial: InterstitialAdPresentable?
+    private var lastInterstitialDate: Date?
+    private var hasShownInCurrentPlay: Bool = false
+    private var isLoadingAd: Bool = false
+    private var isWaitingForPresentation: Bool = false
+    private var retryTask: Task<Void, Never>?
+    private(set) var areAdsDisabled: Bool = false
+
+    init(
+        adUnitID: String,
+        hasValidAdConfiguration: Bool,
+        initialConsentState: AdsConsentState,
+        loader: InterstitialAdLoading = DefaultInterstitialAdLoader(),
+        retryDelay: TimeInterval = 30,
+        minimumInterval: TimeInterval = 300
+    ) {
+        self.adUnitID = adUnitID
+        self.hasValidAdConfiguration = hasValidAdConfiguration
+        self.consentState = initialConsentState
+        self.loader = loader
+        self.retryDelay = retryDelay
+        self.minimumInterval = minimumInterval
+        super.init()
+    }
+
+    deinit {
+        retryTask?.cancel()
+    }
+
+    func updateRemoveAdsProvider(_ provider: @escaping () -> Bool) {
+        removeAdsProvider = provider
+    }
+
+    func beginInitialLoad() {
+        guard !areAdsDisabled else { return }
+        loadInterstitial()
+    }
+
+    func showInterstitial() {
+        guard hasValidAdConfiguration else {
+            debugLog("Info.plist の広告設定が不足しているためインタースティシャル広告の表示を行いません")
+            return
+        }
+
+        if areAdsDisabled || removeAdsProvider() {
+            debugLog("広告が無効化されているため表示処理をスキップしました")
+            return
+        }
+
+        guard consentState.canRequestAds else {
+            debugLog("Google UMP の状態により広告リクエストが許可されていません (canRequestAds: \(consentState.canRequestAds))")
+            return
+        }
+
+        guard canShowByTime() else {
+            debugLog("前回表示から最低インターバルを満たしていないため広告を表示しません")
+            return
+        }
+
+        guard !hasShownInCurrentPlay else {
+            debugLog("同一プレイで既に広告を表示済みのためスキップしました")
+            return
+        }
+
+        guard let root = delegate?.rootViewControllerForPresentation(self) else {
+            debugLog("RootViewController の取得に失敗したため読み込みのみ再実行します")
+            triggerAsyncReload()
+            return
+        }
+
+        guard let interstitial else {
+            debugLog("広告が未ロードのため表示待機フラグを設定し再読み込みします")
+            isWaitingForPresentation = true
+            triggerAsyncReload()
+            return
+        }
+
+        debugLog("インタースティシャル広告の表示を開始します")
+        presentInterstitial(interstitial, from: root)
+    }
+
+    func resetPlayFlag() {
+        hasShownInCurrentPlay = false
+        debugLog("プレイ開始に合わせて広告表示フラグをリセットしました")
+    }
+
+    func disableAds() {
+        guard !areAdsDisabled else {
+            debugLog("広告機能は既に無効化済みのため追加処理を行いません")
+            return
+        }
+        areAdsDisabled = true
+        isWaitingForPresentation = false
+        interstitial = nil
+        retryTask?.cancel()
+        retryTask = nil
+        debugLog("広告機能を無効化しました。今後のリクエストを停止します")
+    }
+
+    func adsConsentCoordinator(_ coordinator: AdsConsentCoordinating, didUpdate state: AdsConsentState, shouldReloadAds: Bool) {
+        consentState = state
+        if shouldReloadAds {
+            interstitial = nil
+            loadInterstitial()
+            return
+        }
+
+        if state.canRequestAds && interstitial == nil && !isLoadingAd {
+            loadInterstitial()
+        }
+    }
+
+    // MARK: - FullScreenContentDelegate
+    func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
+        triggerAsyncReload()
+        debugLog("インタースティシャル広告を閉じたため次の読み込みを開始します")
+    }
+
+    func adWillPresentFullScreenContent(_ ad: FullScreenPresentingAd) {
+        lastInterstitialDate = Date()
+        hasShownInCurrentPlay = true
+        debugLog("インタースティシャル広告の表示準備が完了したためインターバル制御を更新しました")
+    }
+
+    func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        debugError(error, message: "インタースティシャル広告の表示に失敗")
+        interstitial = nil
+        hasShownInCurrentPlay = false
+        isWaitingForPresentation = !areAdsDisabled && !removeAdsProvider()
+        scheduleRetry()
+    }
+
+    // MARK: - 内部処理
+    private func triggerAsyncReload() {
+        Task { [weak self] in
+            guard let self else { return }
+            await MainActor.run { self.loadInterstitial() }
+        }
+    }
+
+    private func loadInterstitial() {
+        guard hasValidAdConfiguration else {
+            debugLog("Info.plist の広告設定が不足しているためインタースティシャル広告の読み込みを行いません")
+            return
+        }
+
+        guard consentState.canRequestAds else {
+            debugLog("Google UMP の状態により広告リクエストが許可されていません (canRequestAds: \(consentState.canRequestAds))")
+            return
+        }
+
+        guard !areAdsDisabled else {
+            debugLog("adsDisabled フラグが立っているため広告読み込みをスキップしました")
+            return
+        }
+
+        guard !removeAdsProvider() else {
+            debugLog("広告削除オプションが有効なため広告読み込みをスキップしました")
+            return
+        }
+
+        guard !isLoadingAd else {
+            debugLog("インタースティシャル広告を読み込み中のため二重リクエストを防ぎました")
+            return
+        }
+
+        guard interstitial == nil else {
+            debugLog("既にキャッシュ済みのインタースティシャルが存在するため新規読み込みを行いません")
+            return
+        }
+
+        debugLog("インタースティシャル広告の読み込みを開始します (NPA: \(consentState.shouldUseNPA))")
+        isLoadingAd = true
+
+        let request = GoogleMobileAds.Request()
+        if consentState.shouldUseNPA {
+            let extras = Extras()
+            extras.additionalParameters = ["npa": "1"]
+            request.register(extras)
+        }
+
+        loader.load(adUnitID: adUnitID, request: request) { [weak self] ad, error in
+            Task { [weak self] in
+                guard let self else { return }
+                await self.handleLoadResult(ad: ad, error: error)
+            }
+        }
+    }
+
+    private func handleLoadResult(ad: InterstitialAdPresentable?, error: Error?) async {
+        isLoadingAd = false
+
+        if let error {
+            debugError(error, message: "インタースティシャル広告の読み込みに失敗")
+            scheduleRetry()
+            return
+        }
+
+        guard !areAdsDisabled, !removeAdsProvider() else { return }
+        interstitial = ad
+        interstitial?.fullScreenContentDelegate = self
+        retryTask?.cancel()
+        retryTask = nil
+        debugLog("インタースティシャル広告の読み込みが完了しました")
+        presentInterstitialIfNeededAfterLoad()
+    }
+
+    private func presentInterstitial(_ interstitial: InterstitialAdPresentable, from root: UIViewController) {
+        isWaitingForPresentation = false
+        self.interstitial = nil
+        interstitial.present(from: root)
+        delegate?.interstitialAdControllerShouldPlayWarningHaptic(self)
+        debugLog("インタースティシャル広告の表示処理をトリガーしました")
+    }
+
+    private func presentInterstitialIfNeededAfterLoad() {
+        guard isWaitingForPresentation else { return }
+        debugLog("読み込み完了後の自動表示処理を開始します")
+
+        guard !areAdsDisabled, !removeAdsProvider() else {
+            isWaitingForPresentation = false
+            interstitial = nil
+            debugLog("広告が無効化されているため自動表示を取りやめました")
+            return
+        }
+
+        guard let interstitial else {
+            debugLog("インタースティャル広告の表示待機中に広告インスタンスが破棄されたため、再読み込みを実行します")
+            loadInterstitial()
+            return
+        }
+
+        guard let root = delegate?.rootViewControllerForPresentation(self) else {
+            debugLog("インタースティシャル広告の表示待機中でしたが RootViewController が取得できませんでした。再読み込みして次回に備えます")
+            self.interstitial = nil
+            loadInterstitial()
+            return
+        }
+
+        debugLog("読み込み完了直後にインタースティシャル広告を自動表示します")
+        presentInterstitial(interstitial, from: root)
+    }
+
+    private func scheduleRetry() {
+        guard !areAdsDisabled else { return }
+        retryTask?.cancel()
+        retryTask = Task { [weak self] in
+            guard let self else { return }
+            let delay = UInt64(self.retryDelay * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: delay)
+            await MainActor.run { self.loadInterstitial() }
+        }
+        debugLog("インタースティシャル広告の再読み込みを \(retryDelay) 秒後にスケジュールしました")
+    }
+
+    private func canShowByTime() -> Bool {
+        guard let lastInterstitialDate else { return true }
+        return Date().timeIntervalSince(lastInterstitialDate) >= minimumInterval
+    }
+}


### PR DESCRIPTION
## Summary
- extract Google UMP handling into AdsConsentCoordinator with injectable environment and presentation delegate
- move interstitial ad loading/presentation logic into InterstitialAdController and have AdsService delegate UI concerns
- update AdsService to wire coordinators through dependency injection and add unit tests for the new components and service integration

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d3ec174494832c870abb8f2f3d6901