### PR TITLE
Refactor platform service protocols and mocks

### DIFF
--- a/Services/AdsService.swift
+++ b/Services/AdsService.swift
@@ -7,16 +7,7 @@ import GoogleMobileAds
 import SharedSupport
 
 // MARK: - Protocol
-/// UI レイヤーからメインスレッド経由で利用する前提のため、プロトコル自体も MainActor に固定する
-@MainActor
-protocol AdsServiceProtocol: AnyObject {
-    func showInterstitial()
-    func resetPlayFlag()
-    func disableAds()
-    func requestTrackingAuthorization() async
-    func requestConsentIfNeeded() async
-    func refreshConsentStatus() async
-}
+// AdsServiceProtocol 自体は `ServiceInterfaces.swift` で共通定義しているため、ここでは実装のみを記述する。
 
 // MARK: - 補助的な依存関係
 /// Google Mobile Ads SDK の初期化処理を差し替えやすくするためのプロトコル

--- a/Services/GameCenterService.swift
+++ b/Services/GameCenterService.swift
@@ -44,24 +44,6 @@ private struct GameCenterLeaderboardCatalog {
     }
 }
 
-/// Game Center 操作に必要なインターフェースを定義するプロトコル
-/// - NOTE: 認証やスコア送信をテストしやすくするために利用する
-protocol GameCenterServiceProtocol: AnyObject {
-    /// 現在認証済みであるかどうか
-    var isAuthenticated: Bool { get }
-    /// ローカルプレイヤーの認証を行う
-    /// - Parameter completion: 認証結果を受け取るクロージャ
-    func authenticateLocalPlayer(completion: ((Bool) -> Void)?)
-    /// リーダーボードへスコア（ポイント）を送信する
-    /// - Parameters:
-    ///   - score: 送信するポイント値
-    ///   - modeIdentifier: スコアを送信したゲームモードの識別子
-    func submitScore(_ score: Int, for modeIdentifier: GameMode.Identifier)
-    /// ランキング画面を表示する
-    /// - Parameter modeIdentifier: 表示したいリーダーボードが紐付くゲームモード識別子
-    func showLeaderboard(for modeIdentifier: GameMode.Identifier)
-}
-
 /// Game Center 関連の操作をまとめたサービス
 /// 実際に Game Center と連携する実装
 final class GameCenterService: NSObject, GKGameCenterControllerDelegate, GameCenterServiceProtocol {

--- a/Services/ServiceInterfaces.swift
+++ b/Services/ServiceInterfaces.swift
@@ -1,0 +1,58 @@
+import Combine
+import Foundation
+import Game
+
+// MARK: - プラットフォームサービス共通プロトコル
+/// Game Center / AdMob / StoreKit を横断して依存注入しやすくするための共通インターフェース定義。
+/// UI テストやプレビューで実装を差し替えることを想定し、サービスごとに最小限の機能を公開する。
+
+// MARK: Game Center
+@MainActor
+protocol GameCenterServiceProtocol: AnyObject {
+    /// 現在 Game Center へ認証済みかどうかを確認する。
+    var isAuthenticated: Bool { get }
+    /// ローカルプレイヤーの認証を試みる。
+    /// - Parameter completion: 認証完了後に呼び出されるクロージャ（省略可能）。
+    func authenticateLocalPlayer(completion: ((Bool) -> Void)?)
+    /// 指定したモード用リーダーボードへスコアを送信する。
+    /// - Parameters:
+    ///   - score: 投稿するスコア値。
+    ///   - modeIdentifier: 対象モードの識別子。
+    func submitScore(_ score: Int, for modeIdentifier: GameMode.Identifier)
+    /// 指定モードのリーダーボードを表示する。
+    /// - Parameter modeIdentifier: 表示対象モードの識別子。
+    func showLeaderboard(for modeIdentifier: GameMode.Identifier)
+}
+
+// MARK: AdMob
+@MainActor
+protocol AdsServiceProtocol: AnyObject {
+    /// インタースティシャル広告を表示する。
+    func showInterstitial()
+    /// プレイ開始フラグをリセットし、広告表示条件を初期化する。
+    func resetPlayFlag()
+    /// 広告読み込みを完全に停止する（IAP 購入時などに利用）。
+    func disableAds()
+    /// ATT（アプリトラッキング許可）をリクエストする。
+    func requestTrackingAuthorization() async
+    /// UMP（ユーザー同意）を必要に応じて提示する。
+    func requestConsentIfNeeded() async
+    /// 同意状態を最新化する。
+    func refreshConsentStatus() async
+}
+
+// MARK: StoreKit
+@MainActor
+protocol StoreServiceProtocol: ObservableObject, AnyObject {
+    /// 広告除去オプションが購入済みかどうかを公開する。
+    var isRemoveAdsPurchased: Bool { get }
+    /// 表示用の価格テキスト。商品情報取得前は `nil`。
+    var removeAdsPriceText: String? { get }
+    /// 商品情報の取得や再取得を行う。
+    func refreshProducts() async
+    /// 広告除去商品の購入フローを開始する。
+    func purchaseRemoveAds() async
+    /// App Store と同期して購入履歴を復元する。
+    /// - Returns: 復元処理が成功したかどうか。
+    func restorePurchases() async -> Bool
+}

--- a/Services/ServiceMocks.swift
+++ b/Services/ServiceMocks.swift
@@ -67,4 +67,34 @@ final class MockAdsService: AdsServiceProtocol {
         }
     }
 }
