### PR TITLE
Fix async ATT authorization request

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -139,7 +139,13 @@ final class AdsService: NSObject, ObservableObject, AdsServiceProtocol {
 
     func requestTrackingAuthorization() async {
         guard ATTrackingManager.trackingAuthorizationStatus == .notDetermined else { return }
-        _ = await ATTrackingManager.requestTrackingAuthorization()
+        // ATT の許諾ダイアログはクロージャベース API のため、Continuation で async/await へ橋渡しする
+        _ = await withCheckedContinuation { (continuation: CheckedContinuation<ATTrackingManager.AuthorizationStatus, Never>) in
+            ATTrackingManager.requestTrackingAuthorization { status in
+                // 取得した許諾ステータスをそのまま呼び出し元へ返す
+                continuation.resume(returning: status)
+            }
+        }
     }
 
     func requestConsentIfNeeded() async {


### PR DESCRIPTION
## Summary
- ATT 許諾ダイアログの非同期呼び出しを Continuation で async/await へ橋渡ししました
- 実装意図が伝わるようコメントを追加しました

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d45a8625b8832c9e445a084444695e