### PR TITLE
Refine GameView layout calculator

### DIFF
--- a/MonoKnightAppTests/GameViewLayoutCalculatorTests.swift
+++ b/MonoKnightAppTests/GameViewLayoutCalculatorTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import SwiftUI
+@testable import MonoKnightApp
+
+/// GameViewLayoutCalculator の計算ロジックを検証するテスト
+/// - Note: オーバーレイ補正やフォールバック処理が複雑化しやすいため、
+///         実測値から切り出した `GameViewLayoutParameters` を用いてロジックを直接テストする。
+final class GameViewLayoutCalculatorTests: XCTestCase {
+
+    /// トップオーバーレイを差し引いた後のセーフエリア量が二重に減算されないことを確認する
+    func testOverlayAdjustedTopInsetMatchesResolvedTopInset() {
+        // 典型的な iPhone（ノッチあり）を想定した寸法を用意
+        // - 高さ 844pt / 幅 390pt（iPhone 13 など）
+        // - セーフエリア上端 91pt（ステータスバー 47pt + カスタムオーバーレイ 44pt）
+        // - セーフエリア下端 34pt（ホームインジケータ相当）
+        let parameters = GameViewLayoutParameters(
+            size: CGSize(width: 390, height: 844),
+            safeAreaTop: 91,
+            safeAreaBottom: 34
+        )
+
+        // カスタムオーバーレイ 44pt / 統計領域 120pt / 手札領域 260pt を想定
+        let calculator = GameViewLayoutCalculator(
+            parameters: parameters,
+            horizontalSizeClass: .compact,
+            topOverlayHeight: 44,
+            baseTopSafeAreaInset: 47,
+            statisticsHeight: 120,
+            handSectionHeight: 260
+        )
+
+        let context = calculator.makeContext()
+
+        // オーバーレイ除去後のトップセーフエリアは 47pt に揃う想定
+        XCTAssertEqual(context.topInset, 47, accuracy: 0.001, "トップインセットが期待値と一致しません")
+        // overlayAdjustedTopInset も topInset と同じ値を維持し、二重減算が解消されていることを確認
+        XCTAssertEqual(context.overlayAdjustedTopInset, context.topInset, accuracy: 0.001, "overlayAdjustedTopInset がトップインセットと不一致です")
+        // コントロール行の余白はセーフエリアに 8pt 加算した 55pt 以上であるべき
+        XCTAssertGreaterThanOrEqual(context.controlRowTopPadding, 55, "コントロール行の余白が不足しています")
+        // 記録用の topOverlayHeight にはオーバーレイ量がそのまま反映されていることも確認
+        XCTAssertEqual(context.topOverlayHeight, 44, accuracy: 0.001, "オーバーレイ高さの記録値が想定と異なります")
+    }
+}
+


### PR DESCRIPTION
## Summary
- 抽出した `GameViewLayoutParameters` で GeometryProxy 依存を薄め、レイアウト計算をテストしやすく整理
- トップオーバーレイ補正の二重減算を解消し、盤面コントロール行やバナーの余白が正しく確保されるよう修正
- テストで代表的なデバイス寸法を用いてオーバーレイ補正の計算結果を確認

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d48c0a8434832c8ac70e5b07f4e4cb