### PR TITLE
Enhance campaign result rewards and stage transition

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -383,6 +383,10 @@ private extension RootView {
                     onRequestReturnToTitle: {
                         // GameView 内からの戻り要求を親へ伝播させる
                         onReturnToTitle()
+                    },
+                    onRequestStartCampaignStage: { stage in
+                        // クリア後に解放されたステージへの即時挑戦リクエストを受け取り、ゲーム準備をやり直す
+                        startGamePreparation(for: stage.makeGameMode())
                     }
                 )
                 .id(gameSessionID)


### PR DESCRIPTION
## Summary
- store the latest campaign clear record and newly unlocked stages in `GameViewModel` so the result sheet can reflect rewards
- extend `ResultView` to display a campaign reward checklist and offer buttons that jump directly to newly unlocked stages
- thread a new campaign stage start request closure through `GameView` and `RootView` to restart the game in the unlocked stage

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68d5cce5b2f4832c915424ba594f4d18