### PR TITLE
Fix CampaignStageSelectionView parameter order

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -1349,13 +1349,13 @@ fileprivate struct TitleScreenView: View {
                     campaignLibrary: campaignLibrary,
                     progressStore: campaignProgressStore,
                     selectedStageID: selectedCampaignStage?.id,
-                    showsCloseButton: false,
                     onClose: { popNavigationStack() },
                     onSelectStage: { stage in
                         // ステージ決定時はスタックを初期化してからゲーム開始処理へ進む
                         resetNavigationStack()
                         handleCampaignStageSelection(stage)
-                    }
+                    },
+                    showsCloseButton: false
                 )
             case .freeModeEditor:
                 FreeModeRegulationView(


### PR DESCRIPTION
## Summary
- update the CampaignStageSelectionView initializer call in RootView to match the parameter order expected by the initializer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63b789fd8832ca45e96d293167c76