### PR TITLE
Fix GameView scene access level for layout extension

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -58,7 +58,9 @@ struct GameView: View {
     /// - Note: レイアウト拡張（GameView+Layout）でも利用するため、アクセスレベルを internal（デフォルト）で共有する。
     @Namespace var cardAnimationNamespace
     /// SpriteKit シーンへのショートカット
-    private var scene: GameScene { boardBridge.scene }
+    /// - Note: レイアウト用拡張（`GameView+Layout`）で SpriteView を構築する際にも同じシーンへアクセスするため、
+    ///         アクセスレベルを internal（デフォルト）へ緩和し、型の拡張からも参照できるようにしている。
+    var scene: GameScene { boardBridge.scene }
 
     /// デフォルトのサービスを利用して `GameView` を生成するコンビニエンスイニシャライザ
     /// - Parameters:


### PR DESCRIPTION
## Summary
- relax the GameView.scene access level so layout helpers can embed the SpriteView
- document the reason in Japanese comments to clarify cross-file usage

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4e4f1bb88832ca11061a7ed886dcd