### PR TITLE
Fix interstitial load API label

### DIFF
--- a/Services/InterstitialAdController.swift
+++ b/Services/InterstitialAdController.swift
@@ -43,7 +43,8 @@ protocol InterstitialAdLoading {
 /// 実機用の標準ローダー
 struct DefaultInterstitialAdLoader: InterstitialAdLoading {
     func load(adUnitID: String, request: GoogleMobileAds.Request, completion: @escaping (InterstitialAdPresentable?, Error?) -> Void) {
-        InterstitialAd.load(withAdUnitID: adUnitID, request: request) { ad, error in
+        // API の引数ラベル変更に合わせ、`withAdUnitID` ではなく `with` を使用する
+        InterstitialAd.load(with: adUnitID, request: request) { ad, error in
             completion(ad, error)
         }
     }


### PR DESCRIPTION
## Summary
- update the default interstitial ad loader to use the new GoogleMobileAds API label
- add a Japanese comment explaining the API label change

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d45923c52c832c9c1b690295934632