### PR TITLE
Fix color scheme access for GameView observers

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -17,9 +17,9 @@ struct GameView: View {
     ///         同一型の別ファイル拡張からも参照できるようアクセスレベルはデフォルト（internal）にしている。
     let theme = AppTheme()
     /// 現在のライト/ダーク設定を環境から取得し、SpriteKit 側の色にも反映する
-    /// - Note: 監視系ロジックを別ファイルに切り出した `GameView+Observers` でも参照するため、
-    ///         `private` ではなく `fileprivate` へ緩和し、同一型拡張からアクセスできるようにする。
-    @Environment(\.colorScheme) fileprivate var colorScheme
+    /// - Note: 監視系ロジックを別ファイルへ分割しているため、`fileprivate` にするとアクセスできずビルドエラーとなる。
+    ///         そのためアクセスレベルはデフォルト（internal）のままにして、同一モジュール内の拡張から安全に参照できるようにしている。
+    @Environment(\.colorScheme) var colorScheme
     /// デバイスの横幅サイズクラスを取得し、iPad などレギュラー幅でのモーダル挙動を調整する
     /// - Note: レイアウト計算用の拡張（`GameView+Layout`）でも参照するため、アクセスレベルは internal に緩和している
     @Environment(\.horizontalSizeClass) var horizontalSizeClass


### PR DESCRIPTION
## Summary
- GameView の colorScheme プロパティを internal として公開し、拡張から参照できるように修正
- コメントを更新し、別ファイル拡張での利用を考慮したアクセスレベル方針を明記

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4e5042b60832c9ded3ea7eea86a52