### PR TITLE
Refactor move handling to support multi-vector cards

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -11,6 +11,8 @@ struct Deck {
     struct Configuration {
         /// 抽選対象とするカード一覧（順序を維持する）
         let allowedMoves: [MoveCard]
+        /// 抽選対象カードの移動ベクトル配列（順序を維持する）
+        let allowedMoveSignatures: [[MoveVector]]
         /// 各カードの基礎重み
         let baseWeights: [MoveCard: Int]
         /// 連続排出抑制を行うかどうか
@@ -43,6 +45,7 @@ struct Deck {
             deckSummaryText: String
         ) {
             self.allowedMoves = allowedMoves
+            self.allowedMoveSignatures = allowedMoves.map { $0.movementVectors }
             self.baseWeights = baseWeights
             self.shouldApplyProbabilityReduction = shouldApplyProbabilityReduction
             self.normalWeightMultiplier = normalWeightMultiplier

--- a/Game/GameCore+Penalty.swift
+++ b/Game/GameCore+Penalty.swift
@@ -76,7 +76,7 @@ extension GameCore {
         // スポーン待機中は判定不要
         guard progress != .awaitingSpawn, let current = current else { return }
 
-        // availableMoves() を利用して盤面内へ進めるカードが残っているかを判定する
+        // availableMoves() 内で primaryVector が評価されるため、将来の複数候補カードでも共通ロジックを維持できる
         let usableMoves = availableMoves(handStacks: handStacks, current: current)
         guard usableMoves.isEmpty else { return }
 

--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -121,7 +121,9 @@ public final class GameCore: ObservableObject {
         guard handStacks.indices.contains(index) else { return }
         let stack = handStacks[index]
         guard let card = stack.topCard else { return }
-        let target = currentPosition.offset(dx: card.move.dx, dy: card.move.dy)
+        // primaryVector を経由することで、将来的に複数候補を持つカードでも同じ分岐から処理を広げられる
+        let vector = card.move.primaryVector
+        let target = currentPosition.offset(dx: vector.dx, dy: vector.dy)
         // UI 側で無効カードを弾く想定だが、念のため安全確認
         guard board.contains(target) else { return }
 
@@ -203,7 +205,8 @@ public final class GameCore: ObservableObject {
         for (index, stack) in referenceHandStacks.enumerated() {
             // トップカードが存在しなければスキップ
             guard let topCard = stack.topCard else { continue }
-            let vector = MoveVector(dx: topCard.move.dx, dy: topCard.move.dy)
+            // primaryVector を使えば複数候補カード導入時にここで候補展開を切り替えられる
+            let vector = topCard.move.primaryVector
             let destination = origin.offset(dx: vector.dx, dy: vector.dy)
             // 盤面外の移動は候補から除外
             guard activeBoard.contains(destination) else { continue }

--- a/Game/HandStack.swift
+++ b/Game/HandStack.swift
@@ -31,6 +31,10 @@ public struct HandStack: Identifiable, Equatable {
     /// 最新カードの MoveCard を取得する。スタックが空の場合は nil。
     public var representativeMove: MoveCard? { topCard?.move }
 
+    /// 最新カードが持つ移動ベクトル配列を返す
+    /// - Note: 今後同じ移動候補を持つ別カードが増えてもスタックを共用できるよう、MoveCard の列挙値ではなくベクトル列を比較基準とする
+    public var representativeVectors: [MoveVector]? { representativeMove?.movementVectors }
+
     /// 同じ種類のカードを積み増しする
     /// - Parameter card: 追加したい `DealtCard`
     public mutating func append(_ card: DealtCard) {

--- a/Game/Models.swift
+++ b/Game/Models.swift
@@ -1,6 +1,24 @@
 import Foundation
 import SharedSupport // ログユーティリティを利用するため追加
 
+/// カードが持つ移動量を一括管理するためのベクトル構造体
+/// - Note: `dx` / `dy` の組み合わせを 1 単位として扱い、今後の複数候補カードでも再利用しやすいよう共通モデル層へ配置する
+public struct MoveVector: Hashable, Codable {
+    /// x 方向への移動量
+    public let dx: Int
+    /// y 方向への移動量
+    public let dy: Int
+
+    /// 指定移動量で構造体を生成するためのイニシャライザ
+    /// - Parameters:
+    ///   - dx: x 方向に加算する値
+    ///   - dy: y 方向に加算する値
+    public init(dx: Int, dy: Int) {
+        self.dx = dx
+        self.dy = dy
+    }
+}
+
 /// 座標を表す構造体
 /// - 備考: 原点は左下、x は右方向、y は上方向に増加する
 public struct GridPoint: Hashable, Codable {

--- a/Game/MoveCard.swift
+++ b/Game/MoveCard.swift
@@ -86,65 +86,70 @@ public enum MoveCard: CaseIterable {
     /// 斜め: 左上に 2
     case diagonalUpLeft2
 
-    // MARK: - 移動量
-    /// x 方向の移動量
-    public var dx: Int {
+    // MARK: - 移動ベクトル
+    /// カードが持つ移動候補一覧を返す
+    /// - Important: 現行カードは 1 要素のみだが、今後複数候補を持つカード追加時に拡張しやすいよう配列で保持する
+    public var movementVectors: [MoveVector] {
         switch self {
-        case .kingUp: return 0
-        case .kingUpRight: return 1
-        case .kingRight: return 1
-        case .kingDownRight: return 1
-        case .kingDown: return 0
-        case .kingDownLeft: return -1
-        case .kingLeft: return -1
-        case .kingUpLeft: return -1
-        case .knightUp2Right1: return 1
-        case .knightUp2Left1: return -1
-        case .knightUp1Right2: return 2
-        case .knightUp1Left2: return -2
-        case .knightDown2Right1: return 1
-        case .knightDown2Left1: return -1
-        case .knightDown1Right2: return 2
-        case .knightDown1Left2: return -2
-        case .straightUp2: return 0
-        case .straightDown2: return 0
-        case .straightRight2: return 2
-        case .straightLeft2: return -2
-        case .diagonalUpRight2: return 2
-        case .diagonalDownRight2: return 2
-        case .diagonalDownLeft2: return -2
-        case .diagonalUpLeft2: return -2
+        case .kingUp:
+            return [MoveVector(dx: 0, dy: 1)]
+        case .kingUpRight:
+            return [MoveVector(dx: 1, dy: 1)]
+        case .kingRight:
+            return [MoveVector(dx: 1, dy: 0)]
+        case .kingDownRight:
+            return [MoveVector(dx: 1, dy: -1)]
+        case .kingDown:
+            return [MoveVector(dx: 0, dy: -1)]
+        case .kingDownLeft:
+            return [MoveVector(dx: -1, dy: -1)]
+        case .kingLeft:
+            return [MoveVector(dx: -1, dy: 0)]
+        case .kingUpLeft:
+            return [MoveVector(dx: -1, dy: 1)]
+        case .knightUp2Right1:
+            return [MoveVector(dx: 1, dy: 2)]
+        case .knightUp2Left1:
+            return [MoveVector(dx: -1, dy: 2)]
+        case .knightUp1Right2:
+            return [MoveVector(dx: 2, dy: 1)]
+        case .knightUp1Left2:
+            return [MoveVector(dx: -2, dy: 1)]
+        case .knightDown2Right1:
+            return [MoveVector(dx: 1, dy: -2)]
+        case .knightDown2Left1:
+            return [MoveVector(dx: -1, dy: -2)]
+        case .knightDown1Right2:
+            return [MoveVector(dx: 2, dy: -1)]
+        case .knightDown1Left2:
+            return [MoveVector(dx: -2, dy: -1)]
+        case .straightUp2:
+            return [MoveVector(dx: 0, dy: 2)]
+        case .straightDown2:
+            return [MoveVector(dx: 0, dy: -2)]
+        case .straightRight2:
+            return [MoveVector(dx: 2, dy: 0)]
+        case .straightLeft2:
+            return [MoveVector(dx: -2, dy: 0)]
+        case .diagonalUpRight2:
+            return [MoveVector(dx: 2, dy: 2)]
+        case .diagonalDownRight2:
+            return [MoveVector(dx: 2, dy: -2)]
+        case .diagonalDownLeft2:
+            return [MoveVector(dx: -2, dy: -2)]
+        case .diagonalUpLeft2:
+            return [MoveVector(dx: -2, dy: 2)]
         }
     }
 
-    /// y 方向の移動量
-    public var dy: Int {
-        switch self {
-        case .kingUp: return 1
-        case .kingUpRight: return 1
-        case .kingRight: return 0
-        case .kingDownRight: return -1
-        case .kingDown: return -1
-        case .kingDownLeft: return -1
-        case .kingLeft: return 0
-        case .kingUpLeft: return 1
-        case .knightUp2Right1: return 2
-        case .knightUp2Left1: return 2
-        case .knightUp1Right2: return 1
-        case .knightUp1Left2: return 1
-        case .knightDown2Right1: return -2
-        case .knightDown2Left1: return -2
-        case .knightDown1Right2: return -1
-        case .knightDown1Left2: return -1
-        case .straightUp2: return 2
-        case .straightDown2: return -2
-        case .straightRight2: return 0
-        case .straightLeft2: return 0
-        case .diagonalUpRight2: return 2
-        case .diagonalDownRight2: return -2
-        case .diagonalDownLeft2: return -2
-        case .diagonalUpLeft2: return 2
+    /// 既存コードとの互換性を維持するための代表ベクトル
+    /// - Note: 候補が複数化した際は UI 側での選択ロジックを追加しやすいよう、先頭要素を共通の入口として公開する
+    public var primaryVector: MoveVector {
+        guard let vector = movementVectors.first else {
+            assertionFailure("MoveCard.movementVectors は最低 1 要素を想定している")
+            return MoveVector(dx: 0, dy: 0)
         }
+        return vector
     }
 
     // MARK: - UI 表示名
@@ -252,8 +257,9 @@ public enum MoveCard: CaseIterable {
     ///   - boardSize: 判定対象となる盤面サイズ
     /// - Returns: 盤内に移動できる場合は true
     public func canUse(from: GridPoint, boardSize: Int) -> Bool {
-        // 現在位置に移動量を加算し、盤内かどうかを評価する
-        let destination = from.offset(dx: dx, dy: dy)
+        // 代表ベクトルを通じて移動先を求める。複数候補カード追加時もここを起点に分岐を検討する
+        let vector = primaryVector
+        let destination = from.offset(dx: vector.dx, dy: vector.dy)
         return destination.isInside(boardSize: boardSize)
     }
 }

--- a/Game/ResolvedCardMove.swift
+++ b/Game/ResolvedCardMove.swift
@@ -1,23 +1,5 @@
 import Foundation
 
-/// カードの移動量を表すベクトル構造体
-/// - Note: `dx` / `dy` をまとめて扱うことで、ログ出力やテストでの比較を簡略化する。
-public struct MoveVector: Hashable, Codable {
-    /// x 方向の移動量
-    public let dx: Int
-    /// y 方向の移動量
-    public let dy: Int
-
-    /// 公開イニシャライザ
-    /// - Parameters:
-    ///   - dx: x 方向へ加算する値
-    ///   - dy: y 方向へ加算する値
-    public init(dx: Int, dy: Int) {
-        self.dx = dx
-        self.dy = dy
-    }
-}
-
 /// 手札スタックから盤面へ移動可能なカード情報を解決した結果を保持する構造体
 /// - Note: スタック識別子・インデックス・カード種別・移動後座標など、UI とロジック双方で共有したい情報を 1 箇所へ集約する。
 public struct ResolvedCardMove: Hashable {

--- a/Tests/GameTests/BoardMovementTests.swift
+++ b/Tests/GameTests/BoardMovementTests.swift
@@ -22,4 +22,17 @@ final class BoardMovementTests: XCTestCase {
         let inside = origin.offset(dx: 1, dy: 0)
         XCTAssertTrue(inside.isInside(boardSize: boardSize))
     }
+
+    /// MoveCard の移動ベクトルが従来の dx/dy と同じ値を返すかを確認する
+    func testMoveCardMovementVectorsMatchLegacyValues() {
+        let card = MoveCard.kingRight
+        let expectedVector = MoveVector(dx: 1, dy: 0)
+        XCTAssertEqual(card.movementVectors, [expectedVector], "移動候補配列が既存仕様と一致しません")
+        XCTAssertEqual(card.primaryVector, expectedVector, "primaryVector が従来値と一致しません")
+
+        let knightCard = MoveCard.knightUp1Right2
+        let knightVector = MoveVector(dx: 2, dy: 1)
+        XCTAssertEqual(knightCard.movementVectors, [knightVector], "桂馬カードの移動候補が想定と異なります")
+        XCTAssertEqual(knightCard.primaryVector, knightVector, "桂馬カードの代表ベクトルが想定と異なります")
+    }
 }

--- a/Tests/GameTests/GameCoreTests.swift
+++ b/Tests/GameTests/GameCoreTests.swift
@@ -399,7 +399,8 @@ final class GameCoreTests: XCTestCase {
             [.kingUp, .kingRight, .straightUp2, .kingLeft, .knightUp1Right2],
             "空きスロットに新カードが補充されていません"
         )
-        if let rightStack = core.handStacks.first(where: { $0.representativeMove == .kingRight }) {
+        let kingRightVectors = MoveCard.kingRight.movementVectors
+        if let rightStack = core.handStacks.first(where: { $0.representativeVectors == kingRightVectors }) {
             XCTAssertEqual(rightStack.count, 2, "重なったカード枚数が想定と異なります")
         } else {
             XCTFail("キング右のスタックが見つかりません")
@@ -447,8 +448,10 @@ final class GameCoreTests: XCTestCase {
         XCTAssertFalse(core.isAwaitingManualDiscardSelection)
         XCTAssertEqual(core.penaltyCount, initialPenalty + core.mode.manualDiscardPenaltyCost)
         XCTAssertEqual(core.handStacks.count, 5)
-        XCTAssertFalse(core.handStacks.contains(where: { $0.representativeMove == .kingRight }))
-        XCTAssertTrue(core.handStacks.contains(where: { $0.representativeMove == .straightUp2 }))
+        let kingRightVectors = MoveCard.kingRight.movementVectors
+        let straightUpVectors = MoveCard.straightUp2.movementVectors
+        XCTAssertFalse(core.handStacks.contains(where: { $0.representativeVectors == kingRightVectors }))
+        XCTAssertTrue(core.handStacks.contains(where: { $0.representativeVectors == straightUpVectors }))
         XCTAssertEqual(
             core.nextCards.map { $0.move },
             [.diagonalUpRight2, .kingUpRight, .straightDown2]

--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -192,7 +192,7 @@ final class GameBoardBridgeViewModel: ObservableObject {
             return
         }
 
-        // GameCore.availableMoves() を利用して重複排除と境界チェックを共通化する
+        // GameCore.availableMoves() 内で primaryVector が評価されるため、複数候補カード追加後もここから同じインターフェースで受け取れる
         let resolvedMoves = core.availableMoves(handStacks: handStacks, current: current)
         let candidatePoints = Set(resolvedMoves.map { $0.destination })
 
@@ -244,6 +244,7 @@ final class GameBoardBridgeViewModel: ObservableObject {
         guard let topCard = stack.topCard else { return false }
 
         // 現在の手札状況に基づく使用可能カードを検索し、該当スタックの候補を取得する
+        // - Note: availableMoves() 側が primaryVector で位置を算出するため、複数候補カードを導入してもここでの分岐は据え置ける
         guard let resolvedMove = core.availableMoves().first(where: { candidate in
             candidate.stackID == stack.id && candidate.card.id == topCard.id
         }) else {
@@ -366,6 +367,7 @@ final class GameBoardBridgeViewModel: ObservableObject {
     /// - Returns: 使用可能なら true
     func isCardUsable(_ stack: HandStack) -> Bool {
         guard let card = stack.topCard else { return false }
+        // availableMoves() が primaryVector を利用しているため、1 候補カードと同じ手続きで拡張に備えられる
         return core.availableMoves().contains { candidate in
             candidate.stackID == stack.id && candidate.card.id == card.id
         }

--- a/UI/GameViewModel.swift
+++ b/UI/GameViewModel.swift
@@ -278,7 +278,9 @@ final class GameViewModel: ObservableObject {
             return
         }
 
-        let destination = current.offset(dx: card.move.dx, dy: card.move.dy)
+        // primaryVector を介して移動先を算出する。複数候補カード追加時もここで分岐を整理できるようにするための布石。
+        let vector = card.move.primaryVector
+        let destination = current.offset(dx: vector.dx, dy: vector.dy)
         if core.board.contains(destination) {
             boardBridge.updateForcedSelectionHighlights([destination])
         } else {

--- a/docs/refactoring-guidelines.md
+++ b/docs/refactoring-guidelines.md
@@ -52,6 +52,11 @@
 ## 3. 優先すべきリファクタリング領域
 1. **ゲームコアロジック (`Game` パッケージ)**
    - `GameModuleInterfaces` を経由した依存注入が整備されたため、今後は `HandManager` や `Deck` の再利用性を高める。
+   - 2024-05 リファクタリング: 移動量を `MoveVector` へ集約し、`MoveCard.movementVectors` / `primaryVector` を通じて参照する。
+     - 旧実装で `dx` / `dy` を直接参照している箇所は、`primaryVector.dx` / `.dy` へ置き換える。
+     - 同一挙動カードの比較は `MoveVector` 配列をキーにする。`HandStack.representativeVectors` や `Deck.Configuration.allowedMoveSignatures` を活用する。
+     - 複数候補カードを導入する場合は `movementVectors` の配列を増やし、UI は `ResolvedCardMove` の拡張で候補選択ロジックを追加する。
+     - テストは `MoveCard` の代表ベクトルが期待通りであることを明示的に検証し、回帰検知の指標とする。
    - モードごとのペナルティ・手札整理ロジックを `GameMode` のパラメータに一本化し、盤面追加時にも破綻しないようテストを拡充する。
      `GameCore+Penalty.swift` など機能別ファイルの役割をドキュメントへ反映しておく。
 2. **UI レイヤー (`UI/` ディレクトリ)**


### PR DESCRIPTION
## Summary
- centralize the MoveVector struct in the shared models layer and expose movementVectors/primaryVector on MoveCard
- update deck configuration, hand management, game core, and UI helpers to rely on vector signatures so stacking and ordering remain stable
- expand regression tests and documentation to cover the new vector-based flow

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68dc94589b90832c96de3c60f39e995a