### PR TITLE
Use live elapsed time in GameViewModel

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -458,5 +458,14 @@ extension GameCore {
     func simulateSpawnSelection(forTesting point: GridPoint) {
         handleSpawnSelection(at: point)
     }
+
+    /// テスト時に任意の開始時刻へ調整し、`liveElapsedSeconds` の計算結果を制御する
+    /// - Parameter newStartDate: 擬似的に設定したい開始時刻
+    func setStartDateForTesting(_ newStartDate: Date) {
+        // リアルタイム計測は startDate と現在時刻の差分で算出されるため、テストでは任意の値へ差し替えられるようにする。
+        startDate = newStartDate
+        // 進行中のケースを再現するため、終了時刻は強制的に未確定へ戻しておく。
+        endDate = nil
+    }
 }
 #endif

--- a/MonoKnightAppTests/GameViewModelTests.swift
+++ b/MonoKnightAppTests/GameViewModelTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import MonoKnightApp
+import Game
+
+/// GameViewModel の動作を検証するテスト群
+/// - Note: ViewModel は MainActor 上での実行を前提としているため、テストメソッドにも @MainActor を付与する。
+@MainActor
+final class GameViewModelTests: XCTestCase {
+
+    /// プレイ中は GameCore.liveElapsedSeconds を参照して経過時間が増加することを確認
+    func testUpdateDisplayedElapsedTimeUsesLiveElapsedSecondsWhilePlaying() {
+        // 120 秒前にゲームが開始された状況を再現し、リアルタイム計測の挙動を確認する。
+        let targetElapsedSeconds: TimeInterval = 120
+        let core = GameCore(mode: .standard)
+        core.setStartDateForTesting(Date().addingTimeInterval(-targetElapsedSeconds))
+
+        // GameModuleInterfaces 経由で上記 GameCore を注入し、サービスは最小限のダミーを渡す。
+        let interfaces = GameModuleInterfaces { _ in core }
+        let viewModel = GameViewModel(
+            mode: .standard,
+            gameInterfaces: interfaces,
+            gameCenterService: DummyGameCenterService(),
+            adsService: DummyAdsService(),
+            onRequestReturnToTitle: nil
+        )
+
+        // liveElapsedSeconds は Int へ丸められるため、呼び出し直後の差分許容範囲を確保して検証する。
+        viewModel.updateDisplayedElapsedTime()
+        XCTAssertGreaterThanOrEqual(
+            viewModel.displayedElapsedSeconds,
+            Int(targetElapsedSeconds) - 1,
+            "リアルタイム経過秒数が期待よりも小さすぎます"
+        )
+        XCTAssertLessThanOrEqual(
+            viewModel.displayedElapsedSeconds,
+            Int(targetElapsedSeconds) + 2,
+            "リアルタイム経過秒数が許容範囲を超えてしまいました"
+        )
+    }
+}
+
+// MARK: - テスト用ダミーサービス
+
+/// GameCenterServiceProtocol を満たす最小限のダミー実装
+@MainActor
+private final class DummyGameCenterService: GameCenterServiceProtocol {
+    var isAuthenticated: Bool = false
+    func authenticateLocalPlayer(completion: ((Bool) -> Void)?) { completion?(true) }
+    func submitScore(_ score: Int, for modeIdentifier: GameMode.Identifier) {}
+    func showLeaderboard(for modeIdentifier: GameMode.Identifier) {}
+}
+
+/// AdsServiceProtocol を満たす最小限のダミー実装
+@MainActor
+private final class DummyAdsService: AdsServiceProtocol {
+    func showInterstitial() {}
+    func resetPlayFlag() {}
+    func disableAds() {}
+    func requestTrackingAuthorization() async {}
+    func requestConsentIfNeeded() async {}
+    func refreshConsentStatus() async {}
+}

--- a/UI/GameViewModel.swift
+++ b/UI/GameViewModel.swift
@@ -148,7 +148,10 @@ final class GameViewModel: ObservableObject {
 
     /// 表示用の経過時間を再計算する
     func updateDisplayedElapsedTime() {
-        displayedElapsedSeconds = core.elapsedSeconds
+        // GameCore 側では経過秒数をリアルタイム計測しつつ、クリア確定時に `elapsedSeconds` へ確定値を格納する。
+        // プレイ中に UI で使用する値は `liveElapsedSeconds` を参照することで、
+        // ストップウォッチのように 1 秒刻みで増加し続ける体験を提供できるようにする。
+        displayedElapsedSeconds = core.liveElapsedSeconds
     }
 
     /// 指定スタックのカードが現在位置から使用可能か判定する


### PR DESCRIPTION
## Summary
- GameViewModel の経過時間表示を GameCore.liveElapsedSeconds に切り替えてリアルタイム化
- GameCore に開始時刻をテスト用に調整できるヘルパーを追加
- GameViewModel の経過時間更新を検証するユニットテストを追加

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d480abd104832caa337547250b2cf1