### PR TITLE
Adjust GameView access levels for layout extension

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -13,7 +13,9 @@ import UIKit  // ハプティクス用のフレームワークを追加
 @MainActor
 struct GameView: View {
     /// カラーテーマを生成し、ビュー全体で共通の配色を利用できるようにする
-    private var theme = AppTheme()
+    /// - Note: レイアウト補助の拡張（`GameView+Layout`）でもテーマカラーを共有する必要があるため、
+    ///         `fileprivate` へアクセスレベルを緩和している。
+    fileprivate let theme = AppTheme()
     /// 現在のライト/ダーク設定を環境から取得し、SpriteKit 側の色にも反映する
     @Environment(\.colorScheme) private var colorScheme
     /// デバイスの横幅サイズクラスを取得し、iPad などレギュラー幅でのモーダル挙動を調整する
@@ -29,7 +31,8 @@ struct GameView: View {
     /// - Note: レイアウト補助用の拡張（`GameView+Layout`）でも参照するため、`fileprivate` へ緩和している
     @Environment(\.baseTopSafeAreaInset) fileprivate var baseTopSafeAreaInset: CGFloat
     /// 手札スロットの数（常に 5 スロット分の枠を確保してレイアウトを安定させる）
-    private let handSlotCount = 5
+    /// - Note: レイアウト拡張でハンド UI の構築にも利用するため、`fileprivate` へ緩和して同一型内で共有している。
+    fileprivate let handSlotCount = 5
     /// View とロジックの橋渡しを担う ViewModel
     /// - Note: レイアウトや監視系の拡張（別ファイル）からもアクセスするため、`internal` 相当の公開範囲（デフォルト）を維持する。
     ///         `fileprivate` にすると `GameView+Layout` から参照できずビルドエラーになるため注意。


### PR DESCRIPTION
## Summary
- relax GameView theme property access so the layout extension can reuse shared colors
- expose the hand slot count to the layout helper to resolve protection level errors

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4da7d9f9c832c98baef3b0f10573d