### PR TITLE
Expose BoardLayoutSnapshot to GameViewModel

### DIFF
--- a/UI/BoardLayoutSnapshot.swift
+++ b/UI/BoardLayoutSnapshot.swift
@@ -1,0 +1,54 @@
+import CoreGraphics
+
+/// 盤面レイアウトの実測値をまとめたスナップショット構造体
+/// Equatable 準拠により差分検出が容易になり、診断ログの出力を最小限に抑えられる
+struct BoardLayoutSnapshot: Equatable {
+    /// 親ビューのサイズ
+    let geometrySize: CGSize
+    /// 盤面表示領域に割り当てられた高さ
+    let availableHeight: CGFloat
+    /// 横方向の基準となる盤面ベースサイズ
+    let horizontalBoardBase: CGFloat
+    /// 縦方向の基準となる盤面ベースサイズ
+    let verticalBoardBase: CGFloat
+    /// 最終的に採用された盤面ベースサイズ
+    let boardBaseSize: CGFloat
+    /// 実際に描画へ用いる盤面幅
+    let boardWidth: CGFloat
+    /// 生のトップセーフエリア値
+    let rawTopInset: CGFloat
+    /// 生のボトムセーフエリア値
+    let rawBottomInset: CGFloat
+    /// デフォルトのトップセーフエリア値
+    let baseTopSafeAreaInset: CGFloat
+    /// セーフエリアなどを反映した最終的なトップインセット
+    let resolvedTopInset: CGFloat
+    /// オーバーレイ考慮後のトップインセット
+    let overlayAdjustedTopInset: CGFloat
+    /// セーフエリアなどを反映した最終的なボトムインセット
+    let resolvedBottomInset: CGFloat
+    /// 統計表示エリアの高さ
+    let statisticsHeight: CGFloat
+    /// フォールバック適用後の統計表示エリアの高さ
+    let resolvedStatisticsHeight: CGFloat
+    /// 手札表示エリアの高さ
+    let handSectionHeight: CGFloat
+    /// フォールバック適用後の手札表示エリアの高さ
+    let resolvedHandSectionHeight: CGFloat
+    /// レギュラー幅向けの追加ボトム余白
+    let regularAdditionalBottomPadding: CGFloat
+    /// 手札エリア下部の余白
+    let handSectionBottomPadding: CGFloat
+    /// トップセーフエリアがフォールバックされたか
+    let usedTopSafeAreaFallback: Bool
+    /// ボトムセーフエリアがフォールバックされたか
+    let usedBottomSafeAreaFallback: Bool
+    /// 統計表示エリアがフォールバックされたか
+    let usedStatisticsFallback: Bool
+    /// 手札表示エリアがフォールバックされたか
+    let usedHandSectionFallback: Bool
+    /// コントロール行のトップ余白
+    let controlRowTopPadding: CGFloat
+    /// 盤面上部のオーバーレイ高さ
+    let topOverlayHeight: CGFloat
+}

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -1331,7 +1331,7 @@ struct GameView: View {
     }
 
     /// GeometryReader から求めたレイアウト値を保持する内部専用の構造体
