### PR TITLE
Fix card animation overlay target position

### DIFF
--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -213,7 +213,10 @@ final class GameBoardBridgeViewModel: ObservableObject {
         guard let current = core.current else { return false }
         guard let topCard = stack.topCard, isCardUsable(stack) else { return false }
 
-        animationTargetGridPoint = current
+        // 現在位置からカードの移動量を適用し、演出で目指す盤面座標を算出する
+        // ここをプレイ前の現在地で固定してしまうと、カードが正しいマスへ移動しないため注意する
+        let targetPoint = current.offset(dx: topCard.move.dx, dy: topCard.move.dy)
+        animationTargetGridPoint = targetPoint
         hiddenCardIDs.insert(topCard.id)
         animatingCard = topCard
         animatingStackID = stack.id


### PR DESCRIPTION
## Summary
- 修正: 手札演出の移動先を現在位置ではなくカードが到達するマスへ設定し、盤面演出が正しく表示されるように変更

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68d4ea615534832cadb69e8051d347d8