### PR TITLE
Improve campaign selection logging diagnostics

### DIFF
--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -79,7 +79,15 @@ struct CampaignStageSelectionView: View {
         // ステージ一覧の表示状態を追跡し、遷移の成否をログで確認できるようにする
         .onAppear {
             let unlockedCount = campaignLibrary.allStages.filter { progressStore.isStageUnlocked($0) }.count
-            debugLog("CampaignStageSelectionView: onAppear -> ステージ総数=\(campaignLibrary.allStages.count) 解放済=\(unlockedCount)")
+            // 章ごとのステージ数を列挙し、定義抜けによる空表示を切り分けやすくする
+            let chapterSummaries = campaignLibrary.chapters
+                .map { chapter in "Chapter \(chapter.id):\(chapter.stages.count)" }
+                .joined(separator: ", ")
+            let selectedDescription = selectedStageID?.displayCode ?? "なし"
+            debugLog("CampaignStageSelectionView: onAppear -> ステージ総数=\(campaignLibrary.allStages.count) 解放済=\(unlockedCount) 章内訳=[\(chapterSummaries)] 選択中=\(selectedDescription)")
+            if campaignLibrary.chapters.isEmpty {
+                debugLog("CampaignStageSelectionView: 章定義が空です。CampaignLibrary.buildChapters() の戻り値を確認してください。")
+            }
         }
         .onDisappear {
             debugLog("CampaignStageSelectionView: onDisappear")


### PR DESCRIPTION
## Summary
- add detailed logging when resolving campaign stages so missing metadata is surfaced
- record campaign library statistics when the selector is opened to help spot empty definitions
- expand the stage selector appearance log with chapter breakdowns and an empty-state warning

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d66763e28c832c95f195da13b8e974