### PR TITLE
Fix color scheme change observer invocation

### DIFF
--- a/UI/GameView+Observers.swift
+++ b/UI/GameView+Observers.swift
@@ -40,7 +40,7 @@ extension GameView {
                 )
             }
             // ライト/ダーク切り替えが発生した場合も SpriteKit 側へ反映
-            .onChange(of: colorScheme) { newScheme in
+            .onChange(of: colorScheme, initial: false) { newScheme in
                 viewModel.applyScenePalette(for: newScheme)
                 // カラースキーム変更時はガイドの色味も再描画して視認性を確保
                 viewModel.refreshGuideHighlights()


### PR DESCRIPTION
## Summary
- update the color scheme observer to use the explicit `initial` argument so the SwiftUI signature matches expectations on older toolchains

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4e5110678832c93a11718b9f5b1ae