### PR TITLE
Refine close toolbar handling across views

### DIFF
--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -59,16 +59,15 @@ struct CampaignStageSelectionView: View {
         }
         .navigationTitle("キャンペーン")
         .toolbar {
-            // SwiftUI のオーバーロード解決を明示しつつ、閉じるボタンの表示制御をその場で把握できるように直接 ToolbarItem を記述する
-            ToolbarItem(placement: .cancellationAction) {
-                if showsCloseButton {
-                    Button("閉じる") {
-                        // ナビゲーションスタックをポップする契機を記録し、手動クローズのトレースを取りやすくする
-                        debugLog("CampaignStageSelectionView.toolbar: 閉じるボタン押下 -> NavigationStackポップ要求")
-                        onClose()
-                    }
+            // 共通の ToolbarContent に委譲し、閉じるボタンの表示可否とアクションを一元管理する
+            CloseButtonToolbarContent(
+                showsCloseButton: showsCloseButton,
+                onClose: {
+                    // ナビゲーションスタックをポップする契機を記録し、手動クローズのトレースを取りやすくする
+                    debugLog("CampaignStageSelectionView.toolbar: 閉じるボタン押下 -> NavigationStackポップ要求")
+                    onClose()
                 }
-            }
+            )
         }
         // ステージ一覧の表示状態を追跡し、遷移の成否をログで確認できるようにする
         .onAppear {
@@ -252,5 +251,26 @@ struct CampaignStageSelectionView: View {
         }
     }
 
+}
+
+/// モーダルやナビゲーションスタックで共通利用する「閉じる」ボタン付きのツールバー
+/// - Note: showsCloseButton の判定を内部で行うことで、呼び出し側では条件分岐を気にせずに済むようにする
+struct CloseButtonToolbarContent: ToolbarContent {
+    /// 閉じるボタンを表示するかどうか
+    let showsCloseButton: Bool
+    /// 閉じるボタンが押下された際の処理
+    let onClose: () -> Void
+
+    var body: some ToolbarContent {
+        ToolbarItem(placement: .cancellationAction) {
+            if showsCloseButton {
+                Button("閉じる") {
+                    // ボタン押下を検知したタイミングでデバッグログを残し、遷移トラブルの調査材料とする
+                    debugLog("CloseButtonToolbarContent: 閉じるボタン押下 -> onClose を実行")
+                    onClose()
+                }
+            }
+        }
+    }
 }
 

--- a/UI/HowToPlayView.swift
+++ b/UI/HowToPlayView.swift
@@ -95,14 +95,15 @@ struct HowToPlayView: View {
         .background(Color(UIColor.systemBackground))
         .navigationTitle("遊び方")
         .toolbar {
-            // MARK: - モーダル用の閉じるボタン
-            if showsCloseButton {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("閉じる") {
-                        dismiss()
-                    }
+            // MARK: - モーダル用の閉じるボタンを共通コンポーネントで表示
+            CloseButtonToolbarContent(
+                showsCloseButton: showsCloseButton,
+                onClose: {
+                    // dismiss の実行契機を明示し、想定外の閉じる動作が発生した際にトレースしやすくする
+                    debugLog("HowToPlayView.toolbar: 閉じるボタン押下 -> dismiss を実行")
+                    dismiss()
                 }
-            }
+            )
         }
     }
 }

--- a/UI/PauseMenuView.swift
+++ b/UI/PauseMenuView.swift
@@ -124,12 +124,16 @@ struct PauseMenuView: View {
             .listStyle(.insetGrouped)
             .navigationTitle("ポーズ")
             .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("閉じる") {
+                // MARK: - プレイ再開とセットで閉じるボタンを共通実装へ委譲
+                CloseButtonToolbarContent(
+                    showsCloseButton: true,
+                    onClose: {
+                        // 再開処理と dismiss の順序を保ちつつ、デバッグログでトレース可能にする
+                        debugLog("PauseMenuView.toolbar: 閉じるボタン押下 -> onResume と dismiss を順番に実行")
                         onResume()
                         dismiss()
                     }
-                }
+                )
             }
             .background(theme.backgroundPrimary)
         }


### PR DESCRIPTION
## Summary
- add a reusable ToolbarContent implementation to manage the "閉じる" button in CampaignStageSelectionView
- adopt the shared toolbar component in CampaignStageSelectionView, HowToPlayView, and PauseMenuView with additional debug logging

## Testing
- not run (Xcode build is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc4750f150832c9ff2375d414d7393