### PR TITLE
Add campaign mode infrastructure with first stage

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -1,0 +1,300 @@
+import Foundation
+
+/// キャンペーンに登場するステージを一意に識別するための構造体
+/// - Note: 章番号と章内インデックスを組み合わせて管理し、UI 表示と永続化の双方で扱いやすいようにしている
+public struct CampaignStageID: Hashable, Codable {
+    /// 章番号（1 始まり）
+    public let chapter: Int
+    /// 章内でのステージ順序（1 始まり）
+    public let index: Int
+
+    /// 公開イニシャライザ
+    /// - Parameters:
+    ///   - chapter: 章番号
+    ///   - index: 章内インデックス
+    public init(chapter: Int, index: Int) {
+        self.chapter = chapter
+        self.index = index
+    }
+
+    /// "1-1" のような表示用コードを生成
+    public var displayCode: String {
+        "\(chapter)-\(index)"
+    }
+
+    /// UserDefaults へ保存する際のキー
+    var storageKey: String {
+        displayCode
+    }
+
+    /// 保存済みキー文字列から `CampaignStageID` を復元
+    /// - Parameter storageKey: "章-ステージ" 形式の文字列
+    init?(storageKey: String) {
+        let components = storageKey.split(separator: "-")
+        guard components.count == 2,
+              let chapter = Int(components[0]),
+              let index = Int(components[1])
+        else { return nil }
+        self.chapter = chapter
+        self.index = index
+    }
+}
+
+/// ステージ解放に必要な条件
+public enum CampaignStageUnlockRequirement: Equatable {
+    /// 常に解放済み
+    case always
+    /// 合計スター数が指定値以上
+    case totalStars(minimum: Int)
+    /// 指定ステージをクリア済み
+    case stageClear(CampaignStageID)
+}
+
+/// キャンペーンステージの実体定義
+public struct CampaignStage: Identifiable, Equatable {
+    /// ステージ固有の追加条件
+    public enum SecondaryObjective: Equatable {
+        /// 指定手数以内でクリア
+        case finishWithinMoves(maxMoves: Int)
+        /// 指定時間以内でクリア
+        case finishWithinSeconds(maxSeconds: Int)
+        /// ペナルティ加算なしでクリア
+        case finishWithoutPenalty
+
+        /// 条件をプレイ結果に照らし合わせて判定
+        /// - Parameter metrics: クリア時の統計値
+        /// - Returns: 条件を満たしていれば true
+        func isSatisfied(by metrics: CampaignStageClearMetrics) -> Bool {
+            switch self {
+            case .finishWithinMoves(let maxMoves):
+                return metrics.moveCount <= maxMoves
+            case .finishWithinSeconds(let maxSeconds):
+                return metrics.elapsedSeconds <= maxSeconds
+            case .finishWithoutPenalty:
+                return metrics.penaltyCount == 0
+            }
+        }
+
+        /// UI 表示向け説明文
+        var description: String {
+            switch self {
+            case .finishWithinMoves(let maxMoves):
+                return "移動 \(maxMoves) 手以内でクリア"
+            case .finishWithinSeconds(let maxSeconds):
+                return "\(maxSeconds) 秒以内でクリア"
+            case .finishWithoutPenalty:
+                return "ペナルティを受けずにクリア"
+            }
+        }
+    }
+
+    public let id: CampaignStageID
+    /// タイトル表示用の名称
+    public let title: String
+    /// 短い説明文
+    public let summary: String
+    /// 実際に利用するレギュレーション
+    public let regulation: GameMode.Regulation
+    /// 2 個目のスター獲得条件
+    public let secondaryObjective: SecondaryObjective?
+    /// 3 個目のスター獲得に必要なスコア上限
+    public let scoreTarget: Int?
+    /// ステージ解放条件
+    public let unlockRequirement: CampaignStageUnlockRequirement
+
+    /// 初期化
+    public init(
+        id: CampaignStageID,
+        title: String,
+        summary: String,
+        regulation: GameMode.Regulation,
+        secondaryObjective: SecondaryObjective?,
+        scoreTarget: Int?,
+        unlockRequirement: CampaignStageUnlockRequirement
+    ) {
+        self.id = id
+        self.title = title
+        self.summary = summary
+        self.regulation = regulation
+        self.secondaryObjective = secondaryObjective
+        self.scoreTarget = scoreTarget
+        self.unlockRequirement = unlockRequirement
+    }
+
+    /// UI で表示する際のコード表記
+    public var displayCode: String { id.displayCode }
+
+    /// 二つ目のスター条件説明
+    public var secondaryObjectiveDescription: String? {
+        secondaryObjective?.description
+    }
+
+    /// 三つ目のスター条件説明
+    public var scoreTargetDescription: String? {
+        guard let scoreTarget else { return nil }
+        return "スコア \(scoreTarget) pt 以下でクリア"
+    }
+
+    /// ステージ解放条件の説明
+    public var unlockDescription: String {
+        switch unlockRequirement {
+        case .always:
+            return "最初から解放済み"
+        case .totalStars(let minimum) where minimum <= 0:
+            return "最初から解放済み"
+        case .totalStars(let minimum):
+            return "スターを合計 \(minimum) 個集める"
+        case .stageClear(let requiredID):
+            return "ステージ \(requiredID.displayCode) をクリア"
+        }
+    }
+
+    /// クリア時の成績から獲得スター数を判定
+    /// - Parameter metrics: クリア時の統計値
+    /// - Returns: 達成状況の評価結果
+    public func evaluateClear(with metrics: CampaignStageClearMetrics) -> CampaignStageEvaluation {
+        let objectiveAchieved = secondaryObjective?.isSatisfied(by: metrics) ?? false
+        let scoreAchieved: Bool
+        if let scoreTarget {
+            scoreAchieved = metrics.score <= scoreTarget
+        } else {
+            scoreAchieved = false
+        }
+
+        var stars = 1 // クリアそのものが 1 個目のスター
+        if objectiveAchieved { stars += 1 }
+        if scoreAchieved { stars += 1 }
+
+        return CampaignStageEvaluation(
+            stageID: id,
+            earnedStars: stars,
+            achievedSecondaryObjective: objectiveAchieved,
+            achievedScoreGoal: scoreAchieved
+        )
+    }
+
+    /// ゲームプレイ用の `GameMode` を生成
+    /// - Returns: ステージに対応するモード
+    public func makeGameMode() -> GameMode {
+        GameMode(
+            identifier: .campaignStage,
+            displayName: "\(displayCode) \(title)",
+            regulation: regulation,
+            leaderboardEligible: false,
+            campaignMetadata: .init(stageID: id)
+        )
+    }
+}
+
+/// クリア時の統計値をまとめた構造体
+public struct CampaignStageClearMetrics {
+    public let moveCount: Int
+    public let penaltyCount: Int
+    public let elapsedSeconds: Int
+    public let totalMoveCount: Int
+    public let score: Int
+
+    public init(
+        moveCount: Int,
+        penaltyCount: Int,
+        elapsedSeconds: Int,
+        totalMoveCount: Int,
+        score: Int
+    ) {
+        self.moveCount = moveCount
+        self.penaltyCount = penaltyCount
+        self.elapsedSeconds = elapsedSeconds
+        self.totalMoveCount = totalMoveCount
+        self.score = score
+    }
+}
+
+/// ステージ評価結果
+public struct CampaignStageEvaluation {
+    public let stageID: CampaignStageID
+    public let earnedStars: Int
+    public let achievedSecondaryObjective: Bool
+    public let achievedScoreGoal: Bool
+}
+
+/// 章単位でステージを束ねる定義
+public struct CampaignChapter: Identifiable, Equatable {
+    public let id: Int
+    public let title: String
+    public let summary: String
+    public let stages: [CampaignStage]
+
+    public init(id: Int, title: String, summary: String, stages: [CampaignStage]) {
+        self.id = id
+        self.title = title
+        self.summary = summary
+        self.stages = stages
+    }
+}
+
+/// ステージ定義一式を提供するライブラリ
+public struct CampaignLibrary {
+    /// アプリ全体で共有するデフォルト定義
+    public static let shared = CampaignLibrary()
+
+    /// 章一覧
+    public let chapters: [CampaignChapter]
+
+    /// プライベートイニシャライザで定義を構築
+    public init() {
+        self.chapters = CampaignLibrary.buildChapters()
+    }
+
+    /// 指定 ID に一致するステージを検索
+    /// - Parameter id: 探索したいステージ ID
+    /// - Returns: 見つかった場合は該当ステージ
+    public func stage(with id: CampaignStageID) -> CampaignStage? {
+        for chapter in chapters {
+            if let stage = chapter.stages.first(where: { $0.id == id }) {
+                return stage
+            }
+        }
+        return nil
+    }
+
+    /// 全ステージの一次元配列
+    public var allStages: [CampaignStage] {
+        chapters.flatMap { $0.stages }
+    }
+
+    /// 定義の実装本体
+    private static func buildChapters() -> [CampaignChapter] {
+        // MARK: - 1 章のステージ群
+        let stage11 = CampaignStage(
+            id: CampaignStageID(chapter: 1, index: 1),
+            title: "序盤訓練",
+            summary: "4×4 の小さな盤面で基本操作を確認しましょう。",
+            regulation: GameMode.Regulation(
+                boardSize: 4,
+                handSize: 5,
+                nextPreviewCount: 3,
+                allowsStacking: true,
+                deckPreset: .standard,
+                spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 4)),
+                penalties: GameMode.PenaltySettings(
+                    deadlockPenaltyCost: 5,
+                    manualRedrawPenaltyCost: 5,
+                    manualDiscardPenaltyCost: 1,
+                    revisitPenaltyCost: 0
+                )
+            ),
+            secondaryObjective: .finishWithinMoves(maxMoves: 18),
+            scoreTarget: 280,
+            unlockRequirement: .totalStars(minimum: 0)
+        )
+
+        let chapter1 = CampaignChapter(
+            id: 1,
+            title: "基礎訓練",
+            summary: "カード移動の定石を学ぶ章。",
+            stages: [stage11]
+        )
+
+        return [chapter1]
+    }
+}

