### PR TITLE
Fix deprecated onChange usage in ResultView

### DIFF
--- a/UI/ResultView.swift
+++ b/UI/ResultView.swift
@@ -478,7 +478,8 @@ struct ResultView: View {
             .accessibilityElement(children: .ignore)
             .accessibilityLabel("累計スター: \(record.progress.earnedStars) / 3")
             .onAppear { startAnimation() }
-            .onChange(of: record.progress.earnedStars) { _ in
+            // iOS 17 以降で推奨される 2 引数版 onChange を利用し、将来の非推奨 API を回避する
+            .onChange(of: record.progress.earnedStars) { _, _ in
                 startAnimation()
             }
             .onDisappear {


### PR DESCRIPTION
## Summary
- switch ResultView's star animation listener to the new two-parameter `onChange` closure
- add a Japanese comment documenting the iOS 17 API update for future maintenance

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d675021f74832cba79f20c8f74e809