### PR TITLE
Relax base top inset access for layout extension

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -24,7 +24,8 @@ struct GameView: View {
     @Environment(\.topOverlayHeight) private var topOverlayHeight: CGFloat
     /// ルートビューの GeometryReader で得たシステム由来セーフエリアの上端量
     /// - Note: safeAreaInset により増加した分を差し引くための基準値として利用する
-    @Environment(\.baseTopSafeAreaInset) private var baseTopSafeAreaInset: CGFloat
+    /// - Note: レイアウト補助用の拡張（`GameView+Layout`）でも参照するため、`fileprivate` へ緩和している
+    @Environment(\.baseTopSafeAreaInset) fileprivate var baseTopSafeAreaInset: CGFloat
     /// 手札スロットの数（常に 5 スロット分の枠を確保してレイアウトを安定させる）
     private let handSlotCount = 5
     /// View とロジックの橋渡しを担う ViewModel


### PR DESCRIPTION
## Summary
- GameView の baseTopSafeAreaInset を layout 拡張から参照できるよう fileprivate へ緩和
- アクセスレベル変更の理由をコメントで補足

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4d93f77c0832c9e0a00f3cd49b055