### PR TITLE
Adjust GameView access control for layout extensions

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -27,9 +27,11 @@ struct GameView: View {
     /// 手札スロットの数（常に 5 スロット分の枠を確保してレイアウトを安定させる）
     private let handSlotCount = 5
     /// View とロジックの橋渡しを担う ViewModel
-    @StateObject private var viewModel: GameViewModel
+    /// - Note: レイアウトや監視系の拡張（別ファイル）からもアクセスできるように `fileprivate` を採用する。
+    @StateObject fileprivate var viewModel: GameViewModel
     /// SpriteKit との仲介を担う BoardBridge
-    @ObservedObject private var boardBridge: GameBoardBridgeViewModel
+    /// - Note: レイアウト系拡張から直接参照するため `fileprivate` として公開範囲を揃える。
+    @ObservedObject fileprivate var boardBridge: GameBoardBridgeViewModel
     /// ハプティクスを有効にするかどうかの設定値
     @AppStorage("haptics_enabled") private var hapticsEnabled: Bool = true
     /// ガイドモードのオン/オフを永続化し、盤面ハイライト表示を制御する


### PR DESCRIPTION
## Summary
- expose GameView's viewModel and boardBridge to layout/observer extensions by switching them to fileprivate
- document the access change so future updates maintain extension compatibility

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4d8aa2ef8832c80807e3392b1a97c