+
+/// StoreKit の購入フローを即座に成功させる UI テスト用モック
+final class MockStoreService: ObservableObject, StoreServiceProtocol {
+    /// 広告除去が購入済みかどうかのフラグ
+    @Published private(set) var isRemoveAdsPurchased: Bool
+    /// 価格表示用のテキスト（テスト用に任意の値を設定できる）
+    @Published private(set) var removeAdsPriceText: String?
+
+    /// - Parameters:
+    ///   - isPurchased: 初期状態で購入済みにするかどうか。
+    ///   - priceText: 画面に表示する価格文言。`nil` にするとローディング表示を再現できる。
+    init(isPurchased: Bool = false, priceText: String? = "¥320") {
+        self.isRemoveAdsPurchased = isPurchased
+        self.removeAdsPriceText = priceText
+    }
+
+    /// プロダクト情報の取得は不要なので何もしない。
+    func refreshProducts() async {}
+
+    /// 購入操作を実行すると即座にフラグを立てる。
+    func purchaseRemoveAds() async {
+        isRemoveAdsPurchased = true
+    }
+
+    /// 復元操作は常に成功したものとして扱う。
+    func restorePurchases() async -> Bool {
+        isRemoveAdsPurchased = true
+        return true
+    }
+}
 #endif

--- a/Services/StoreService.swift
+++ b/Services/StoreService.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import StoreKit
 import SwiftUI
@@ -8,34 +9,46 @@ import SharedSupport // debugLog / debugError を利用するため追加
 /// StoreKit2 を用いた課金処理をまとめたサービス
 /// `remove_ads_mk` 商品の購入・復元・状態保持を担当する
 @MainActor
