### PR TITLE
Fix GamePreparationOverlayView visibility

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -526,7 +526,10 @@ private extension RootView {
 
     /// ゲーム開始前のローディング表示を担うオーバーレイビュー
     /// - NOTE: ペナルティ設定やリワード条件を一覧できるよう、スクロール可能なカード型レイアウトで表示する
-    struct GamePreparationOverlayView: View {
+    /// `private extension` 配下ではデフォルトで初期化子が `private` 扱いになり、
+    /// 呼び出し元の `RootContentView` から参照できずビルドエラーとなるため、
+    /// アクセスレベルを `fileprivate` に引き上げて同一ファイル内の利用を許可する。
+    fileprivate struct GamePreparationOverlayView: View {
         /// 開始予定のゲームモード
         let mode: GameMode
         /// キャンペーンステージ（該当する場合）


### PR DESCRIPTION
## Summary
- raise GamePreparationOverlayView to fileprivate within RootView so its memberwise initializer is accessible to RootContentView
- document the reason in Japanese comments to follow repository guidelines

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68d5baec5cf0832cafd575a13f7f4d68