### PR TITLE
Fix ambiguous toolbar usage in campaign stage selection

### DIFF
--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -59,15 +59,7 @@ struct CampaignStageSelectionView: View {
         }
         .navigationTitle("キャンペーン")
         .toolbar {
-            if showsCloseButton {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("閉じる") {
-                        // 手動クローズ時にナビゲーション操作を記録し、戻れない問題の切り分けに備える
-                        debugLog("CampaignStageSelectionView: 閉じるボタン押下 -> NavigationStackポップ要求")
-                        onClose()
-                    }
-                }
-            }
+            toolbarContent
         }
         // ステージ一覧の表示状態を追跡し、遷移の成否をログで確認できるようにする
         .onAppear {
@@ -168,6 +160,20 @@ struct CampaignStageSelectionView: View {
         }
         .accessibilityLabel("スター獲得数: \(earnedStars) / 3")
         .padding(.top, 4)
+    }
+
+    /// ナビゲーションバーへ配置するツールバー構成を切り出し、型推論の曖昧さを回避する
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        if showsCloseButton {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("閉じる") {
+                    // 手動クローズ時にナビゲーション操作を記録し、戻れない問題の切り分けに備える
+                    debugLog("CampaignStageSelectionView: 閉じるボタン押下 -> NavigationStackポップ要求")
+                    onClose()
+                }
+            }
+        }
     }
 
     /// 章とステージが正しく読み込めた場合の一覧表示


### PR DESCRIPTION
## Summary
- extract the campaign selection toolbar configuration into a dedicated ToolbarContent builder
- reference the extracted builder from the view body to avoid ambiguous overload resolution

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6fea50724832c87fc162ef4650f4c