### PR TITLE
Fix InterstitialAdPresentable conformance

### DIFF
--- a/Services/InterstitialAdController.swift
+++ b/Services/InterstitialAdController.swift
@@ -33,7 +33,14 @@ protocol InterstitialAdPresentable: AnyObject, FullScreenPresentingAd {
     func present(from viewController: UIViewController)
 }
 
-extension InterstitialAd: InterstitialAdPresentable {}
+extension InterstitialAd: InterstitialAdPresentable {
+    // MARK: - GoogleMobileAds.InterstitialAd をプロトコル経由で扱うための橋渡し
+    /// GoogleMobileAds 側の `present(fromRootViewController:)` をアプリ内のインターフェースに合わせてラップする
+    /// - Parameter viewController: 表示元となる最前面の ViewController
+    func present(from viewController: UIViewController) {
+        present(fromRootViewController: viewController)
+    }
+}
 
 /// インタースティシャル広告のロード処理を差し替え可能にする
 protocol InterstitialAdLoading {


### PR DESCRIPTION
## Summary
- bridge GoogleMobileAds.InterstitialAd to the InterstitialAdPresentable protocol by wrapping the present method to match the protocol signature

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4591c7e28832c8e3519c6001a0dd9