### PR TITLE
Fix CardAnimationPhase visibility for GameViewModel

### DIFF
--- a/UI/CardAnimationPhase.swift
+++ b/UI/CardAnimationPhase.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// カード演出の段階を共有するための列挙型
+/// GameView と GameViewModel の両方で利用し、演出の状態遷移を同期する
+enum CardAnimationPhase: Equatable {
+    /// 演出が発生していない待機状態
+    case idle
+    /// 手札から盤面へ移動するアニメーションを実行中
+    case movingToBoard
+}

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -1887,12 +1887,6 @@ fileprivate struct NextCardOverlayView: View {
 }
 
 // MARK: - カード演出用の状態と PreferenceKey
-/// カードが移動中かどうかを示すアニメーションフェーズ
-private enum CardAnimationPhase: Equatable {
-    case idle
-    case movingToBoard
-}
-
 /// 手札・NEXT に配置されたカードのアンカーを UUID 単位で収集する PreferenceKey
 private struct CardPositionPreferenceKey: PreferenceKey {
     static var defaultValue: [UUID: Anchor<CGRect>] = [:]


### PR DESCRIPTION
## Summary
- add a shared CardAnimationPhase definition so GameViewModel can reference animation states
- remove the duplicate private enum from GameView.swift

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68d4609474d8832c9dfa2de456810801