### PR TITLE
Add debug log for campaign destination construction

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -1367,6 +1367,8 @@ fileprivate struct TitleScreenView: View {
         .navigationDestination(for: TitleNavigationTarget.self) { target in
             switch target {
             case .campaign:
+                // ナビゲーション遷移先の構築段階でインスタンス識別子とスタック状況を把握する
+                debugLog("TitleScreenView: NavigationDestination.campaign 構築開始 -> instance=\(instanceIdentifier) / stackCount=\(navigationPath.count)")
                 CampaignStageSelectionView(
                     campaignLibrary: campaignLibrary,
                     progressStore: campaignProgressStore,


### PR DESCRIPTION
## Summary
- add a debug log before constructing the campaign navigation destination so the instance identifier and stack count are captured

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d686a4a268832caa959925a43e3958