--- a/MonoKnightAppTests/CampaignProgressStoreTests.swift
+++ b/MonoKnightAppTests/CampaignProgressStoreTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import MonoKnightApp
+import Game
+
+/// キャンペーン進捗ストアの基本的な挙動を検証するテスト
+final class CampaignProgressStoreTests: XCTestCase {
+    /// テスト用に分離された UserDefaults を生成
+    private func makeIsolatedDefaults() throws -> UserDefaults {
+        let suiteName = "campaign_progress_tests." + UUID().uuidString
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("UserDefaults を生成できませんでした")
+            throw NSError(domain: "CampaignProgressStoreTests", code: -1)
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    /// 1-1 ステージの解放条件が初期状態で満たされていることを確認
+    func testStageInitiallyUnlocked() throws {
+        let defaults = try makeIsolatedDefaults()
+        let store = CampaignProgressStore(userDefaults: defaults)
+        let library = CampaignLibrary.shared
+        let stageID = CampaignStageID(chapter: 1, index: 1)
+        guard let stage = library.stage(with: stageID) else {
+            XCTFail("ステージ定義が見つかりません")
+            return
+        }
+
+        XCTAssertTrue(store.isStageUnlocked(stage), "初期ステージは最初から解放されている想定です")
+    }
+
+    /// クリア登録によってスター数やベストスコアが更新されることを検証
+    func testRegisterClearUpdatesProgress() throws {
+        let defaults = try makeIsolatedDefaults()
+        let store = CampaignProgressStore(userDefaults: defaults)
+        let library = CampaignLibrary.shared
+        let stageID = CampaignStageID(chapter: 1, index: 1)
+        guard let stage = library.stage(with: stageID) else {
+            XCTFail("ステージ定義が見つかりません")
+            return
+        }
+
+        let metrics = CampaignStageClearMetrics(
+            moveCount: 16,
+            penaltyCount: 0,
+            elapsedSeconds: 90,
+            totalMoveCount: 16,
+            score: 250
+        )
+
+        let record = store.registerClear(for: stage, metrics: metrics)
+        XCTAssertEqual(record.progress.earnedStars, 3, "1-1 は指定条件を満たすと 3 スター獲得できる想定です")
+        XCTAssertEqual(store.totalStars, 3)
+
+        // より悪いスコアで再登録してもベスト値は維持されることを確認
+        let worseMetrics = CampaignStageClearMetrics(
+            moveCount: 20,
+            penaltyCount: 2,
+            elapsedSeconds: 140,
+            totalMoveCount: 22,
+            score: 360
+        )
+        _ = store.registerClear(for: stage, metrics: worseMetrics)
+        let stored = store.progress(for: stageID)
+        XCTAssertEqual(stored?.bestScore, metrics.score, "ベストスコアはより良い値を保持する必要があります")
+        XCTAssertEqual(stored?.earnedStars, 3, "一度獲得したスターは維持される想定です")
+    }
+}

--- a/Services/CampaignProgressStore.swift
+++ b/Services/CampaignProgressStore.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Game
+import SharedSupport
+
+/// キャンペーンの進捗（獲得スターやベストスコア）を管理するストア
+/// - Note: `UserDefaults` へ JSON で保存し、アプリ再起動後も進捗を復元できるようにする
+@MainActor
+final class CampaignProgressStore: ObservableObject {
+    /// UserDefaults へ保存する際のキー
+    private let storageKey = "campaign_progress_v1"
+    /// 永続化先
+    private let userDefaults: UserDefaults
+
+    /// ステージごとの進捗マップ
+    @Published private(set) var progressMap: [CampaignStageID: CampaignStageProgress]
+
+    /// 合計スター数
+    var totalStars: Int {
+        progressMap.values.reduce(0) { $0 + $1.earnedStars }
+    }
+
+    /// 指定したステージの進捗を取得
+    /// - Parameter stageID: 参照したいステージ ID
+    /// - Returns: 保存済みの進捗があればその値
+    func progress(for stageID: CampaignStageID) -> CampaignStageProgress? {
+        progressMap[stageID]
+    }
+
+    /// 初期化
+    /// - Parameter userDefaults: 保存に利用する `UserDefaults`
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        self.progressMap = [:]
+        self.progressMap = loadProgress()
+    }
+
+    /// ステージが解放済みか判定する
+    /// - Parameter stage: 対象ステージ
+    /// - Returns: 解放済みであれば true
+    func isStageUnlocked(_ stage: CampaignStage) -> Bool {
+        switch stage.unlockRequirement {
+        case .always:
+            return true
+        case .totalStars(let minimum):
+            return totalStars >= minimum
+        case .stageClear(let requiredID):
+            let earned = progressMap[requiredID]?.earnedStars ?? 0
+            return earned > 0
+        }
+    }
+
+    /// クリア結果を登録し、獲得スターやベスト記録を更新する
+    /// - Parameters:
+    ///   - stage: 対象ステージ
+    ///   - metrics: クリア時の統計値
+    /// - Returns: 更新後の記録と評価
+    @discardableResult
+    func registerClear(for stage: CampaignStage, metrics: CampaignStageClearMetrics) -> CampaignStageClearRecord {
+        let evaluation = stage.evaluateClear(with: metrics)
+        var current = progressMap[stage.id] ?? CampaignStageProgress()
+
+        current.earnedStars = max(current.earnedStars, evaluation.earnedStars)
+        if evaluation.achievedSecondaryObjective {
+            current.achievedSecondaryObjective = true
+        }
+        if evaluation.achievedScoreGoal {
+            current.achievedScoreGoal = true
+        }
+
+        current.bestScore = CampaignProgressStore.minValue(current.bestScore, newValue: metrics.score)
+        current.bestMoveCount = CampaignProgressStore.minValue(current.bestMoveCount, newValue: metrics.moveCount)
+        current.bestTotalMoveCount = CampaignProgressStore.minValue(current.bestTotalMoveCount, newValue: metrics.totalMoveCount)
+        current.bestPenaltyCount = CampaignProgressStore.minValue(current.bestPenaltyCount, newValue: metrics.penaltyCount)
+        current.bestElapsedSeconds = CampaignProgressStore.minValue(current.bestElapsedSeconds, newValue: metrics.elapsedSeconds)
+
+        progressMap[stage.id] = current
+        saveProgress()
+
+        debugLog("CampaignProgressStore: ステージ \(stage.id.displayCode) を更新 スター=\(current.earnedStars)")
+
+        return CampaignStageClearRecord(stage: stage, evaluation: evaluation, progress: current)
+    }
+
+    /// 進捗データを読み出し
+    private func loadProgress() -> [CampaignStageID: CampaignStageProgress] {
+        guard let data = userDefaults.data(forKey: storageKey) else { return [:] }
+        do {
+            let decoded = try JSONDecoder().decode([String: CampaignStageProgress].self, from: data)
+            var map: [CampaignStageID: CampaignStageProgress] = [:]
+            for (key, value) in decoded {
+                guard let id = CampaignStageID(storageKey: key) else { continue }
+                map[id] = value
+            }
+            return map
+        } catch {
+            debugError("CampaignProgressStore: 読み込みに失敗しました -> \(error)")
+            return [:]
+        }
+    }
+
+    /// 現在の進捗を保存
+    private func saveProgress() {
+        let encoder = JSONEncoder()
+        let storageDictionary = progressMap.reduce(into: [String: CampaignStageProgress]()) { partialResult, element in
+            partialResult[element.key.storageKey] = element.value
+        }
+        do {
+            let data = try encoder.encode(storageDictionary)
+            userDefaults.set(data, forKey: storageKey)
+        } catch {
+            debugError("CampaignProgressStore: 保存に失敗しました -> \(error)")
+        }
+    }
+
+    /// ベスト値を更新する際の最小値計算
+    private static func minValue(_ current: Int?, newValue: Int) -> Int {
+        if let current {
+            return min(current, newValue)
+        } else {
+            return newValue
+        }
+    }
+}
+
+/// ステージの進捗を表すモデル
+struct CampaignStageProgress: Codable {
+    /// 獲得済みスター数
+    var earnedStars: Int = 0
+    /// 二つ目のスター条件を達成したことがあるか
+    var achievedSecondaryObjective: Bool = false
+    /// 三つ目のスター条件を達成したことがあるか
+    var achievedScoreGoal: Bool = false
+    /// ベストスコア（低いほど良い）
+    var bestScore: Int?
+    /// ベストの移動回数
+    var bestMoveCount: Int?
+    /// ベストの合計手数
+    var bestTotalMoveCount: Int?
+    /// 最小ペナルティ手数
+    var bestPenaltyCount: Int?
+    /// 最短クリアタイム（秒）
+    var bestElapsedSeconds: Int?
+}
+
+/// クリア登録後のレスポンス
+struct CampaignStageClearRecord {
+    let stage: CampaignStage
+    let evaluation: CampaignStageEvaluation
+    let progress: CampaignStageProgress
+}

