### PR TITLE
Fix ambiguous toolbar usage in campaign stage view

### DIFF
--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -59,7 +59,16 @@ struct CampaignStageSelectionView: View {
         }
         .navigationTitle("キャンペーン")
         .toolbar {
-            toolbarContent
+            // ツールバー構成をここで直接定義し、SwiftUI のオーバーロード解決を明示的にする
+            if showsCloseButton {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("閉じる") {
+                        // 手動クローズ時にナビゲーション操作を記録し、戻れない問題の切り分けに備える
+                        debugLog("CampaignStageSelectionView: 閉じるボタン押下 -> NavigationStackポップ要求")
+                        onClose()
+                    }
+                }
+            }
         }
         // ステージ一覧の表示状態を追跡し、遷移の成否をログで確認できるようにする
         .onAppear {
@@ -160,20 +169,6 @@ struct CampaignStageSelectionView: View {
         }
         .accessibilityLabel("スター獲得数: \(earnedStars) / 3")
         .padding(.top, 4)
-    }
-
-    /// ナビゲーションバーへ配置するツールバー構成を切り出し、型推論の曖昧さを回避する
-    @ToolbarContentBuilder
-    private var toolbarContent: some ToolbarContent {
-        if showsCloseButton {
-            ToolbarItem(placement: .cancellationAction) {
-                Button("閉じる") {
-                    // 手動クローズ時にナビゲーション操作を記録し、戻れない問題の切り分けに備える
-                    debugLog("CampaignStageSelectionView: 閉じるボタン押下 -> NavigationStackポップ要求")
-                    onClose()
-                }
-            }
-        }
     }
 
     /// 章とステージが正しく読み込めた場合の一覧表示


### PR DESCRIPTION
## Summary
- inline the campaign stage selection toolbar definition to avoid the ambiguous `toolbar(content:)` overload
- retain the close button logging to aid debugging when the toolbar is visible

## Testing
- not run (SwiftUI view change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6ffb05304832c8bf542307cc78e61