### PR TITLE
Fix hand ordering storage visibility for observers

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -45,9 +45,9 @@ struct GameView: View {
     /// ガイドモードのオン/オフを永続化し、盤面ハイライト表示を制御する
     @AppStorage("guide_mode_enabled") private var guideModeEnabled: Bool = true
     /// 手札の並び替え方式。設定変更時に GameCore へ伝搬する
-    /// - Note: 監視系ロジックを切り出した `GameView+Observers` からも参照するため、
-    ///         アクセスレベルを `fileprivate` へ広げて同一型拡張内で共有できるようにする。
-    @AppStorage(HandOrderingStrategy.storageKey) fileprivate var handOrderingRawValue: String = HandOrderingStrategy.insertionOrder.rawValue
+    /// - Note: 監視系ロジックを切り出した `GameView+Observers` でも値を参照する必要があるため、
+    ///         デフォルトのアクセスレベル（internal）を維持し、モジュール内の別ファイル拡張からも安全に共有できるようにしている。
+    @AppStorage(HandOrderingStrategy.storageKey) var handOrderingRawValue: String = HandOrderingStrategy.insertionOrder.rawValue
     /// 手札や NEXT の位置をマッチングさせるための名前空間
     /// - Note: レイアウト拡張（GameView+Layout）でも利用するため、アクセスレベルを internal（デフォルト）で共有する。
     @Namespace var cardAnimationNamespace


### PR DESCRIPTION
## Summary
- relax the hand ordering AppStorage property visibility so observer extensions can access it
- refresh the inline documentation to clarify why the property remains internal

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4df4a5504832cb522b20dba8e93d4