-    private struct LayoutComputationContext {
+    fileprivate struct LayoutComputationContext {
         let geometrySize: CGSize
         let rawTopInset: CGFloat
         let rawBottomInset: CGFloat
@@ -1358,64 +1358,40 @@ struct GameView: View {
         let usedHandSectionFallback: Bool
     }
 
-    /// レイアウト監視で扱う値をひとまとめにした構造体
-    /// - Note: Equatable 準拠により onChange での差分検出に利用する
-    private struct BoardLayoutSnapshot: Equatable {
-        let geometrySize: CGSize
-        let availableHeight: CGFloat
-        let horizontalBoardBase: CGFloat
-        let verticalBoardBase: CGFloat
-        let boardBaseSize: CGFloat
-        let boardWidth: CGFloat
-        let rawTopInset: CGFloat
-        let rawBottomInset: CGFloat
-        let baseTopSafeAreaInset: CGFloat
-        let resolvedTopInset: CGFloat
-        let overlayAdjustedTopInset: CGFloat
-        let resolvedBottomInset: CGFloat
-        let statisticsHeight: CGFloat
-        let resolvedStatisticsHeight: CGFloat
-        let handSectionHeight: CGFloat
-        let resolvedHandSectionHeight: CGFloat
-        let regularAdditionalBottomPadding: CGFloat
-        let handSectionBottomPadding: CGFloat
-        let usedTopSafeAreaFallback: Bool
-        let usedBottomSafeAreaFallback: Bool
-        let usedStatisticsFallback: Bool
-        let usedHandSectionFallback: Bool
-        let controlRowTopPadding: CGFloat
-        let topOverlayHeight: CGFloat
+}
 
-        /// レイアウト計算で得られたコンテキストからスナップショットを構築するイニシャライザ
-        /// - Parameter context: GeometryReader の結果を整理したレイアウトコンテキスト
-        init(context: LayoutComputationContext) {
-            self.geometrySize = context.geometrySize
-            self.availableHeight = context.availableHeightForBoard
-            self.horizontalBoardBase = context.horizontalBoardBase
-            self.verticalBoardBase = context.verticalBoardBase
-            self.boardBaseSize = context.boardBaseSize
-            self.boardWidth = context.boardWidth
-            self.rawTopInset = context.rawTopInset
-            self.rawBottomInset = context.rawBottomInset
-            self.baseTopSafeAreaInset = context.baseTopSafeAreaInset
-            self.resolvedTopInset = context.topInset
-            self.overlayAdjustedTopInset = context.overlayAdjustedTopInset
-            self.resolvedBottomInset = context.bottomInset
-            self.statisticsHeight = context.statisticsHeight
-            self.resolvedStatisticsHeight = context.resolvedStatisticsHeight
-            self.handSectionHeight = context.handSectionHeight
-            self.resolvedHandSectionHeight = context.resolvedHandSectionHeight
-            self.regularAdditionalBottomPadding = context.regularAdditionalBottomPadding
-            self.handSectionBottomPadding = context.handSectionBottomPadding
-            self.usedTopSafeAreaFallback = context.usedTopFallback
-            self.usedBottomSafeAreaFallback = context.usedBottomFallback
-            self.usedStatisticsFallback = context.usedStatisticsFallback
-            self.usedHandSectionFallback = context.usedHandSectionFallback
-            self.controlRowTopPadding = context.controlRowTopPadding
-            self.topOverlayHeight = context.topOverlayHeight
-        }
+/// LayoutComputationContext から BoardLayoutSnapshot を組み立てるための補助イニシャライザ
+/// - Note: GameView 内部のみで利用するためアクセスレベルは private extension とする
+private extension BoardLayoutSnapshot {
+    init(context: GameView.LayoutComputationContext) {
+        // GeometryReader から取得した実測値を丸ごとコピーし、ViewModel からも参照できる形へ変換
+        self.init(
+            geometrySize: context.geometrySize,
+            availableHeight: context.availableHeightForBoard,
+            horizontalBoardBase: context.horizontalBoardBase,
+            verticalBoardBase: context.verticalBoardBase,
+            boardBaseSize: context.boardBaseSize,
+            boardWidth: context.boardWidth,
+            rawTopInset: context.rawTopInset,
+            rawBottomInset: context.rawBottomInset,
+            baseTopSafeAreaInset: context.baseTopSafeAreaInset,
+            resolvedTopInset: context.topInset,
+            overlayAdjustedTopInset: context.overlayAdjustedTopInset,
+            resolvedBottomInset: context.bottomInset,
+            statisticsHeight: context.statisticsHeight,
+            resolvedStatisticsHeight: context.resolvedStatisticsHeight,
+            handSectionHeight: context.handSectionHeight,
+            resolvedHandSectionHeight: context.resolvedHandSectionHeight,
+            regularAdditionalBottomPadding: context.regularAdditionalBottomPadding,
+            handSectionBottomPadding: context.handSectionBottomPadding,
+            usedTopSafeAreaFallback: context.usedTopFallback,
+            usedBottomSafeAreaFallback: context.usedBottomFallback,
+            usedStatisticsFallback: context.usedStatisticsFallback,
+            usedHandSectionFallback: context.usedHandSectionFallback,
+            controlRowTopPadding: context.controlRowTopPadding,
+            topOverlayHeight: context.topOverlayHeight
+        )
     }
-
 }
 
 private extension GameView {


### PR DESCRIPTION
## Summary
- extract the board layout snapshot structure into its own file so it can be reused outside GameView
- add a GameView-only initializer to rebuild the snapshot from the layout computation context
- adjust access control so the layout context remains file-scoped while allowing the view model to store snapshots

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4608dcdac832cb852383b9b3e35e3