### PR TITLE
Fix PauseMenuView HandOrderingStrategy import

### DIFF
--- a/UI/PauseMenuView.swift
+++ b/UI/PauseMenuView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Game  // ゲームパッケージ内の HandOrderingStrategy などを利用するために読み込む
 
 /// ポーズメニュー本体。プレイ中によく調整する項目をリスト形式でまとめる
 /// - Note: フルスクリーンカバーとして再利用できるよう、`GameView` から切り出して独立させた。


### PR DESCRIPTION
## Summary
- 読み込み忘れだった Game モジュールを PauseMenuView に追加し、HandOrderingStrategy を参照できるようにしました

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4e07ce4a0832ca216b13003322500