### PR TITLE
Handle missing UMP consent form configuration

### DIFF
--- a/MonoKnightAppTests/TestDoubles/AdsConsentTestDoubles.swift
+++ b/MonoKnightAppTests/TestDoubles/AdsConsentTestDoubles.swift
@@ -25,6 +25,8 @@ final class TestAdsConsentEnvironment: AdsConsentEnvironment {
 
     /// ConsentInformation 更新時に追加で実行したい処理を注入するためのクロージャ
     var requestUpdateHandler: (() -> Void)?
+    /// requestConsentInfoUpdate で発生させたいエラー（フォーム未設定などの検証用）
+    var requestUpdateError: Error?
     /// 同意フォームのプレゼンターを差し替えるためのクロージャ
     var presenterFactory: (() -> ConsentFormPresenter)?
     /// プライバシーオプションのプレゼンターを差し替えるためのクロージャ
@@ -33,6 +35,9 @@ final class TestAdsConsentEnvironment: AdsConsentEnvironment {
     func requestConsentInfoUpdate(with parameters: RequestParameters) async throws {
         requestUpdateCallCount += 1
         requestUpdateHandler?()
+        if let requestUpdateError {
+            throw requestUpdateError
+        }
     }
 
     func loadConsentFormPresenter() async throws -> ConsentFormPresenter {


### PR DESCRIPTION
## Summary
- add a fallback path in `AdsConsentCoordinator` so that missing Google UMP forms enable non-personalized ads instead of surfacing repeated errors
- short-circuit further consent requests once the fallback is active and log the state only once
- extend the consent coordinator tests and doubles to cover the new missing-form scenario

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4a52a7780832cb911743d6840df6a