### PR TITLE
Fix observer access to GameView AppStorage properties

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -43,11 +43,11 @@ struct GameView: View {
     /// - Note: こちらもレイアウト拡張からの参照が必要なため、`internal`（デフォルト）のアクセスレベルを確保している。
     @ObservedObject var boardBridge: GameBoardBridgeViewModel
     /// ハプティクスを有効にするかどうかの設定値
-    /// - Note: 設定変更を監視する処理を `GameView+Observers` 側へ移譲しているため、拡張からも参照できるよう `fileprivate` へ拡張する。
-    @AppStorage("haptics_enabled") fileprivate var hapticsEnabled: Bool = true
+    /// - Note: 監視処理を切り出した `GameView+Observers` からも利用するため、アクセスレベルは internal（デフォルト）で公開している。
+    @AppStorage("haptics_enabled") var hapticsEnabled: Bool = true
     /// ガイドモードのオン/オフを永続化し、盤面ハイライト表示を制御する
-    /// - Note: 同様に監視処理が別ファイルの拡張へ分離されているため、アクセスレベルを `fileprivate` に調整している。
-    @AppStorage("guide_mode_enabled") fileprivate var guideModeEnabled: Bool = true
+    /// - Note: こちらも監視処理を別ファイルで扱う必要があるため、`fileprivate` ではなく internal を維持して拡張から参照できるようにする。
+    @AppStorage("guide_mode_enabled") var guideModeEnabled: Bool = true
     /// 手札の並び替え方式。設定変更時に GameCore へ伝搬する
 
     /// - Note: 監視系ロジックを切り出した `GameView+Observers` でも値を参照する必要があるため、


### PR DESCRIPTION
## Summary
- expose the haptics and guide AppStorage flags with internal access so GameView observers can compile
- update inline documentation to explain why the properties stay internal

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4e52421c0832c895162be541d1a23