### PR TITLE
Add multi-visit tiles and campaign chapter 2 stage

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -399,6 +399,45 @@ public struct CampaignLibrary {
             stages: [stage11, stage12]
         )
 
-        return [chapter1]
+        // MARK: - 2 章のステージ群
+        // (1,2) と (3,4) の指定は 1 始まりの座標と解釈し、内部表現の 0 始まりへ変換する。
+        let doubleVisitOverrides: [GridPoint: Int] = [
+            GridPoint(x: 0, y: 1): 2,
+            GridPoint(x: 2, y: 3): 2
+        ]
+
+        let stage21 = CampaignStage(
+            id: CampaignStageID(chapter: 2, index: 1),
+            title: "重踏応用",
+            summary: "二度踏まないと踏破できない特殊マスを活用する演習です。",
+            regulation: GameMode.Regulation(
+                boardSize: 4,
+                handSize: 5,
+                nextPreviewCount: 3,
+                allowsStacking: true,
+                deckPreset: .standard,
+                spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 4)),
+                penalties: GameMode.PenaltySettings(
+                    deadlockPenaltyCost: 3,
+                    manualRedrawPenaltyCost: 1,
+                    manualDiscardPenaltyCost: 1,
+                    revisitPenaltyCost: 0
+                ),
+                additionalVisitRequirements: doubleVisitOverrides
+            ),
+            secondaryObjective: .finishWithPenaltyAtMost(maxPenaltyCount: 5),
+            scoreTarget: 350,
+            scoreTargetComparison: .lessThan,
+            unlockRequirement: .stageClear(stage12.id)
+        )
+
+        let chapter2 = CampaignChapter(
+            id: 2,
+            title: "応用特訓",
+            summary: "複数回踏むマスを扱う章。",
+            stages: [stage21]
+        )
+
+        return [chapter1, chapter2]
     }
 }

--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -84,7 +84,11 @@ public final class GameCore: ObservableObject {
     public init(mode: GameMode = .standard) {
         self.mode = mode
         // BoardGeometry を介することで盤面サイズ拡張時も初期化処理を共通化できる
-        board = Board(size: mode.boardSize, initialVisitedPoints: mode.initialVisitedPoints)
+        board = Board(
+            size: mode.boardSize,
+            initialVisitedPoints: mode.initialVisitedPoints,
+            requiredVisitOverrides: mode.additionalVisitRequirements
+        )
         current = mode.initialSpawnPoint ?? BoardGeometry.defaultSpawnPoint(for: mode.boardSize)
         deck = Deck(configuration: mode.deckConfiguration)
         progress = mode.requiresSpawnSelection ? .awaitingSpawn : .playing
@@ -200,7 +204,11 @@ public final class GameCore: ObservableObject {
             deck.reset()
         }
 
-        board = Board(size: mode.boardSize, initialVisitedPoints: mode.initialVisitedPoints)
+        board = Board(
+            size: mode.boardSize,
+            initialVisitedPoints: mode.initialVisitedPoints,
+            requiredVisitOverrides: mode.additionalVisitRequirements
+        )
         current = mode.initialSpawnPoint
         moveCount = 0
         penaltyCount = 0
@@ -371,9 +379,16 @@ extension GameCore {
 
         let resolvedCurrent = current ?? mode.initialSpawnPoint
         if let resolvedCurrent {
-            core.board = Board(size: mode.boardSize, initialVisitedPoints: [resolvedCurrent])
+            core.board = Board(
+                size: mode.boardSize,
+                initialVisitedPoints: [resolvedCurrent],
+                requiredVisitOverrides: mode.additionalVisitRequirements
+            )
         } else {
-            core.board = Board(size: mode.boardSize)
+            core.board = Board(
+                size: mode.boardSize,
+                requiredVisitOverrides: mode.additionalVisitRequirements
+            )
         }
         core.current = resolvedCurrent
         core.moveCount = 0

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -186,6 +186,8 @@ public struct GameMode: Equatable, Identifiable {
         public var spawnRule: SpawnRule
         /// ペナルティ設定一式
         public var penalties: PenaltySettings
+        /// マスごとの追加踏破回数設定
+        public var additionalVisitRequirements: [GridPoint: Int] = [:]
 
         /// レギュレーションを組み立てるためのイニシャライザ
         /// - Parameters:
@@ -203,7 +205,8 @@ public struct GameMode: Equatable, Identifiable {
             allowsStacking: Bool,
             deckPreset: GameDeckPreset,
             spawnRule: SpawnRule,
-            penalties: PenaltySettings
+            penalties: PenaltySettings,
+            additionalVisitRequirements: [GridPoint: Int] = [:]
         ) {
             self.boardSize = boardSize
             self.handSize = handSize
@@ -212,6 +215,7 @@ public struct GameMode: Equatable, Identifiable {
             self.deckPreset = deckPreset
             self.spawnRule = spawnRule
             self.penalties = penalties
+            self.additionalVisitRequirements = additionalVisitRequirements
         }
     }
 
@@ -355,6 +359,9 @@ public struct GameMode: Equatable, Identifiable {
             return []
         }
     }
+
+    /// 追加踏破回数が必要なマス集合
+    public var additionalVisitRequirements: [GridPoint: Int] { regulation.additionalVisitRequirements }
 
     /// スタンダードモード（既存仕様）
     public static var standard: GameMode {

--- a/Tests/GameTests/BoardClearTests.swift
+++ b/Tests/GameTests/BoardClearTests.swift
@@ -26,4 +26,22 @@ final class BoardClearTests: XCTestCase {
         // 中央以外は踏破していないため false のはず
         XCTAssertFalse(board.isCleared)
     }
+
+    /// 複数回踏破が必要なマスが正しく段階的に処理されるか
+    func testMultiVisitTileRequiresMultipleSteps() {
+        // 4×4 盤で (1,1) のマスに 2 回踏破が必要な設定を適用する
+        let specialPoint = GridPoint(x: 1, y: 1)
+        var board = Board(size: 4, requiredVisitOverrides: [specialPoint: 2])
+
+        XCTAssertFalse(board.isVisited(specialPoint), "初期状態では未踏破のはず")
+        XCTAssertEqual(board.remainingCount, 16, "未踏破マスが 16 のままか確認する")
+
+        board.markVisited(specialPoint)
+        XCTAssertFalse(board.isVisited(specialPoint), "1 回踏んだだけでは踏破完了にならない")
+        XCTAssertEqual(board.remainingCount, 16, "残り踏破数は変化しない")
+
+        board.markVisited(specialPoint)
+        XCTAssertTrue(board.isVisited(specialPoint), "2 回目で踏破済みになる")
+        XCTAssertEqual(board.remainingCount, 15, "1 マス分だけ残数が減る")
+    }
 }

--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -61,7 +61,8 @@ final class GameBoardBridgeViewModel: ObservableObject {
 
         let preparedScene = GameScene(
             initialBoardSize: mode.boardSize,
-            initialVisitedPoints: mode.initialVisitedPoints
+            initialVisitedPoints: mode.initialVisitedPoints,
+            requiredVisitOverrides: mode.additionalVisitRequirements
         )
         preparedScene.scaleMode = .resizeFill
         preparedScene.gameCore = core


### PR DESCRIPTION
## Summary
- タイルの踏破回数を管理できるよう Board/TileState を拡張し、複数回踏破マスを実装
- GameScene を更新して踏破段階の色変化とアクセシビリティ読み上げを対応
- キャンペーン 2-1 ステージを追加し、ブリッジやテストを更新

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d63d40a718832cbb914779b9406cdc