--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+import Game
+import SharedSupport
+
+/// キャンペーンのステージ一覧を表示し、挑戦するステージを選択するビュー
+struct CampaignStageSelectionView: View {
+    /// ステージ定義
+    let campaignLibrary: CampaignLibrary
+    /// 進捗ストア
+    @ObservedObject var progressStore: CampaignProgressStore
+    /// 既に選択済みのステージ
+    let selectedStageID: CampaignStageID?
+    /// クローズハンドラ
+    let onClose: () -> Void
+    /// ステージ決定時のハンドラ
+    let onSelectStage: (CampaignStage) -> Void
+
+    /// テーマカラー
+    private var theme = AppTheme()
+
+    var body: some View {
+        List {
+            ForEach(campaignLibrary.chapters) { chapter in
+                Section {
+                    ForEach(chapter.stages) { stage in
+                        stageRow(for: stage)
+                    }
+                } header: {
+                    Text("Chapter \(chapter.id) \(chapter.title)")
+                        .font(.system(size: 15, weight: .semibold, design: .rounded))
+                } footer: {
+                    Text(chapter.summary)
+                        .font(.system(size: 11, weight: .regular, design: .rounded))
+                        .foregroundColor(.secondary)
+                        .padding(.top, 4)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("キャンペーン")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("閉じる") { onClose() }
+            }
+        }
+    }
+
+    /// ステージ行の描画
+    /// - Parameter stage: 表示対象のステージ
+    /// - Returns: ステージを選択するためのボタン
+    private func stageRow(for stage: CampaignStage) -> some View {
+        let isUnlocked = progressStore.isStageUnlocked(stage)
+        let earnedStars = progressStore.progress(for: stage.id)?.earnedStars ?? 0
+        let isSelected = stage.id == selectedStageID
+
+        return Button {
+            guard isUnlocked else { return }
+            debugLog("CampaignStageSelectionView: ステージを選択 -> \(stage.id.displayCode)")
+            onSelectStage(stage)
+        } label: {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Text(stage.displayCode)
+                        .font(.system(size: 13, weight: .semibold, design: .rounded))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            Capsule().fill(theme.backgroundElevated.opacity(0.8))
+                        )
+                        .foregroundColor(theme.textPrimary)
+                    Text(stage.title)
+                        .font(.system(size: 15, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.textPrimary)
+                    Spacer(minLength: 0)
+                    if isSelected {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(theme.accentPrimary)
+                            .font(.system(size: 18, weight: .bold))
+                    } else if !isUnlocked {
+                        Image(systemName: "lock.fill")
+                            .foregroundColor(theme.textSecondary.opacity(0.7))
+                            .font(.system(size: 15, weight: .medium))
+                    }
+                }
+
+                Text(stage.summary)
+                    .font(.system(size: 12, weight: .regular, design: .rounded))
+                    .foregroundColor(theme.textSecondary)
+
+                starIcons(for: earnedStars)
+
+                if let objective = stage.secondaryObjectiveDescription {
+                    Text("★2: \(objective)")
+                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                        .foregroundColor(theme.textSecondary.opacity(0.85))
+                }
+
+                if let scoreText = stage.scoreTargetDescription {
+                    Text("★3: \(scoreText)")
+                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                        .foregroundColor(theme.textSecondary.opacity(0.85))
+                }
+
+                if !isUnlocked {
+                    Text("解放条件: \(stage.unlockDescription)")
+                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                        .foregroundColor(theme.accentPrimary)
+                        .padding(.top, 2)
+                }
+            }
+            .padding(.vertical, 8)
+        }
+        .buttonStyle(.plain)
+        .disabled(!isUnlocked)
+    }
+
+    /// 星アイコンを生成する
+    /// - Parameter earnedStars: 獲得済みの星の数
+    /// - Returns: 星 3 つの並び
+    private func starIcons(for earnedStars: Int) -> some View {
+        HStack(spacing: 4) {
+            ForEach(0..<3, id: \.self) { index in
+                Image(systemName: index < earnedStars ? "star.fill" : "star")
+                    .foregroundColor(index < earnedStars ? theme.accentPrimary : theme.textSecondary.opacity(0.6))
+            }
+        }
+        .accessibilityLabel("スター獲得数: \(earnedStars) / 3")
+        .padding(.top, 4)
+    }
+}

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -81,6 +81,7 @@ struct GameView: View {
             gameInterfaces: gameInterfaces,
             gameCenterService: GameCenterService.shared,
             adsService: AdsService.shared,
+            campaignProgressStore: CampaignProgressStore(),
             onRequestReturnToTitle: onRequestReturnToTitle
         )
     }
