### PR TITLE
Fix accessibility traits compilation error

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -687,8 +687,8 @@ private extension RootView {
                 .disabled(!isReady)
                 .accessibilityLabel("ステージを開始")
                 .accessibilityHint(isReady ? "ゲームを開始します" : "準備が完了すると押せるようになります")
-                // VoiceOver でボタンの有効 / 無効状態を正しく伝える
-                .accessibilityAddTraits(isReady ? [.isButton] : [.isButton, .isNotEnabled])
+                // VoiceOver でボタンであることを明示（.disabled 修飾子が自動で無効状態を伝えてくれる）
+                .accessibilityAddTraits(.isButton)
             }
         }
 


### PR DESCRIPTION
## Summary
- remove usage of the unavailable `.isNotEnabled` accessibility trait on the stage start button
- rely on the `.disabled` modifier to communicate disabled state while preserving the button trait

## Testing
- not run (SwiftUI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d5c8047d28832caff64b6cfd4bc359