### PR TITLE
設定画面にデバッグ用ステージ解放パスコードを追加

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -277,6 +277,8 @@ private extension RootView {
             .fullScreenCover(isPresented: stateStore.binding(for: \.isPresentingTitleSettings)) {
                 // RootView から AdsServiceProtocol を引き渡し、設定画面でも共通プロトコル経由で操作できるようにする。
                 SettingsView(adsService: adsService)
+                    // キャンペーン進捗ストアも同じインスタンスを共有し、デバッグ用パスコード入力で即座に反映されるようにする。
+                    .environmentObject(campaignProgressStore)
             }
     }
 


### PR DESCRIPTION
## Summary
- add a persistent debug unlock flag to `CampaignProgressStore` so that entering the debug password bypasses campaign gating
- expose the campaign progress store to `SettingsView` and add a password field/alert that enables the unlock when "6031" is entered
- cover the new behavior with a regression test that ensures the unlock persists across store instances

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d5cf2fc8cc832c82fa44f5503ad210