### PR TITLE
Restore campaign metrics enhancements

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -48,6 +48,9 @@ public final class GameCore: ObservableObject {
     @Published public private(set) var moveCount: Int = 0
     /// ペナルティによる加算手数（手詰まり通知に利用するため公開）
     @Published public private(set) var penaltyCount: Int = 0
+    /// プレイ中に一度でも既踏マスへ戻ったかどうか
+    /// - Note: キャンペーンの追加リワード条件「同じマスを踏まない」を判定するための状態
+    @Published public private(set) var hasRevisitedTile: Bool = false
     /// クリアまでに要した経過秒数
     /// - Note: クリア確定時に計測し、リセット時に 0 へ戻す
     @Published public private(set) var elapsedSeconds: Int = 0
@@ -131,10 +134,14 @@ public final class GameCore: ObservableObject {
         board.markVisited(target)
         moveCount += 1
 
-        // 既踏マスへの再訪ペナルティを加算
-        if revisiting && mode.revisitPenaltyCost > 0 {
-            penaltyCount += mode.revisitPenaltyCost
-            debugLog("既踏マス再訪ペナルティ: +\(mode.revisitPenaltyCost)")
+        // 既踏マスへ戻った場合はフラグを立て、必要に応じてペナルティを加算する
+        if revisiting {
+            hasRevisitedTile = true
+
+            if mode.revisitPenaltyCost > 0 {
+                penaltyCount += mode.revisitPenaltyCost
+                debugLog("既踏マス再訪ペナルティ: +\(mode.revisitPenaltyCost)")
+            }
         }
 
         // 盤面更新に合わせて残り踏破数を読み上げ
@@ -197,6 +204,7 @@ public final class GameCore: ObservableObject {
         current = mode.initialSpawnPoint
         moveCount = 0
         penaltyCount = 0
+        hasRevisitedTile = false
         elapsedSeconds = 0
         lastPenaltyAmount = 0
         penaltyEventID = nil
@@ -370,6 +378,7 @@ extension GameCore {
         core.current = resolvedCurrent
         core.moveCount = 0
         core.penaltyCount = 0
+        core.hasRevisitedTile = false
         core.progress = (resolvedCurrent == nil && mode.requiresSpawnSelection) ? .awaitingSpawn : .playing
 
         core.handManager.resetAll(using: &core.deck)
@@ -388,10 +397,12 @@ extension GameCore {
     ///   - moveCount: 設定したい移動回数
     ///   - penaltyCount: 設定したいペナルティ手数
     ///   - elapsedSeconds: 設定したい所要時間（秒）
-    func overrideMetricsForTesting(moveCount: Int, penaltyCount: Int, elapsedSeconds: Int) {
+    ///   - hasRevisitedTile: 既踏マスへ戻ったことがあるかどうか（追加リワード条件の検証に使用）
+    func overrideMetricsForTesting(moveCount: Int, penaltyCount: Int, elapsedSeconds: Int, hasRevisitedTile: Bool = false) {
         self.moveCount = moveCount
         self.penaltyCount = penaltyCount
         self.elapsedSeconds = elapsedSeconds
+        self.hasRevisitedTile = hasRevisitedTile
         sessionTimer.overrideFinalizedElapsedSecondsForTesting(elapsedSeconds)
     }
 

--- a/MonoKnightAppTests/CampaignProgressStoreTests.swift
+++ b/MonoKnightAppTests/CampaignProgressStoreTests.swift
@@ -45,7 +45,8 @@ final class CampaignProgressStoreTests: XCTestCase {
             penaltyCount: 0,
             elapsedSeconds: 90,
             totalMoveCount: 16,
-            score: 250
+            score: 250,
+            hasRevisitedTile: false
         )
 
         let record = store.registerClear(for: stage, metrics: metrics)
@@ -58,7 +59,8 @@ final class CampaignProgressStoreTests: XCTestCase {
             penaltyCount: 2,
             elapsedSeconds: 140,
             totalMoveCount: 22,
-            score: 360
+            score: 360,
+            hasRevisitedTile: true
         )
         _ = store.registerClear(for: stage, metrics: worseMetrics)
         let stored = store.progress(for: stageID)

--- a/Tests/GameTests/GameCoreTests.swift
+++ b/Tests/GameTests/GameCoreTests.swift
@@ -471,6 +471,7 @@ final class GameCoreTests: XCTestCase {
         core.simulateSpawnSelection(forTesting: spawnPoint)
 
         XCTAssertEqual(core.penaltyCount, 0)
+        XCTAssertFalse(core.hasRevisitedTile, "初期状態で再訪フラグが立っていてはいけません")
 
         guard let firstMoveIndex = core.handStacks.enumerated().first(where: { _, stack in
             stack.topCard?.move == .knightUp2Right1
@@ -480,6 +481,7 @@ final class GameCoreTests: XCTestCase {
         }
         core.playCard(at: firstMoveIndex)
         XCTAssertEqual(core.penaltyCount, 0)
+        XCTAssertFalse(core.hasRevisitedTile, "未踏マスを移動した直後はフラグが false のままの想定です")
 
         guard let returnIndex = core.handStacks.enumerated().first(where: { _, stack in
             stack.topCard?.move == .knightDown2Left1
@@ -490,6 +492,7 @@ final class GameCoreTests: XCTestCase {
         core.playCard(at: returnIndex)
 
         XCTAssertEqual(core.penaltyCount, core.mode.revisitPenaltyCost, "既踏マスへの再訪ペナルティが適用されていない")
+        XCTAssertTrue(core.hasRevisitedTile, "既踏マスへ戻った場合はフラグが立つべきです")
     }
 
     /// クラシカルチャレンジの手動引き直しでモード固有のペナルティ量が適用されるか検証

--- a/UI/GameViewModel.swift
+++ b/UI/GameViewModel.swift
@@ -511,7 +511,8 @@ final class GameViewModel: ObservableObject {
             penaltyCount: core.penaltyCount,
             elapsedSeconds: core.elapsedSeconds,
             totalMoveCount: core.totalMoveCount,
-            score: core.score
+            score: core.score,
+            hasRevisitedTile: core.hasRevisitedTile
         )
 
         campaignProgressStore.registerClear(for: stage, metrics: metrics)

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -17,6 +17,8 @@ struct RootView: View {
     private let gameCenterService: GameCenterServiceProtocol
     /// 広告表示を扱うサービス（GameView へ受け渡す）
     private let adsService: AdsServiceProtocol
+    /// キャンペーンステージ定義を参照するライブラリ
+    private let campaignLibrary = CampaignLibrary.shared
     /// デバイスの横幅サイズクラスを参照し、iPad などレギュラー幅での余白やログ出力を調整する
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     /// 画面全体の状態とログ出力を一元管理するステートストア
@@ -92,6 +94,13 @@ final class RootViewStateStore: ObservableObject {
             debugLog("RootView.isPreparingGame 更新: \(isPreparingGame)")
         }
     }
+    /// ゲーム開始準備が完了し、ユーザーの開始操作待ちかどうか
+    @Published var isGameReadyForManualStart: Bool {
+        didSet {
+            guard oldValue != isGameReadyForManualStart else { return }
+            debugLog("RootView.isGameReadyForManualStart 更新: \(isGameReadyForManualStart)")
+        }
+    }
     /// 実際にプレイへ適用しているモード
     @Published var activeMode: GameMode {
         didSet {
@@ -140,6 +149,7 @@ final class RootViewStateStore: ObservableObject {
         self.isAuthenticated = initialIsAuthenticated
         self.isShowingTitleScreen = true
         self.isPreparingGame = false
+        self.isGameReadyForManualStart = false
         self.activeMode = .standard
         self.selectedModeForTitle = .standard
         self.gameSessionID = UUID()
@@ -197,6 +207,14 @@ private extension RootView {
         )
     }
 
+    /// 現在のモードに対応するキャンペーンステージを取得する
+    /// - Parameter mode: 判定対象のゲームモード
+    /// - Returns: キャンペーンステージであれば定義、該当しなければ nil
+    func campaignStage(for mode: GameMode) -> CampaignStage? {
+        guard let metadata = mode.campaignMetadataSnapshot else { return nil }
+        return campaignLibrary.stage(with: metadata.stageID)
+    }
+
     /// RootView 本体の `body` から切り離したメソッドで、サブビュー生成ロジックを共通化する
     /// - Parameter layoutContext: GeometryReader から構築したレイアウト情報
     /// - Returns: 依存サービスや状態をバインディングした `RootContentView`
@@ -213,6 +231,7 @@ private extension RootView {
             isAuthenticated: stateStore.binding(for: \.isAuthenticated),
             isShowingTitleScreen: stateStore.binding(for: \.isShowingTitleScreen),
             isPreparingGame: stateStore.binding(for: \.isPreparingGame),
+            isGameReadyForManualStart: stateStore.binding(for: \.isGameReadyForManualStart),
             activeMode: stateStore.binding(for: \.activeMode),
             selectedModeForTitle: stateStore.binding(for: \.selectedModeForTitle),
             gameSessionID: stateStore.binding(for: \.gameSessionID),
@@ -227,6 +246,10 @@ private extension RootView {
             onReturnToTitle: {
                 // GameView からの戻る要求をハンドリングし、タイトル表示へ切り替える
                 handleReturnToTitleRequest()
+            },
+            onConfirmGameStart: {
+                // ローディング完了後の開始操作を受け取り、ゲームをスタートさせる
+                finishGamePreparationAndStart()
             }
         )
     }
@@ -280,6 +303,8 @@ private extension RootView {
         @Binding var isShowingTitleScreen: Bool
         /// ゲーム準備中（ローディング表示中）かどうか
         @Binding var isPreparingGame: Bool
+        /// 初期化が完了しユーザー操作待ちかどうか
+        @Binding var isGameReadyForManualStart: Bool
         /// 実際にプレイへ適用されているモード
         @Binding var activeMode: GameMode
         /// タイトル画面で選択中のモード
@@ -298,6 +323,8 @@ private extension RootView {
         let onStartGame: (GameMode) -> Void
         /// GameView からタイトルへ戻る際の処理
         let onReturnToTitle: () -> Void
+        /// ローディング完了後にユーザーが開始ボタンを押した際の処理
+        let onConfirmGameStart: () -> Void
         /// 直近でログ出力したスナップショットをローカルに保持し、重複出力と同時にレイアウト警告も防ぐキャッシュ
         @State private var loggedSnapshotCache: RootLayoutSnapshot?
         /// トップバー高さを一度でも正しく計測できたかどうかを追跡するフラグ
@@ -374,7 +401,19 @@ private extension RootView {
         @ViewBuilder
         private var loadingOverlay: some View {
             if isPreparingGame {
-                GamePreparationOverlayView()
+                let stage = campaignStage(for: activeMode)
+                let progress = stage.flatMap { campaignProgressStore.progress(for: $0.id) }
+
+                GamePreparationOverlayView(
+                    mode: activeMode,
+                    campaignStage: stage,
+                    progress: progress,
+                    isReady: isGameReadyForManualStart,
+                    onStart: {
+                        // ユーザーが明示的に開始したタイミングでローディングを閉じる
+                        onConfirmGameStart()
+                    }
+                )
                     .transition(.opacity)
             } else {
                 EmptyView()
@@ -475,11 +514,30 @@ private extension RootView {
                 debugLog("RootView.layout 警告: safeArea が負値です。GeometryReader の取得値を再確認してください。")
             }
         }
+
+        /// 与えられたモードがキャンペーンステージかどうかを判定し、該当する場合は定義を返す
+        /// - Parameter mode: 判定したいモード
+        /// - Returns: キャンペーンステージなら定義、該当しなければ nil
+        private func campaignStage(for mode: GameMode) -> CampaignStage? {
+            guard let metadata = mode.campaignMetadataSnapshot else { return nil }
+            return CampaignLibrary.shared.stage(with: metadata.stageID)
+        }
     }
 
     /// ゲーム開始前のローディング表示を担うオーバーレイビュー
-    /// - NOTE: ZStack の最上位でフェード表示するため、背景のディミングやカード風ボックスをここで完結させる
+    /// - NOTE: ペナルティ設定やリワード条件を一覧できるよう、スクロール可能なカード型レイアウトで表示する
     struct GamePreparationOverlayView: View {
+        /// 開始予定のゲームモード
+        let mode: GameMode
+        /// キャンペーンステージ（該当する場合）
+        let campaignStage: CampaignStage?
+        /// これまでの達成状況
+        let progress: CampaignStageProgress?
+        /// 初期化が完了して開始可能かどうか
+        let isReady: Bool
+        /// ユーザーが「開始」ボタンを押した際のハンドラ
+        let onStart: () -> Void
+
         /// テーマを利用してライト/ダーク両対応の配色を適用する
         private var theme = AppTheme()
 
@@ -490,27 +548,16 @@ private extension RootView {
                     .opacity(LayoutMetrics.dimmedBackgroundOpacity)
                     .ignoresSafeArea()
 
-                VStack(spacing: LayoutMetrics.verticalSpacing) {
-                    // システム標準のインジケータを拡大し、視認性を確保する
-                    ProgressView()
-                        .progressViewStyle(.circular)
-                        .scaleEffect(LayoutMetrics.progressScale)
-                        .tint(theme.accentPrimary)
-                        .accessibilityHidden(true)
-
-                    VStack(spacing: LayoutMetrics.labelSpacing) {
-                        // メインメッセージは太めのラウンド体で表示し、ゲーム準備中であることを強調する
-                        Text("ゲームを準備中…")
-                            .font(.system(size: 20, weight: .semibold, design: .rounded))
-                            .foregroundColor(theme.textPrimary)
-
-                        // 補足メッセージを添えて待機中である意図をユーザーへ明確にする
-                        Text("カードと盤面を初期化しています")
-                            .font(.system(size: 14, weight: .regular, design: .rounded))
-                            .foregroundColor(theme.textSecondary)
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: LayoutMetrics.sectionSpacing) {
+                        headerSection
+                        penaltySection
+                        rewardSection
+                        recordSection
+                        controlSection
                     }
+                    .padding(LayoutMetrics.contentPadding)
                 }
-                .padding(LayoutMetrics.contentPadding)
                 .frame(maxWidth: LayoutMetrics.maxContentWidth)
                 .background(
                     theme.spawnOverlayBackground
@@ -527,14 +574,235 @@ private extension RootView {
                     x: 0,
                     y: LayoutMetrics.shadowOffsetY
                 )
-                // VoiceOver で単一要素として扱い、「しばらくお待ちください」と案内する
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("ゲームを準備中")
-                .accessibilityHint("しばらくお待ちください")
+                .padding(.horizontal, LayoutMetrics.horizontalSafePadding)
                 .accessibilityIdentifier("game_preparation_overlay")
             }
-            // 透明度アニメーションと組み合わせて自然なフェードを実現する
             .transition(.opacity)
+        }
+
+        /// ヘッダー（ステージ名と概要）
+        private var headerSection: some View {
+            VStack(alignment: .leading, spacing: LayoutMetrics.headerSpacing) {
+                if let stage = campaignStage {
+                    Text(stage.displayCode)
+                        .font(.system(size: 13, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.textSecondary)
+                        .accessibilityLabel("ステージ番号 \(stage.displayCode)")
+
+                    Text(stage.title)
+                        .font(.system(size: 22, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.textPrimary)
+
+                    Text(stage.summary)
+                        .font(.system(size: 15, weight: .regular, design: .rounded))
+                        .foregroundColor(theme.textSecondary)
+                } else {
+                    Text(mode.displayName)
+                        .font(.system(size: 22, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.textPrimary)
+
+                    Text(mode.primarySummaryText)
+                        .font(.system(size: 15, weight: .regular, design: .rounded))
+                        .foregroundColor(theme.textSecondary)
+
+                    Text(mode.secondarySummaryText)
+                        .font(.system(size: 13, weight: .regular, design: .rounded))
+                        .foregroundColor(theme.textSecondary)
+                }
+            }
+        }
+
+        /// ペナルティ設定の一覧
+        private var penaltySection: some View {
+            InfoSection(title: "ペナルティ") {
+                ForEach(penaltyItems, id: \.self) { item in
+                    bulletRow(text: item)
+                }
+            }
+        }
+
+        /// リワード条件と達成状況
+        private var rewardSection: some View {
+            InfoSection(title: "リワード条件") {
+                ForEach(Array(rewardConditions.enumerated()), id: \.offset) { index, condition in
+                    rewardConditionRow(index: index, condition: condition)
+                }
+            }
+        }
+
+        /// 過去のプレイ記録（スターとハイスコア）
+        private var recordSection: some View {
+            InfoSection(title: "これまでの記録") {
+                HStack(spacing: LayoutMetrics.starSpacing) {
+                    ForEach(0..<LayoutMetrics.totalStarCount, id: \.self) { index in
+                        Image(systemName: index < earnedStars ? "star.fill" : "star")
+                            .foregroundColor(theme.accentPrimary)
+                    }
+
+                    Text("スター \(earnedStars)/\(LayoutMetrics.totalStarCount)")
+                        .font(.system(size: 13, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.textSecondary)
+                }
+
+                bulletRow(text: "ハイスコア: \(bestScoreText)")
+                bulletRow(text: "最小ペナルティ: \(bestPenaltyText)")
+            }
+        }
+
+        /// 初期化状況と開始ボタン
+        private var controlSection: some View {
+            VStack(alignment: .leading, spacing: LayoutMetrics.controlSpacing) {
+                if !isReady {
+                    HStack(spacing: LayoutMetrics.rowSpacing) {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .tint(theme.accentPrimary)
+                        Text("初期化中…")
+                            .font(.system(size: 14, weight: .regular, design: .rounded))
+                            .foregroundColor(theme.textSecondary)
+                    }
+                    .accessibilityLabel("初期化中")
+                    .accessibilityHint("完了すると開始ボタンが有効になります")
+                }
+
+                Button(action: {
+                    if isReady {
+                        onStart()
+                    }
+                }) {
+                    Text("ステージを開始")
+                        .font(.system(size: 17, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.accentOnPrimary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, LayoutMetrics.buttonVerticalPadding)
+                        .background(
+                            RoundedRectangle(cornerRadius: LayoutMetrics.buttonCornerRadius)
+                                .fill(theme.accentPrimary.opacity(isReady ? 1 : LayoutMetrics.disabledButtonOpacity))
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(!isReady)
+                .accessibilityLabel("ステージを開始")
+                .accessibilityHint(isReady ? "ゲームを開始します" : "準備が完了すると押せるようになります")
+                .accessibilityAddTraits(isReady ? [.isButton] : [.isButton, .isDisabled])
+            }
+        }
+
+        /// ペナルティ説明文を生成
+        private var penaltyItems: [String] {
+            [
+                mode.deadlockPenaltyCost > 0 ? "手詰まり +\(mode.deadlockPenaltyCost) 手" : "手詰まり ペナルティなし",
+                mode.manualRedrawPenaltyCost > 0 ? "引き直し +\(mode.manualRedrawPenaltyCost) 手" : "引き直し ペナルティなし",
+                mode.manualDiscardPenaltyCost > 0 ? "捨て札 +\(mode.manualDiscardPenaltyCost) 手" : "捨て札 ペナルティなし",
+                mode.revisitPenaltyCost > 0 ? "再訪 +\(mode.revisitPenaltyCost) 手" : "再訪ペナルティなし"
+            ]
+        }
+
+        /// 条件達成状況をまとめた構造
+        private var rewardConditions: [RewardConditionDisplay] {
+            var results: [RewardConditionDisplay] = []
+            let earnedStars = progress?.earnedStars ?? 0
+            results.append(.init(title: "ステージクリア", achieved: earnedStars > 0))
+
+            if let stage = campaignStage, let description = stage.secondaryObjectiveDescription {
+                let achieved = progress?.achievedSecondaryObjective ?? false
+                results.append(.init(title: description, achieved: achieved))
+            }
+
+            if let stage = campaignStage, let scoreText = stage.scoreTargetDescription {
+                let achieved = progress?.achievedScoreGoal ?? false
+                results.append(.init(title: scoreText, achieved: achieved))
+            }
+
+            return results
+        }
+
+        /// これまで獲得したスター数
+        private var earnedStars: Int {
+            progress?.earnedStars ?? 0
+        }
+
+        /// ハイスコアの表示用テキスト
+        private var bestScoreText: String {
+            if let best = progress?.bestScore {
+                return "\(best) pt"
+            } else {
+                return "未記録"
+            }
+        }
+
+        /// 最小ペナルティの表示用テキスト
+        private var bestPenaltyText: String {
+            if let best = progress?.bestPenaltyCount {
+                return "\(best) 手"
+            } else {
+                return "未記録"
+            }
+        }
+
+        /// 箇条書きの 1 行を描画
+        /// - Parameter text: 表示したい本文
+        private func bulletRow(text: String) -> some View {
+            HStack(alignment: .firstTextBaseline, spacing: LayoutMetrics.bulletSpacing) {
+                Circle()
+                    .fill(theme.textSecondary.opacity(0.6))
+                    .frame(width: LayoutMetrics.bulletSize, height: LayoutMetrics.bulletSize)
+                    .accessibilityHidden(true)
+
+                Text(text)
+                    .font(.system(size: 15, weight: .regular, design: .rounded))
+                    .foregroundColor(theme.textPrimary)
+            }
+        }
+
+        /// リワード条件 1 行分のレイアウト
+        /// - Parameters:
+        ///   - index: スター番号（0 始まり）
+        ///   - condition: 表示したい条件内容
+        private func rewardConditionRow(index: Int, condition: RewardConditionDisplay) -> some View {
+            HStack(alignment: .top, spacing: LayoutMetrics.rowSpacing) {
+                Image(systemName: condition.achieved ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(condition.achieved ? theme.accentPrimary : theme.textSecondary)
+                    .font(.system(size: 18, weight: .bold))
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("スター \(index + 1)")
+                        .font(.system(size: 12, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.textSecondary)
+
+                    Text(condition.title)
+                        .font(.system(size: 15, weight: .medium, design: .rounded))
+                        .foregroundColor(theme.textPrimary)
+                }
+            }
+        }
+
+        /// 条件一覧で扱う内部モデル
+        private struct RewardConditionDisplay {
+            let title: String
+            let achieved: Bool
+        }
+
+        /// 情報カード内のセクション共通レイアウト
+        private struct InfoSection<Content: View>: View {
+            let title: String
+            let content: Content
+
+            init(title: String, @ViewBuilder content: () -> Content) {
+                self.title = title
+                self.content = content()
+            }
+
+            var body: some View {
+                VStack(alignment: .leading, spacing: LayoutMetrics.sectionContentSpacing) {
+                    Text(title)
+                        .font(.system(size: 13, weight: .semibold, design: .rounded))
+                        .foregroundColor(AppTheme().textSecondary)
+
+                    content
+                }
+            }
         }
 
         /// レイアウト定数を 1 箇所へ集約し、値の調整を容易にする
@@ -542,15 +810,35 @@ private extension RootView {
             /// 背景ディミングの透過率
             static let dimmedBackgroundOpacity: Double = 0.45
             /// コンテンツ全体の最大幅
-            static let maxContentWidth: CGFloat = 280
+            static let maxContentWidth: CGFloat = 360
             /// コンテンツ周囲の余白
             static let contentPadding: CGFloat = 28
-            /// プログレスインジケータとテキストの縦方向間隔
-            static let verticalSpacing: CGFloat = 20
-            /// テキスト同士の間隔
-            static let labelSpacing: CGFloat = 8
-            /// カード風ボックスの角丸半径
-            static let cornerRadius: CGFloat = 22
+            /// セクション間の余白
+            static let sectionSpacing: CGFloat = 24
+            /// セクション内のコンテンツ間隔
+            static let sectionContentSpacing: CGFloat = 12
+            /// ヘッダー内の行間
+            static let headerSpacing: CGFloat = 6
+            /// 箇条書きのドットと本文の間隔
+            static let bulletSpacing: CGFloat = 8
+            /// 箇条書きドットのサイズ
+            static let bulletSize: CGFloat = 6
+            /// 行要素の基本間隔
+            static let rowSpacing: CGFloat = 12
+            /// スターアイコンの間隔
+            static let starSpacing: CGFloat = 10
+            /// スターの最大数
+            static let totalStarCount: Int = 3
+            /// ボタン周辺の余白
+            static let controlSpacing: CGFloat = 14
+            /// ボタンの角丸
+            static let buttonCornerRadius: CGFloat = 16
+            /// ボタンの上下パディング
+            static let buttonVerticalPadding: CGFloat = 14
+            /// 無効状態のボタン透過率
+            static let disabledButtonOpacity: Double = 0.45
+            /// カードの角丸半径
+            static let cornerRadius: CGFloat = 24
             /// 枠線の太さ
             static let borderWidth: CGFloat = 1
             /// ドロップシャドウの半径
@@ -559,8 +847,8 @@ private extension RootView {
             static let shadowOffsetY: CGFloat = 8
             /// 背景に適用するブラー量
             static let backgroundBlur: CGFloat = 0
-            /// プログレスインジケータの拡大率
-            static let progressScale: CGFloat = 1.2
+            /// 端末横幅が狭い場合に備えた左右の安全マージン
+            static let horizontalSafePadding: CGFloat = 20
         }
     }
 
@@ -580,6 +868,9 @@ private extension RootView {
         stateStore.gameSessionID = UUID()
         let scheduledSessionID = stateStore.gameSessionID
         debugLog("RootView: 新規ゲームセッションを割り当て sessionID=\(scheduledSessionID)")
+
+        // ゲーム開始準備が完了するまでは開始ボタンを押せないようフラグを下ろしておく
+        stateStore.isGameReadyForManualStart = false
 
         withAnimation(.easeInOut(duration: 0.25)) {
             // タイトルを閉じ、ローディングオーバーレイを表示する
@@ -604,6 +895,7 @@ private extension RootView {
 
         // ローディング状態は即時で解除し、タイトル遷移のみアニメーションさせる
         stateStore.isPreparingGame = false
+        stateStore.isGameReadyForManualStart = false
 
         withAnimation(.easeInOut(duration: 0.25)) {
             stateStore.isShowingTitleScreen = true
@@ -629,11 +921,9 @@ private extension RootView {
                 return
             }
 
-            debugLog("RootView: ゲーム準備完了 ローディング解除 sessionID=\(sessionID)")
+            debugLog("RootView: ゲーム準備完了 手動開始待ちへ移行 sessionID=\(sessionID)")
 
-            withAnimation(.easeInOut(duration: 0.25)) {
-                stateStore.isPreparingGame = false
-            }
+            stateStore.isGameReadyForManualStart = true
 
             // 再利用を防ぐため参照を破棄する
             pendingGameActivationWorkItem = nil
@@ -653,6 +943,20 @@ private extension RootView {
         debugLog("RootView: 保留中のゲーム準備ワークアイテムをキャンセル sessionID=\(stateStore.gameSessionID)")
         workItem.cancel()
         pendingGameActivationWorkItem = nil
+        stateStore.isGameReadyForManualStart = false
+    }
+
+    /// ローディング完了後にユーザーが開始ボタンを押した際の処理
+    func finishGamePreparationAndStart() {
+        // 既にローディングが閉じられている場合は何もしない
+        guard stateStore.isPreparingGame else { return }
+
+        debugLog("RootView: ユーザー操作によりゲームを開始")
+
+        withAnimation(.easeInOut(duration: 0.25)) {
+            stateStore.isPreparingGame = false
+        }
+        stateStore.isGameReadyForManualStart = false
     }
 
     /// Game Center 認証 API 呼び出しをカプセル化し、ビュー側からの参照を単純化する


### PR DESCRIPTION
## Summary
- reintroduce the campaign objective for avoiding revisits and support configurable score goal comparisons
- track revisit state within GameCore and propagate the metric through progress registration
- restore the richer campaign preparation overlay with manual start flow and refreshed tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68d5b8b3a520832ca45b8924de2e4cd7