### PR TITLE
Add king-only intro stage and shift campaign stages

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -335,10 +335,41 @@ public struct CampaignLibrary {
         // 章内で複数のステージが同一ルールを参照する場合に備え、先に共通変数へ切り出しておく。
         let classicalChallengeRegulation = GameMode.classicalChallenge.regulationSnapshot
 
+        // 既存のクラシカル相当レギュレーションからペナルティ設定を拝借する。
+        // - Note: 3×3 の新ステージでもペナルティ難度だけは据え置きたいという要望に合わせる。
+        let classicalPenalties = classicalChallengeRegulation.penalties
+
+        // 1-1 は 3×3 盤かつ王将型カードのみで構成された超短距離訓練ステージ。
+        // ペナルティ条件とスター獲得条件は従来の 1-2 と揃えて、報酬の認知負荷を減らす。
         let stage11 = CampaignStage(
             id: CampaignStageID(chapter: 1, index: 1),
-            title: "序盤訓練",
-            summary: "4×4 の小さな盤面で基本操作を確認しましょう。",
+            title: "王将訓練",
+            summary: "3×3 の盤で王将カードだけを使い、基本の詰めを体験しましょう。",
+            regulation: GameMode.Regulation(
+                boardSize: 3,
+                handSize: 5,
+                nextPreviewCount: 3,
+                allowsStacking: true,
+                deckPreset: .kingOnly,
+                spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 3)),
+                penalties: GameMode.PenaltySettings(
+                    deadlockPenaltyCost: classicalPenalties.deadlockPenaltyCost,
+                    manualRedrawPenaltyCost: classicalPenalties.manualRedrawPenaltyCost,
+                    manualDiscardPenaltyCost: classicalPenalties.manualDiscardPenaltyCost,
+                    revisitPenaltyCost: classicalPenalties.revisitPenaltyCost
+                )
+            ),
+            secondaryObjective: .finishWithinSeconds(maxSeconds: 120),
+            scoreTarget: 900,
+            scoreTargetComparison: .lessThan,
+            unlockRequirement: .totalStars(minimum: 0)
+        )
+
+        // 1-2 は従来の 1-1 レギュレーションをそのまま移設し、4×4 盤での応用を学ぶ位置付けにする。
+        let stage12 = CampaignStage(
+            id: CampaignStageID(chapter: 1, index: 2),
+            title: "序盤応用",
+            summary: "4×4 の小さな盤面でスタンダードデッキの動きを復習しましょう。",
             regulation: GameMode.Regulation(
                 boardSize: 4,
                 handSize: 5,
@@ -354,24 +385,11 @@ public struct CampaignLibrary {
                 )
             ),
             // MARK: 2 個目のスター条件: ペナルティ発生を 5 回以下に抑える
-            // - Note: 新米プレイヤーが多少の詰まりを経験しても達成可能な難易度に調整する。
+            // - Note: 章 1 の段階では引き直しペナルティの存在に慣れてもらうことが目的。
             secondaryObjective: .finishWithPenaltyAtMost(maxPenaltyCount: 5),
             scoreTarget: 350,
             scoreTargetComparison: .lessThan,
-            unlockRequirement: .totalStars(minimum: 0)
-        )
-
-        // 1-2 ステージはクラシカルチャレンジと同等のレギュレーションを採用し、大盤面での立ち回りを学ぶ想定。
-        // リワード条件はユーザー指定に従い、2 個目のスターを 120 秒以内クリア、3 個目をスコア 900 未満達成としている。
-        let stage12 = CampaignStage(
-            id: CampaignStageID(chapter: 1, index: 2),
-            title: "クラシカル演習",
-            summary: "クラシカルチャレンジと同じ 8×8 盤で時間管理を意識しましょう。",
-            regulation: classicalChallengeRegulation,
-            secondaryObjective: .finishWithinSeconds(maxSeconds: 120),
-            scoreTarget: 900,
-            scoreTargetComparison: .lessThan,
-            unlockRequirement: .stageClear(CampaignStageID(chapter: 1, index: 1))
+            unlockRequirement: .stageClear(stage11.id)
         )
 
         let chapter1 = CampaignChapter(

--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -95,6 +95,21 @@ struct Deck {
                 deckSummaryText: "桂馬カードのみ"
             )
         }()
+
+        /// 王将型カードのみを排出する短距離構成
+        static let kingOnly: Configuration = {
+            let kingMoves = MoveCard.allCases.filter { $0.isKingType }
+            let weights = Dictionary(uniqueKeysWithValues: kingMoves.map { ($0, 1) })
+            return Configuration(
+                allowedMoves: kingMoves,
+                baseWeights: weights,
+                shouldApplyProbabilityReduction: false,
+                normalWeightMultiplier: 1,
+                reducedWeightMultiplier: 1,
+                reductionDuration: 0,
+                deckSummaryText: "王将カードのみ"
+            )
+        }()
     }
 
     // MARK: - プロパティ

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -9,6 +9,8 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
     case standard
     /// クラシカルチャレンジと同じ桂馬のみの構成
     case classicalChallenge
+    /// 王将型カードのみの構成（序盤向け超短距離デッキ）
+    case kingOnly
 
     /// `Identifiable` 準拠用の ID
     public var id: String { rawValue }
@@ -20,6 +22,8 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
             return "スタンダード構成"
         case .classicalChallenge:
             return "クラシカル構成"
+        case .kingOnly:
+            return "王将構成"
         }
     }
 
@@ -35,6 +39,8 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
             return .standard
         case .classicalChallenge:
             return .classicalChallenge
+        case .kingOnly:
+            return .kingOnly
         }
     }
 }


### PR DESCRIPTION
## Summary
- introduce a king-only deck preset for regulation definitions and expose it through `GameDeckPreset`
- rework chapter 1 to make 1-1 a 3×3 king-only training stage while moving the former 1-1 rules to 1-2
- keep the requested penalty and reward targets aligned with the previous 1-2 setup and drop the old classical challenge stage

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d63a97fcc0832c94fa93f08eca8f5a