### PR TITLE
Fix debugError usage in CampaignProgressStore

### DIFF
--- a/Services/CampaignProgressStore.swift
+++ b/Services/CampaignProgressStore.swift
@@ -93,7 +93,8 @@ final class CampaignProgressStore: ObservableObject {
             }
             return map
         } catch {
-            debugError("CampaignProgressStore: 読み込みに失敗しました -> \(error)")
+            // エラーの詳細を debugError で出力しつつ、発生箇所を分かりやすくメッセージ化する
+            debugError(error, message: "CampaignProgressStore: 読み込みに失敗しました")
             return [:]
         }
     }
@@ -108,7 +109,8 @@ final class CampaignProgressStore: ObservableObject {
             let data = try encoder.encode(storageDictionary)
             userDefaults.set(data, forKey: storageKey)
         } catch {
-            debugError("CampaignProgressStore: 保存に失敗しました -> \(error)")
+            // 保存時に失敗した場合もエラー内容と原因箇所を記録する
+            debugError(error, message: "CampaignProgressStore: 保存に失敗しました")
         }
     }
 


### PR DESCRIPTION
## Summary
- route JSON load/save error handling in `CampaignProgressStore` through the shared `debugError` helper
- add Japanese comments describing the intent of the new error logging calls

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d5300adb40832ca80e35bdc70eb95b