@@ -91,6 +92,7 @@ struct GameView: View {
         gameInterfaces: GameModuleInterfaces,
         gameCenterService: GameCenterServiceProtocol,
         adsService: AdsServiceProtocol,
+        campaignProgressStore: CampaignProgressStore,
         onRequestReturnToTitle: (() -> Void)? = nil
     ) {
         // MARK: - GameViewModel の生成を 1 度きりに抑制
@@ -106,6 +108,7 @@ struct GameView: View {
                 gameInterfaces: gameInterfaces,
                 gameCenterService: gameCenterService,
                 adsService: adsService,
+                campaignProgressStore: campaignProgressStore,
                 onRequestReturnToTitle: onRequestReturnToTitle,
                 initialHandOrderingRawValue: savedOrdering
             )
@@ -145,6 +148,8 @@ struct GameView: View {
                 penaltyCount: viewModel.penaltyCount,
                 elapsedSeconds: viewModel.elapsedSeconds,
                 modeIdentifier: viewModel.mode.identifier,
+                modeDisplayName: viewModel.mode.displayName,
+                showsLeaderboardButton: viewModel.isLeaderboardEligible,
                 onRetry: {
                     // ViewModel 側でリセットと広告フラグの再設定をまとめて処理する
                     viewModel.handleResultRetry()

--- a/UI/ResultView.swift
+++ b/UI/ResultView.swift
@@ -17,6 +17,10 @@ struct ResultView: View {
 
     /// スコア送信・ランキング表示に利用するゲームモード識別子
     let modeIdentifier: GameMode.Identifier
+    /// 表示用のモード名称
+    let modeDisplayName: String
+    /// ランキングボタンを表示するかどうか
+    let showsLeaderboardButton: Bool
 
     /// 再戦処理を外部から受け取るクロージャ
     let onRetry: () -> Void
@@ -49,6 +53,8 @@ struct ResultView: View {
         penaltyCount: Int,
         elapsedSeconds: Int,
         modeIdentifier: GameMode.Identifier,
+        modeDisplayName: String,
+        showsLeaderboardButton: Bool = true,
         onRetry: @escaping () -> Void
     ) {
         self.init(
@@ -56,6 +62,8 @@ struct ResultView: View {
             penaltyCount: penaltyCount,
             elapsedSeconds: elapsedSeconds,
             modeIdentifier: modeIdentifier,
+            modeDisplayName: modeDisplayName,
+            showsLeaderboardButton: showsLeaderboardButton,
             onRetry: onRetry,
             gameCenterService: GameCenterService.shared,
             adsService: AdsService.shared
@@ -67,6 +75,8 @@ struct ResultView: View {
         penaltyCount: Int,
         elapsedSeconds: Int,
         modeIdentifier: GameMode.Identifier,
+        modeDisplayName: String,
+        showsLeaderboardButton: Bool = true,
         onRetry: @escaping () -> Void,
 
         gameCenterService: GameCenterServiceProtocol,
@@ -83,6 +93,8 @@ struct ResultView: View {
         self.penaltyCount = penaltyCount
         self.elapsedSeconds = elapsedSeconds
         self.modeIdentifier = modeIdentifier
+        self.modeDisplayName = modeDisplayName
+        self.showsLeaderboardButton = showsLeaderboardButton
         self.onRetry = onRetry
         self.gameCenterService = resolvedGameCenterService
         self.adsService = resolvedAdsService
@@ -153,18 +165,18 @@ struct ResultView: View {
                 .buttonStyle(.borderedProminent)
 
                 // MARK: - Game Center ランキングボタン
-                Button(action: {
-                    // 設定が有効なら成功フィードバックを発火
-                    if hapticsEnabled {
-                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                if showsLeaderboardButton {
+                    Button(action: {
+                        if hapticsEnabled {
+                            UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        }
+                        gameCenterService.showLeaderboard(for: modeIdentifier)
+                    }) {
+                        Text("ランキング")
+                            .frame(maxWidth: .infinity)
                     }
-                    // 直前にプレイしていたモードに対応するテスト用リーダーボードを開く
-                    gameCenterService.showLeaderboard(for: modeIdentifier)
-                }) {
-                    Text("ランキング")
-                        .frame(maxWidth: .infinity)
+                    .buttonStyle(.bordered)
                 }
-                .buttonStyle(.bordered)
 
                 // MARK: - リザルト詳細のテーブル
                 VStack(alignment: .leading, spacing: 12) {
@@ -268,7 +280,9 @@ struct ResultView: View {
             // ビュー表示時に広告表示をトリガー
             adsService.showInterstitial()
             // ベスト記録の更新を判定
-            updateBest()
+            if showsLeaderboardButton {
+                updateBest()
+            }
         }
     }
 
@@ -311,7 +325,7 @@ struct ResultView: View {
     /// ShareLink へ渡す共有メッセージを生成
     private var shareMessage: String {
         let penaltyText = penaltyCount == 0 ? "ペナルティなし" : "ペナルティ +\(penaltyCount) 手"
-        return "MonoKnight 5x5 クリア！ポイント \(points)（移動 \(moveCount) 手 / \(penaltyText) / 所要 \(formattedElapsedTime)）"
+        return "MonoKnight \(modeDisplayName) クリア！ポイント \(points)（移動 \(moveCount) 手 / \(penaltyText) / 所要 \(formattedElapsedTime)）"
     }
 
     /// iPad 表示時の最大コンテンツ幅を制御し、中央寄せの見た目を整える
@@ -369,6 +383,7 @@ struct ResultView_Previews: PreviewProvider {
             penaltyCount: 6,
             elapsedSeconds: 132,
             modeIdentifier: .standard5x5,
+            modeDisplayName: "スタンダード",
             onRetry: {},
             gameCenterService: GameCenterService.shared,
             adsService: AdsService.shared
@@ -383,6 +398,7 @@ struct ResultView_Previews: PreviewProvider {
         penaltyCount: 6,
         elapsedSeconds: 132,
         modeIdentifier: .standard5x5,
+        modeDisplayName: "スタンダード",
         onRetry: {}
     )
 }


### PR DESCRIPTION
## Summary
- introduce reusable campaign stage definitions and a progress store to track stars and unlock requirements
- update the title screen and game flow to surface campaign selection, pass stage context, and record results
- expand the result view and supporting view models to handle non-leaderboard stages, plus add unit tests for progress persistence

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d52772a284832cb244b81fade3ed11