### PR TITLE
Update campaign stage penalties and add interactive loading overlay

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -53,6 +53,8 @@ public final class GameCore: ObservableObject {
     @Published public private(set) var elapsedSeconds: Int = 0
     /// 直近で加算されたペナルティ手数
     @Published public private(set) var lastPenaltyAmount: Int = 0
+    /// プレイ中に既踏マスへ戻ったことがあるかどうか
+    public private(set) var hasRevisitedTile: Bool = false
 
     /// 合計手数（移動 + ペナルティ）の計算プロパティ
     /// - Note: 将来的に別レギュレーションで利用する可能性があるため個別に保持
@@ -136,6 +138,10 @@ public final class GameCore: ObservableObject {
             penaltyCount += mode.revisitPenaltyCost
             debugLog("既踏マス再訪ペナルティ: +\(mode.revisitPenaltyCost)")
         }
+        if revisiting {
+            // 既踏マスへ戻った事実を記録し、キャンペーン評価条件へ利用する
+            hasRevisitedTile = true
+        }
 
         // 盤面更新に合わせて残り踏破数を読み上げ
         announceRemainingTiles()
@@ -199,6 +205,7 @@ public final class GameCore: ObservableObject {
         penaltyCount = 0
         elapsedSeconds = 0
         lastPenaltyAmount = 0
+        hasRevisitedTile = false
         penaltyEventID = nil
         boardTapPlayRequest = nil
         isAwaitingManualDiscardSelection = false

--- a/MonoKnightAppTests/CampaignProgressStoreTests.swift
+++ b/MonoKnightAppTests/CampaignProgressStoreTests.swift
@@ -45,7 +45,8 @@ final class CampaignProgressStoreTests: XCTestCase {
             penaltyCount: 0,
             elapsedSeconds: 90,
             totalMoveCount: 16,
-            score: 250
+            score: 250,
+            hasRevisitedTile: false
         )
 
         let record = store.registerClear(for: stage, metrics: metrics)
@@ -58,7 +59,8 @@ final class CampaignProgressStoreTests: XCTestCase {
             penaltyCount: 2,
             elapsedSeconds: 140,
             totalMoveCount: 22,
-            score: 360
+            score: 360,
+            hasRevisitedTile: true
         )
         _ = store.registerClear(for: stage, metrics: worseMetrics)
         let stored = store.progress(for: stageID)

--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -117,7 +117,7 @@ struct CampaignStageSelectionView: View {
                         .foregroundColor(theme.textSecondary.opacity(0.85))
                 }
 
-                if let scoreText = stage.scoreTargetDescription {
+                if let scoreText = stage.scoreGoalDescription {
                     Text("★3: \(scoreText)")
                         .font(.system(size: 11, weight: .medium, design: .rounded))
                         .foregroundColor(theme.textSecondary.opacity(0.85))

--- a/UI/GameViewModel.swift
+++ b/UI/GameViewModel.swift
@@ -511,7 +511,8 @@ final class GameViewModel: ObservableObject {
             penaltyCount: core.penaltyCount,
             elapsedSeconds: core.elapsedSeconds,
             totalMoveCount: core.totalMoveCount,
-            score: core.score
+            score: core.score,
+            hasRevisitedTile: core.hasRevisitedTile
         )
 
         campaignProgressStore.registerClear(for: stage, metrics: metrics)


### PR DESCRIPTION
## Summary
- adjust campaign stage 1-1 penalties and objectives to require no revisits and a score under 350
- extend campaign evaluation models to support revisit tracking and flexible score goals
- replace the loading overlay with a stage briefing that shows penalties, rewards, progress, and requires an explicit start action

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68d5a6368f28832cb4aabbcf11705806