### PR TITLE
Fix toolbar content usage in campaign stage view

### DIFF
--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -58,7 +58,10 @@ struct CampaignStageSelectionView: View {
             }
         }
         .navigationTitle("キャンペーン")
-        .toolbar(content: toolbarContent)
+        .toolbar {
+            // 計算プロパティの内容をクロージャ経由で渡し、`toolbar` のオーバーロード解決を明確化する
+            toolbarContent
+        }
         // ステージ一覧の表示状態を追跡し、遷移の成否をログで確認できるようにする
         .onAppear {
             let unlockedCount = campaignLibrary.allStages.filter { progressStore.isStageUnlocked($0) }.count


### PR DESCRIPTION
## Summary
- update CampaignStageSelectionView to pass toolbar content via closure to match SwiftUI API expectations
- add inline comment explaining the change for overload resolution clarity

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d7016e9620832cbce60d8670f38308