### PR TITLE
Adjust GameView size class access for layout extension

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -17,7 +17,8 @@ struct GameView: View {
     /// 現在のライト/ダーク設定を環境から取得し、SpriteKit 側の色にも反映する
     @Environment(\.colorScheme) private var colorScheme
     /// デバイスの横幅サイズクラスを取得し、iPad などレギュラー幅でのモーダル挙動を調整する
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    /// - Note: レイアウト計算用の拡張（`GameView+Layout`）でも参照するため、アクセスレベルは internal に緩和している
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
     /// RootView 側で挿入したトップバーの高さ。safeAreaInsets.top から減算して余分な余白を除去する
     /// - Note: Swift 6 では独自 EnvironmentKey の値型が明示されていないと推論に失敗するため、CGFloat 型で注釈を付けている
     @Environment(\.topOverlayHeight) private var topOverlayHeight: CGFloat


### PR DESCRIPTION
## Summary
- relax the horizontal size class environment property's access level so layout helpers can read it
- document in code why the access control is widened

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4d86ca118832cba9050482be25977