### PR TITLE
Fix accessibility traits for disabled start button

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -684,7 +684,8 @@ private extension RootView {
                 .disabled(!isReady)
                 .accessibilityLabel("ステージを開始")
                 .accessibilityHint(isReady ? "ゲームを開始します" : "準備が完了すると押せるようになります")
-                .accessibilityAddTraits(isReady ? [.isButton] : [.isButton, .isDisabled])
+                // VoiceOver でボタンの有効 / 無効状態を正しく伝える
+                .accessibilityAddTraits(isReady ? [.isButton] : [.isButton, .isNotEnabled])
             }
         }
 


### PR DESCRIPTION
## Summary
- replace deprecated accessibility trait usage for the stage start button
- ensure VoiceOver reports the disabled state correctly by using `.isNotEnabled`

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d5baf36fd4832cae98f3dd943dad46