### PR TITLE
Switch title screen flows to navigation pushes

### DIFF
--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -12,6 +12,8 @@ struct CampaignStageSelectionView: View {
     let selectedStageID: CampaignStageID?
     /// クローズハンドラ
     let onClose: () -> Void
+    /// ナビゲーションバーに閉じるボタンを表示するかどうか
+    let showsCloseButton: Bool
     /// ステージ決定時のハンドラ
     let onSelectStage: (CampaignStage) -> Void
 
@@ -25,12 +27,14 @@ struct CampaignStageSelectionView: View {
     ///   - selectedStageID: すでに選択済みのステージ ID
     ///   - onClose: ビューを閉じるためのコールバック
     ///   - onSelectStage: ステージ選択確定時に呼び出されるコールバック
+    ///   - showsCloseButton: ナビゲーションバーへ「閉じる」ボタンを表示するかどうか
     init(
         campaignLibrary: CampaignLibrary,
         progressStore: CampaignProgressStore,
         selectedStageID: CampaignStageID?,
         onClose: @escaping () -> Void,
-        onSelectStage: @escaping (CampaignStage) -> Void
+        onSelectStage: @escaping (CampaignStage) -> Void,
+        showsCloseButton: Bool = true
     ) {
         // @ObservedObject プロパティはラッパー経由で代入する必要があるため、明示的に初期化する
         self.campaignLibrary = campaignLibrary
@@ -38,6 +42,7 @@ struct CampaignStageSelectionView: View {
         self.selectedStageID = selectedStageID
         self.onClose = onClose
         self.onSelectStage = onSelectStage
+        self.showsCloseButton = showsCloseButton
     }
 
     var body: some View {
@@ -61,8 +66,10 @@ struct CampaignStageSelectionView: View {
         .listStyle(.insetGrouped)
         .navigationTitle("キャンペーン")
         .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button("閉じる") { onClose() }
+            if showsCloseButton {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("閉じる") { onClose() }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Embed the title screen in a NavigationStack so campaign and free mode entries push dedicated pages instead of modal sheets
- Ensure free mode updates trigger gameplay after saving and keep standard/classical modes starting immediately while resetting the navigation state
- Allow the campaign stage selector to hide its close button when shown via navigation

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d638c1401c832c90fdb3e41ab89d57