### PR TITLE
Fix StoreServiceProtocol objectWillChange publisher type

### DIFF
--- a/Services/ServiceInterfaces.swift
+++ b/Services/ServiceInterfaces.swift
@@ -44,6 +44,13 @@ protocol AdsServiceProtocol: AnyObject {
 // MARK: StoreKit
 @MainActor
 protocol StoreServiceProtocol: ObservableObject, AnyObject {
+    /// Combine の `ObservableObjectPublisher` を利用することを明示し、
+    /// `any StoreServiceProtocol` として扱う際にも `objectWillChange` を利用できるようにする。
+    /// - NOTE: `ObservableObject` では関連型 `ObjectWillChangePublisher` が未確定のため、
+    ///         存在型へ格納するとコンパイラが型を推論できずにエラーとなる。
+    ///         ここで型を固定しておくことで、ラップしたサービスから `objectWillChange`
+    ///         を安全に購読できるようにしている。
+    typealias ObjectWillChangePublisher = ObservableObjectPublisher
     /// 広告除去オプションが購入済みかどうかを公開する。
     var isRemoveAdsPurchased: Bool { get }
     /// 表示用の価格テキスト。商品情報取得前は `nil`。


### PR DESCRIPTION
## Summary
- lock StoreServiceProtocol's ObjectWillChangePublisher to ObservableObjectPublisher so that type-erased wrappers can subscribe to updates without compiler errors

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d49b7d3a18832cafb251c18f0fda93