-final class StoreService: ObservableObject {
+final class StoreService: ObservableObject, StoreServiceProtocol {
     /// シングルトンインスタンス
     static let shared = StoreService()
 
+    /// StoreKit で参照する Product ID を一元管理する内部定数
+    private enum ProductID {
+        static let removeAds = "remove_ads_mk"
+    }
+
     /// 取得済みのプロダクト一覧（現在は広告除去のみ）
-    @Published var products: [Product] = []
+    /// - NOTE: 現状 1 種類のみだが、将来別商品の追加にも備えて配列として保持する。
+    @Published private(set) var products: [Product] = []
 
     /// 広告除去購入済みフラグを UI へ公開するためのプロパティ
     /// - NOTE: `@AppStorage` だけだと SwiftUI の描画更新が走らないため、`@Published` と併用して View 側で購読しやすくする
-    @Published private(set) var isremoveAdsMKPurchased: Bool
+    @Published private(set) var isRemoveAdsPurchased: Bool
+
+    /// 価格表示用のテキスト。商品情報が未取得の間は `nil` のままにし、UI でローディング表示へ切り替える。
+    @Published private(set) var removeAdsPriceText: String?
 
     /// 広告除去購入済みフラグ
     /// - `true` の場合は AdsService が広告を読み込まない
-    @AppStorage("remove_ads_mk") private var removeAdsMK: Bool = false
+    @AppStorage(ProductID.removeAds) private var removeAdsMK: Bool = false
 
-    /// 設定画面などから価格表示に利用できるよう、広告除去商品の参照を提供する
-    var removeAdsMKProduct: Product? { products.first(where: { $0.id == "remove_ads_mk" }) }
+    /// 設定画面などから参照する広告除去商品のキャッシュ
+    private var removeAdsProduct: Product? { products.first(where: { $0.id == ProductID.removeAds }) }
 
     private init() {
         // 起動時点で保存済みの値を読み出し、UI の初期状態に反映する
-        self.isremoveAdsMKPurchased = UserDefaults.standard.bool(forKey: "remove_ads_mk")
+        self.isRemoveAdsPurchased = UserDefaults.standard.bool(forKey: ProductID.removeAds)
+        self.removeAdsPriceText = nil
+
         if removeAdsMK {
             // すでに広告除去が有効な場合は AdsService にも通知しておき、広告ロードを完全に止める
             AdsService.shared.disableAds()
         }
+
         // 初期化と同時に商品情報の取得とトランザクション監視を開始
         Task {
-            await fetchProducts()
+            await refreshProducts()
             await updatePurchasedStatus()
             await observeTransactions()
         }
@@ -44,22 +57,26 @@ final class StoreService: ObservableObject {
     // MARK: - Product
 
     /// `remove_ads_mk` 商品の情報を取得する
-    func fetchProducts() async {
+    func refreshProducts() async {
         do {
             // App Store Connect で登録した Product ID を指定
-            products = try await Product.products(for: ["remove_ads_mk"])
+            products = try await Product.products(for: [ProductID.removeAds])
+            // 取得に成功した場合は表示用の価格テキストも更新する
+            removeAdsPriceText = removeAdsProduct?.displayPrice
         } catch {
             // 失敗時はユーザーへは通知せず、デバッグログのみ詳細を出力
             debugError(error, message: "商品情報の取得に失敗")
+            // エラー発生時は価格をリセットして、UI でローディングを継続表示させる
+            removeAdsPriceText = nil
         }
     }
 
     // MARK: - Purchase
 
     /// 広告除去を購入する
-    func purchaseremoveAdsMK() async {
+    func purchaseRemoveAds() async {
         // 事前に取得したプロダクトを検索
-        guard let product = products.first(where: { $0.id == "remove_ads_mk" }) else { return }
+        guard let product = removeAdsProduct else { return }
 
         do {
             // 購入フローを開始
@@ -67,9 +84,9 @@ final class StoreService: ObservableObject {
             switch result {
             case .success(let verification):
                 // トランザクションの検証
-                if let transaction = checkVerified(verification), transaction.productID == "remove_ads_mk" {
+                if let transaction = checkVerified(verification), transaction.productID == ProductID.removeAds {
                     // フラグ反映と広告停止
-                    applyremoveAdsMK()
+                    applyRemoveAds()
                     // 消費型ではないので明示的に finish
                     await transaction.finish()
                 }
@@ -84,9 +101,9 @@ final class StoreService: ObservableObject {
     }
 
     /// 外部から呼び出して購入済み情報を更新する
-    private func applyremoveAdsMK() {
+    private func applyRemoveAds() {
         removeAdsMK = true
-        isremoveAdsMKPurchased = true
+        isRemoveAdsPurchased = true
         // 広告サービスに通知して表示を停止させる
         AdsService.shared.disableAds()
     }
@@ -97,8 +114,8 @@ final class StoreService: ObservableObject {
     private func updatePurchasedStatus() async {
         // 現在有効なトランザクションをすべてチェック
         for await result in Transaction.currentEntitlements {
-            if let transaction = checkVerified(result), transaction.productID == "remove_ads_mk" {
-                applyremoveAdsMK()
+            if let transaction = checkVerified(result), transaction.productID == ProductID.removeAds {
+                applyRemoveAds()
             }
         }
     }
@@ -107,8 +124,8 @@ final class StoreService: ObservableObject {
     private func observeTransactions() async {
         // 非同期シーケンスとして更新を受け取る
         for await result in Transaction.updates {
-            if let transaction = checkVerified(result), transaction.productID == "remove_ads_mk" {
-                applyremoveAdsMK()
+            if let transaction = checkVerified(result), transaction.productID == ProductID.removeAds {
+                applyRemoveAds()
                 await transaction.finish()
             }
         }
@@ -139,6 +156,69 @@ final class StoreService: ObservableObject {
             // 復元処理が失敗した場合も詳細なログを残す
             debugError(error, message: "購入の復元に失敗")
             return false
+        }
+    }
+}
+
+// MARK: - タイプイレースされた Store サービス
+@MainActor
+final class AnyStoreService: ObservableObject, StoreServiceProtocol {
+    /// 実際の Store サービス実装を保持する。
+    private let base: any StoreServiceProtocol
+    /// Combine 購読を保持し、ラップ対象の objectWillChange を監視するためのセット。
+    private var cancellables: Set<AnyCancellable> = []
+
+    /// 広告除去購入済みフラグを公開する。内部的にはラップ対象の値をそのまま反映する。
+    @Published private(set) var isRemoveAdsPurchased: Bool
+    /// 価格表示用のテキスト。ラップ対象の値が更新され次第このプロパティも追従する。
+    @Published private(set) var removeAdsPriceText: String?
+
+    /// - Parameter base: 実際の StoreService 実装（本番・モックのいずれにも対応）。
+    init(base: any StoreServiceProtocol) {
+        self.base = base
+        self.isRemoveAdsPurchased = base.isRemoveAdsPurchased
+        self.removeAdsPriceText = base.removeAdsPriceText
+
+        // ラップ対象の objectWillChange を監視し、Published プロパティを同期する。
+        base.objectWillChange
+            .sink { [weak self] _ in
+                guard let self else { return }
+                Task { @MainActor in
+                    self.synchronizeFromBase()
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    /// 商品情報の更新を実行し、完了後に Published プロパティへ反映する。
+    func refreshProducts() async {
+        await base.refreshProducts()
+        await synchronizeAfterAsyncOperation()
+    }
+
+    /// 購入フローを実行し、結果を反映する。
+    func purchaseRemoveAds() async {
+        await base.purchaseRemoveAds()
+        await synchronizeAfterAsyncOperation()
+    }
+
+    /// 復元処理を実行し、結果を反映する。
+    func restorePurchases() async -> Bool {
+        let result = await base.restorePurchases()
+        await synchronizeAfterAsyncOperation()
+        return result
+    }
+
+    /// objectWillChange 経由の通知で呼び出される同期処理。
+    private func synchronizeFromBase() {
+        isRemoveAdsPurchased = base.isRemoveAdsPurchased
+        removeAdsPriceText = base.removeAdsPriceText
+    }
+
+    /// 非同期処理完了後にメインスレッドで同期を行うヘルパー。
+    private func synchronizeAfterAsyncOperation() async {
+        await MainActor.run { [weak self] in
+            self?.synchronizeFromBase()
         }
     }
 }


### PR DESCRIPTION
## Summary
- consolidate Game Center / AdMob / StoreKit 向けのプロトコルを `ServiceInterfaces` に切り出して依存注入を整理
- StoreService をリネーム・価格テキスト公開・タイプイレースラッパー `AnyStoreService` 追加で UI テストでも差し替えやすく調整
- MonoKnightApp / SettingsView / ServiceMocks を更新し、UI テスト時にモックサービスを包括的に差し替えられるよう改善

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68d46cc10c68832c839db26d662a7c4d