### PR TITLE
Fix debug logging evaluation in navigation destinations

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -1431,7 +1431,7 @@ fileprivate struct TitleScreenView: View {
             let stackDescription = navigationPath
                 .map { $0.rawValue }
                 .joined(separator: ",")
-            debugLog(
+            let _ = debugLog(
                 "TitleScreenView: NavigationDestination.campaign 構築開始 -> instance=\(instanceIdentifier.uuidString) targetType=\(String(describing: type(of: target))) stackCount=\(navigationPath.count) stack=[\(stackDescription)]"
             )
             CampaignStageSelectionView(
@@ -1458,7 +1458,7 @@ fileprivate struct TitleScreenView: View {
             let stackDescription = navigationPath
                 .map { $0.rawValue }
                 .joined(separator: ",")
-            debugLog(
+            let _ = debugLog(
                 "TitleScreenView: NavigationDestination.freeModeEditor 構築開始 -> instance=\(instanceIdentifier.uuidString) targetType=\(String(describing: type(of: target))) stackCount=\(navigationPath.count) stack=[\(stackDescription)]"
             )
             FreeModeRegulationView(
@@ -1483,7 +1483,7 @@ fileprivate struct TitleScreenView: View {
             let stackDescription = navigationPath
                 .map { $0.rawValue }
                 .joined(separator: ",")
-            debugLog(
+            let _ = debugLog(
                 "TitleScreenView: NavigationDestination.unknown フォールバック -> instance=\(instanceIdentifier.uuidString) rawValue=\(target.rawValue) targetType=\(String(describing: type(of: target))) stackCount=\(navigationPath.count) stack=[\(stackDescription)]"
             )
             EmptyView()


### PR DESCRIPTION
## Summary
- prevent `TitleScreenView` navigation destinations from evaluating logging calls as `ViewBuilder` content by discarding the result explicitly
- apply the same logging handling to the unknown fallback case for consistency

## Testing
- not run (requires Xcode)

------
https://chatgpt.com/codex/tasks/task_e_68dc788d6b60832c96e3795e939389a1