### PR TITLE
Fix MainActor isolation when refreshing diagnostics logs

### DIFF
--- a/UI/DiagnosticsCenterView.swift
+++ b/UI/DiagnosticsCenterView.swift
@@ -183,7 +183,10 @@ struct DiagnosticsCenterView: View {
             ) { _ in
                 // 補足: SwiftUI の View は構造体で循環参照が発生しないため弱参照は不要。
                 // 強参照のまま state を更新する方がコンパイルエラーを避けられる。
-                refreshLogEntries()
+                Task { @MainActor in
+                    // Swift 6 では非同期コンテキストからメインアクター専有メソッドを直接呼べないため、Task 経由でメインアクターへ戻す。
+                    refreshLogEntries()
+                }
             }
         }
         if crashObserver == nil {
@@ -193,7 +196,10 @@ struct DiagnosticsCenterView: View {
                 queue: .main
             ) { _ in
                 // 補足: 上記と同様に View は値型で循環参照を気にする必要がないため弱参照を使用しない。
-                refreshCrashEvents()
+                Task { @MainActor in
+                    // Swift 6 でもメインアクター上で状態更新を行うよう明示し、コンパイルエラーを防ぐ。
+                    refreshCrashEvents()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- NotificationCenter のクロージャーで Task を介してメインアクターに戻すよう修正
- Swift 6 のアクター分離ルールに従いログ／クラッシュ履歴の更新を安全に実行

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4d55bb4b8832c9271e12c5fe4f105