### PR TITLE
Expose storage key initializer for CampaignStageID

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -29,7 +29,7 @@ public struct CampaignStageID: Hashable, Codable {
 
     /// 保存済みキー文字列から `CampaignStageID` を復元
     /// - Parameter storageKey: "章-ステージ" 形式の文字列
-    init?(storageKey: String) {
+    public init?(storageKey: String) {
         let components = storageKey.split(separator: "-")
         guard components.count == 2,
               let chapter = Int(components[0]),


### PR DESCRIPTION
## Summary
- make the CampaignStageID initializer that restores from a storage key public so other modules can use it

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d52feef700832caa89c6a6739b32c2