### PR TITLE
Fix consent form presenter optional handling

### DIFF
--- a/Services/AdsConsentCoordinator.swift
+++ b/Services/AdsConsentCoordinator.swift
@@ -113,7 +113,9 @@ final class DefaultAdsConsentEnvironment: AdsConsentEnvironment {
                 // presenter 内で強参照が残り続けると二重表示の原因になるため、ローカル変数で管理しておく
                 var storedForm: ConsentForm? = form
                 let presenter: ConsentFormPresenter = { viewController, completion in
-                    guard let storedForm else {
+                    // guard の省略記法を使うと storedForm がシャドーイングされてしまい、
+                    // 後続で nil 代入ができなくなるため別名に退避する
+                    guard let formForPresentation = storedForm else {
                         let error = NSError(
                             domain: "MonoKnight.AdsConsentCoordinator",
                             code: -11,
@@ -122,7 +124,7 @@ final class DefaultAdsConsentEnvironment: AdsConsentEnvironment {
                         completion(error)
                         return
                     }
-                    storedForm.present(from: viewController) { error in
+                    formForPresentation.present(from: viewController) { error in
                         storedForm = nil
                         completion(error)
                     }


### PR DESCRIPTION
## Summary
- fix the consent form presenter closure so that the stored form optional is not shadowed
- add Japanese comments explaining the guard rename to maintain readability

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68d457846028832cb85bbbc940ae2649