### PR TITLE
Refactor GameCore hand state publication

### DIFF
--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -317,7 +317,7 @@ final class GameBoardBridgeViewModel: ObservableObject {
 
     /// GameCore の状態変化を監視し、盤面関連の副作用を集約する
     private func bindGameCore() {
-        core.handManager.$handStacks
+        core.$handStacks
             .receive(on: RunLoop.main)
             .sink { [weak self] newHandStacks in
                 guard let self else { return }


### PR DESCRIPTION
## Summary
- expose hand state from `GameCore` via published properties so UI can observe without touching `HandManager`
- mirror hand manager updates through a helper that is invoked after rebuild/reset operations
- retarget `GameBoardBridgeViewModel` to bind against `GameCore.$handStacks`

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d48fc6924c832cb3ba0d8486907d91