### PR TITLE
Fix card overlay matched geometry roles

### DIFF
--- a/UI/GameCardAnimationOverlay.swift
+++ b/UI/GameCardAnimationOverlay.swift
@@ -44,7 +44,13 @@ private extension GameCardAnimationOverlay {
             )
 
             MoveCardIllustrationView(card: animatingCard.move)
-                .matchedGeometryEffect(id: animatingCard.id, in: cardAnimationNamespace)
+                // 盤面オーバーレイ側は matchedGeometryEffect のターゲット役に固定し、
+                // 手札側のビューと同時に isSource: true になる事態を避けて警告を抑止する
+                .matchedGeometryEffect(
+                    id: animatingCard.id,
+                    in: cardAnimationNamespace,
+                    isSource: false
+                )
                 .frame(width: cardFrame.width, height: cardFrame.height)
                 .position(boardBridge.animationState == .movingToBoard ? boardDestination : startCenter)
                 .scaleEffect(boardBridge.animationState == .movingToBoard ? 0.55 : 1.0)


### PR DESCRIPTION
## Summary
- set the SpriteKit overlay card view to act as the matchedGeometryEffect target so only the hand card is marked as a source
- document the reasoning in-line to prevent future duplicate source regressions

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d4f1034214832c8e23602b2dced367