### PR TITLE
Fix UMP under age flag rename

### DIFF
--- a/Services/AdsConsentCoordinator.swift
+++ b/Services/AdsConsentCoordinator.swift
@@ -251,7 +251,7 @@ final class AdsConsentCoordinator: AdsConsentCoordinating {
     @MainActor
     private func makeRequestParameters() -> RequestParameters {
         let parameters = RequestParameters()
-        parameters.tagForUnderAgeOfConsent = false
+        parameters.isTaggedForUnderAgeOfConsent = false // UMP SDK v2 以降のリネームに追従（未成年扱いのフラグを明示的に無効化）
 
         #if DEBUG
         let debugSettings = DebugSettings()


### PR DESCRIPTION
## Summary
- update the UMP request parameter setup to use the renamed `isTaggedForUnderAgeOfConsent` flag
- document the intent in Japanese so the flag usage remains clear after the SDK rename

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4585b955c832c847e1f975128ac95