### PR TITLE
Adjust access level for hand ordering setting

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -45,7 +45,9 @@ struct GameView: View {
     /// ガイドモードのオン/オフを永続化し、盤面ハイライト表示を制御する
     @AppStorage("guide_mode_enabled") private var guideModeEnabled: Bool = true
     /// 手札の並び替え方式。設定変更時に GameCore へ伝搬する
-    @AppStorage(HandOrderingStrategy.storageKey) private var handOrderingRawValue: String = HandOrderingStrategy.insertionOrder.rawValue
+    /// - Note: 監視系ロジックを切り出した `GameView+Observers` からも参照するため、
+    ///         アクセスレベルを `fileprivate` へ広げて同一型拡張内で共有できるようにする。
+    @AppStorage(HandOrderingStrategy.storageKey) fileprivate var handOrderingRawValue: String = HandOrderingStrategy.insertionOrder.rawValue
     /// 手札や NEXT の位置をマッチングさせるための名前空間
     /// - Note: レイアウト拡張（GameView+Layout）でも利用するため、アクセスレベルを `fileprivate` へ広げる。
     @Namespace fileprivate var cardAnimationNamespace


### PR DESCRIPTION
## Summary
- widen the access level of GameView.handOrderingRawValue so observer extensions can read it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4de3e6c78832c9ccc8ef5b6e5249a