### PR TITLE
Fix interstitial presentation recursion

### DIFF
--- a/Services/InterstitialAdController.swift
+++ b/Services/InterstitialAdController.swift
@@ -38,9 +38,9 @@ extension InterstitialAd: InterstitialAdPresentable {
     /// GoogleMobileAds 側の `present(from:)` をアプリ内のインターフェースに合わせてラップする
     /// - Parameter viewController: 表示元となる最前面の ViewController
     func present(from viewController: UIViewController) {
-        // SDK 本体のメソッドを直接呼び出し、ラッパー側での再帰呼び出しを防ぐ
-        // （`FullScreenPresentingAd` プロトコルが提供する fromRootViewController ラベルを利用）
-        present(from: viewController) 
+        // SDK 純正の API は `present(fromRootViewController:)` で提供されているため
+        // 本メソッドからは直接そちらを呼び出し、同名メソッド間での再帰呼び出しを回避する
+        present(fromRootViewController: viewController)
     }
 }
 


### PR DESCRIPTION
## Summary
- call GoogleMobileAds.InterstitialAd's native present(fromRootViewController:) API from the protocol wrapper to avoid infinite recursion
- document the fix to clarify how the SDK API should be used

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d45c8557d8832cbc9e2d88ef747509