### PR TITLE
Refactor GameView to rely on ViewModel accessors

### DIFF
--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -40,6 +40,14 @@ final class GameBoardBridgeViewModel: ObservableObject {
     /// ハプティクスを利用するかどうか
     private(set) var hapticsEnabled = true
 
+    /// 現在の駒の位置
+    /// - Note: GameView 側で盤面アニメーションのフォールバック地点として参照するため公開する
+    var currentPosition: GridPoint? { core.current }
+
+    /// 現在の盤面サイズ
+    /// - Note: 盤面座標を SwiftUI 座標へ変換する際に必要となるため、専用プロパティとして切り出す
+    var boardSize: Int { core.board.size }
+
     /// Combine の購読を保持するためのセット
     private var cancellables = Set<AnyCancellable>()
 

--- a/UI/GameViewModel.swift
+++ b/UI/GameViewModel.swift
@@ -45,6 +45,30 @@ final class GameViewModel: ObservableObject {
     var displayedScore: Int {
         core.totalMoveCount * 10 + displayedElapsedSeconds
     }
+    /// 現在の移動回数
+    /// - Note: 統計バッジ表示で利用し、View 側から GameCore への直接依存を減らす
+    var moveCount: Int { core.moveCount }
+    /// 累計ペナルティ手数
+    /// - Note: ペナルティバナーや統計表示の数値として再利用する
+    var penaltyCount: Int { core.penaltyCount }
+    /// クリア確定時点の経過秒数
+    /// - Note: 結果画面や統計表示で参照するための公開プロパティ
+    var elapsedSeconds: Int { core.elapsedSeconds }
+    /// 未踏破マスの残数
+    /// - Note: 進行状況バッジに表示するために用意する
+    var remainingTiles: Int { core.remainingTiles }
+    /// 現在のゲーム進行状態
+    /// - Note: GameView 側でオーバーレイ表示を切り替える際に利用する
+    var progress: GameProgress { core.progress }
+    /// 直近で加算されたペナルティ量
+    /// - Note: バナー表示のテキストへ反映する
+    var lastPenaltyAmount: Int { core.lastPenaltyAmount }
+    /// 捨て札選択待機中かどうか
+    /// - Note: ボタンのスタイル切り替えに必要な状態をカプセル化する
+    var isAwaitingManualDiscardSelection: Bool { core.isAwaitingManualDiscardSelection }
+    /// 現在の駒位置
+    /// - Note: カード移動演出でフォールバック座標として参照する
+    var currentPosition: GridPoint? { core.current }
     /// レイアウト診断用のスナップショット
     @Published var lastLoggedLayoutSnapshot: BoardLayoutSnapshot?
     /// 経過秒数を 1 秒刻みで更新するためのタイマーパブリッシャ


### PR DESCRIPTION
## Summary
- GameBoardBridgeViewModel に盤面サイズと現在位置のアクセサを追加して UI から直接 GameCore を参照しないよう整理
- GameViewModel に統計値や進行状態などの計算プロパティを追加し、GameView からのアクセス経路を一本化
- GameView 側の UI ロジックを新しいアクセサへ移行して責務境界を明確化

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d49da0e698832cbd2871820851e112