### PR TITLE
ゲーム画面の上部余白を調整

### DIFF
--- a/MonoKnightAppTests/GameViewLayoutCalculatorTests.swift
+++ b/MonoKnightAppTests/GameViewLayoutCalculatorTests.swift
@@ -35,8 +35,13 @@ final class GameViewLayoutCalculatorTests: XCTestCase {
         XCTAssertEqual(context.topInset, 47, accuracy: 0.001, "トップインセットが期待値と一致しません")
         // overlayAdjustedTopInset も topInset と同じ値を維持し、二重減算が解消されていることを確認
         XCTAssertEqual(context.overlayAdjustedTopInset, context.topInset, accuracy: 0.001, "overlayAdjustedTopInset がトップインセットと不一致です")
-        // コントロール行の余白はセーフエリアに 8pt 加算した 55pt 以上であるべき
-        XCTAssertGreaterThanOrEqual(context.controlRowTopPadding, 55, "コントロール行の余白が不足しています")
+        // トップバーで押し下げられたぶんを補正し、コントロール行の余白は基準値 16pt へ収束する想定
+        XCTAssertEqual(
+            context.controlRowTopPadding,
+            GameViewLayoutMetrics.controlRowBaseTopPadding,
+            accuracy: 0.001,
+            "コントロール行の余白が基準値からずれています"
+        )
         // 記録用の topOverlayHeight にはオーバーレイ量がそのまま反映されていることも確認
         XCTAssertEqual(context.topOverlayHeight, 44, accuracy: 0.001, "オーバーレイ高さの記録値が想定と異なります")
     }

--- a/UI/GameViewLayoutSupport.swift
+++ b/UI/GameViewLayoutSupport.swift
@@ -197,9 +197,15 @@ struct GameViewLayoutCalculator {
             : (usedBottomFallback ? GameViewLayoutMetrics.regularWidthBottomSafeAreaFallback : 0)
 
         // MARK: - 盤面上部コントロールバーの余白を決定
+        // MARK: - トップバー追加分を差し引いたうえで必要な余白を計算
+        // safeAreaInset によってコンテンツ全体がトップバー高さぶんだけ下へ押し下げられるため、
+        // overlayCompensation（= topOverlayHeight）をそのまま足し込んでしまうと二重で距離が開いてしまう。
+        // そこでトップバーで増えた高さを差し引いた残差だけを安全余白として扱い、
+        // ステータスバー由来の領域に限って追加のマージン（controlRowSafeAreaAdditionalPadding）を加える。
+        let safeAreaRemainderWithoutOverlay = max(overlayAdjustedTopInset - overlayCompensation, 0)
         let controlRowTopPadding = max(
             GameViewLayoutMetrics.controlRowBaseTopPadding,
-            overlayAdjustedTopInset + GameViewLayoutMetrics.controlRowSafeAreaAdditionalPadding
+            safeAreaRemainderWithoutOverlay + GameViewLayoutMetrics.controlRowSafeAreaAdditionalPadding
         )
 
         // MARK: - 手札セクション下部の余白を決定


### PR DESCRIPTION
## Summary
- safeAreaInset によって追加されたトップバーの高さを差し引いて、盤面コントロール列の余白を適正化
- 期待値が変化したレイアウト計算テストを更新し、新しい基準値（16pt）を検証

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4a2c2862c832cbbbf8a3b57669f35