### PR TITLE
Fix main actor requirement for request parameters

### DIFF
--- a/Services/AdsConsentCoordinator.swift
+++ b/Services/AdsConsentCoordinator.swift
@@ -244,6 +244,9 @@ final class AdsConsentCoordinator: AdsConsentCoordinating {
     }
 
     /// RequestParameters を生成するヘルパー
+    /// - Note: RequestParameters / DebugSettings は MainActor 専有のイニシャライザを持つため、
+    ///         メソッド全体を @MainActor で明示してメインスレッド上で生成されることを保証する。
+    @MainActor
     private func makeRequestParameters() -> RequestParameters {
         let parameters = RequestParameters()
         parameters.tagForUnderAgeOfConsent = false


### PR DESCRIPTION
## Summary
- 明示的に `makeRequestParameters` を `@MainActor` 指定し、UMP の `RequestParameters`/`DebugSettings` 初期化がメインスレッドで実行されるように調整
- MainActor 専有イニシャライザ呼び出しに関するコンパイラ警告を回避

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d45797fc54832c9b684c567eed1fa4