### PR TITLE
Reduce simulator startup log noise

### DIFF
--- a/Services/AdsConsentCoordinator.swift
+++ b/Services/AdsConsentCoordinator.swift
@@ -338,7 +338,12 @@ final class AdsConsentCoordinator: AdsConsentCoordinating {
         stateDelegate?.adsConsentCoordinator(self, didUpdate: state, shouldReloadAds: needsReload)
 
         if let error {
+            #if DEBUG
+            // 開発用の AdMob アプリ ID ではフォーム未設定が想定内なため、エラー扱いではなく状況説明のみに留める
+            debugLog("UMP のフォーム設定が未完了のため非パーソナライズ広告で継続します (フォーム未設定) | error=\(error.localizedDescription)")
+            #else
             debugError(error, message: "UMP のフォーム設定が未完了のため非パーソナライズ広告で継続します (フォーム未設定)")
+            #endif
             hasLoggedMissingConsentFormFallback = true
         } else if !hasLoggedMissingConsentFormFallback {
             debugLog("UMP のフォーム設定が未完了のため非パーソナライズ広告で継続します (フォーム未設定)")


### PR DESCRIPTION
## Summary
- シミュレーター初回描画でトップバー高さが 0 と判定されても警告を出さないよう RootView のログ出力を調整
- Game Center 認証失敗時にユーザーキャンセル／未サインインなど想定内の GKError を情報ログへダウングレード
- 開発用 AdMob 設定で UMP フォーム未設定が想定される場合に、フォールバック処理のログをエラーではなく情報として記録

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4e9771b28832ca1ef3165e9908291