### PR TITLE
Fix campaign stage start handler usage

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -387,8 +387,9 @@ private extension RootView {
                         onReturnToTitle()
                     },
                     onRequestStartCampaignStage: { stage in
-                        // クリア後に解放されたステージへの即時挑戦リクエストを受け取り、ゲーム準備をやり直す
-                        startGamePreparation(for: stage.makeGameMode())
+                        // クリア後に解放されたステージへの即時挑戦リクエストを受け取る
+                        // 親から注入された開始ハンドラを利用してゲーム準備をやり直す
+                        onStartGame(stage.makeGameMode())
                     }
                 )
                 .id(gameSessionID)


### PR DESCRIPTION
## Summary
- use the injected onStartGame handler when campaign stages request a new run so nested views no longer call RootView methods directly
- add Japanese comments clarifying the handoff from GameView to RootView

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d5d2f3b3bc832c95d4208ee18306af