### PR TITLE
Fix CampaignStageSelectionView safe area inset result builder

### DIFF
--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -73,6 +73,9 @@ struct CampaignStageSelectionView: View {
                 .padding(.horizontal, 16)
                 .padding(.vertical, 10)
                 .background(.thinMaterial)
+            } else {
+                // safeAreaInset の ResultBuilder が Void を返さないよう、非表示時は EmptyView を明示する
+                EmptyView()
             }
         }
         // ステージ一覧の表示状態を追跡し、遷移の成否をログで確認できるようにする


### PR DESCRIPTION
## Summary
- ensure CampaignStageSelectionView.safeAreaInset returns a view when the close button is hidden
- add explicit EmptyView to satisfy the view builder when the close button is not displayed

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dc4b1e94e0832c9a43ba96990d3ab6