### PR TITLE
Make CampaignStageEvaluation initializer public

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -262,6 +262,19 @@ public struct CampaignStageEvaluation {
     public let earnedStars: Int
     public let achievedSecondaryObjective: Bool
     public let achievedScoreGoal: Bool
+
+    // Swift パッケージ外でも初期化できるよう明示的に public イニシャライザを用意する
+    public init(
+        stageID: CampaignStageID,
+        earnedStars: Int,
+        achievedSecondaryObjective: Bool,
+        achievedScoreGoal: Bool
+    ) {
+        self.stageID = stageID
+        self.earnedStars = earnedStars
+        self.achievedSecondaryObjective = achievedSecondaryObjective
+        self.achievedScoreGoal = achievedScoreGoal
+    }
 }
 
 /// 章単位でステージを束ねる定義


### PR DESCRIPTION
## Summary
- expose CampaignStageEvaluation's initializer so preview code can construct evaluations from outside the Game package
- document the intent with an inline Japanese comment for clarity

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d5d0a30280832c952a2b89dcd4cfff