### PR TITLE
Fix top overlay environment access for layout extension

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -20,8 +20,10 @@ struct GameView: View {
     /// - Note: レイアウト計算用の拡張（`GameView+Layout`）でも参照するため、アクセスレベルは internal に緩和している
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     /// RootView 側で挿入したトップバーの高さ。safeAreaInsets.top から減算して余分な余白を除去する
+    /// - Important: レイアウト計算を担う `GameView+Layout` からも参照するためアクセスレベルを internal にし、
+    ///             View 拡張側でも同一値を共有できるようにする。
     /// - Note: Swift 6 では独自 EnvironmentKey の値型が明示されていないと推論に失敗するため、CGFloat 型で注釈を付けている
-    @Environment(\.topOverlayHeight) private var topOverlayHeight: CGFloat
+    @Environment(\.topOverlayHeight) var topOverlayHeight: CGFloat
     /// ルートビューの GeometryReader で得たシステム由来セーフエリアの上端量
     /// - Note: safeAreaInset により増加した分を差し引くための基準値として利用する
     @Environment(\.baseTopSafeAreaInset) private var baseTopSafeAreaInset: CGFloat


### PR DESCRIPTION
## Summary
- expose GameView's top overlay environment value to layout extensions so shared calculations compile
- document the access level change to clarify why the property must remain internal

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4d93a3134832cbdd7b7acc939fe41