### PR TITLE
Update campaign stage 1-1 penalties and loading overlay

### DIFF
--- a/MonoKnightAppTests/CampaignProgressStoreTests.swift
+++ b/MonoKnightAppTests/CampaignProgressStoreTests.swift
@@ -45,7 +45,8 @@ final class CampaignProgressStoreTests: XCTestCase {
             penaltyCount: 0,
             elapsedSeconds: 90,
             totalMoveCount: 16,
-            score: 250
+            score: 250,
+            hasRevisitedTile: false
         )
 
         let record = store.registerClear(for: stage, metrics: metrics)
@@ -58,7 +59,8 @@ final class CampaignProgressStoreTests: XCTestCase {
             penaltyCount: 2,
             elapsedSeconds: 140,
             totalMoveCount: 22,
-            score: 360
+            score: 360,
+            hasRevisitedTile: true
         )
         _ = store.registerClear(for: stage, metrics: worseMetrics)
         let stored = store.progress(for: stageID)

--- a/Tests/GameTests/GameCoreTests.swift
+++ b/Tests/GameTests/GameCoreTests.swift
@@ -471,6 +471,7 @@ final class GameCoreTests: XCTestCase {
         core.simulateSpawnSelection(forTesting: spawnPoint)
 
         XCTAssertEqual(core.penaltyCount, 0)
+        XCTAssertFalse(core.hasRevisitedTile, "初期状態で再訪フラグが立っていてはいけません")
 
         guard let firstMoveIndex = core.handStacks.enumerated().first(where: { _, stack in
             stack.topCard?.move == .knightUp2Right1
@@ -490,6 +491,7 @@ final class GameCoreTests: XCTestCase {
         core.playCard(at: returnIndex)
 
         XCTAssertEqual(core.penaltyCount, core.mode.revisitPenaltyCost, "既踏マスへの再訪ペナルティが適用されていない")
+        XCTAssertTrue(core.hasRevisitedTile, "既踏マスへ戻った場合はフラグが立つべきです")
     }
 
     /// クラシカルチャレンジの手動引き直しでモード固有のペナルティ量が適用されるか検証

--- a/UI/GameViewModel.swift
+++ b/UI/GameViewModel.swift
@@ -511,7 +511,8 @@ final class GameViewModel: ObservableObject {
             penaltyCount: core.penaltyCount,
             elapsedSeconds: core.elapsedSeconds,
             totalMoveCount: core.totalMoveCount,
-            score: core.score
+            score: core.score,
+            hasRevisitedTile: core.hasRevisitedTile
         )
 
         campaignProgressStore.registerClear(for: stage, metrics: metrics)


### PR DESCRIPTION
## Summary
- adjust campaign stage 1-1 to use the new penalty costs, no-revisit objective, and a score goal that requires clearing below 350 points
- track whether a run revisits a tile so the new campaign objective and progress metrics can be evaluated
- replace the loading overlay with a manual start screen that lists penalties, reward conditions, prior progress, and high score before entering the stage

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68d5b4d894e4832c88f58f73d1d2d33e