### PR TITLE
Support multi-vector card moves

### DIFF
--- a/Game/Models.swift
+++ b/Game/Models.swift
@@ -220,7 +220,7 @@ public struct BoardTapPlayRequest: Identifiable, Equatable {
     public let id: UUID
     /// 盤面タップ時に対応する手札スタックの識別子
     public let stackID: UUID
-    /// `GameCore.playCard(at:)` に渡すインデックス
+    /// `GameCore.playCard(using:)` に渡す候補のうち、スタック位置を識別するためのインデックス
     public let stackIndex: Int
     /// アニメーション用に参照するスタック先頭のカード
     public let topCard: DealtCard

--- a/Game/MoveCard.swift
+++ b/Game/MoveCard.swift
@@ -89,7 +89,26 @@ public enum MoveCard: CaseIterable {
     // MARK: - 移動ベクトル
     /// カードが持つ移動候補一覧を返す
     /// - Important: 現行カードは 1 要素のみだが、今後複数候補を持つカード追加時に拡張しやすいよう配列で保持する
+    /// テスト向けに movementVectors を差し替えるためのオーバーライド辞書
+    /// - Note: テスト完了後は必ず nil を指定してクリーンアップし、副作用を残さないようにする
+    static var testMovementVectorOverrides: [MoveCard: [MoveVector]] = [:]
+
+    /// movementVectors を一時的に差し替えるヘルパー
+    /// - Parameters:
+    ///   - vectors: 差し替え後の移動ベクトル配列。nil を渡すと元の定義に戻す。
+    ///   - card: 対象となるカード種別
+    static func setTestMovementVectors(_ vectors: [MoveVector]?, for card: MoveCard) {
+        if let vectors {
+            testMovementVectorOverrides[card] = vectors
+        } else {
+            testMovementVectorOverrides.removeValue(forKey: card)
+        }
+    }
+
     public var movementVectors: [MoveVector] {
+        if let override = MoveCard.testMovementVectorOverrides[self] {
+            return override
+        }
         switch self {
         case .kingUp:
             return [MoveVector(dx: 0, dy: 1)]

--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -244,7 +244,7 @@ final class GameBoardBridgeViewModel: ObservableObject {
         guard let topCard = stack.topCard else { return false }
 
         // 現在の手札状況に基づく使用可能カードを検索し、該当スタックの候補を取得する
-        // - Note: availableMoves() 側が primaryVector で位置を算出するため、複数候補カードを導入してもここでの分岐は据え置ける
+        // - Note: availableMoves() がカード内の全ベクトルを展開しているため、複数候補カードでもここから 1 件を選ぶだけで良い
         guard let resolvedMove = core.availableMoves().first(where: { candidate in
             candidate.stackID == stack.id && candidate.card.id == topCard.id
         }) else {
@@ -281,7 +281,7 @@ final class GameBoardBridgeViewModel: ObservableObject {
         DispatchQueue.main.asyncAfter(deadline: .now() + travelDuration) { [weak self] in
             guard let self else { return }
             withAnimation(.easeInOut(duration: 0.22)) {
-                self.core.playCard(at: resolvedMove.stackIndex)
+                self.core.playCard(using: resolvedMove)
             }
             self.hiddenCardIDs.remove(cardID)
             if self.animatingCard?.id == cardID {

--- a/UI/GameViewModel.swift
+++ b/UI/GameViewModel.swift
@@ -278,13 +278,16 @@ final class GameViewModel: ObservableObject {
             return
         }
 
-        // primaryVector を介して移動先を算出する。複数候補カード追加時もここで分岐を整理できるようにするための布石。
-        let vector = card.move.primaryVector
-        let destination = current.offset(dx: vector.dx, dy: vector.dy)
-        if core.board.contains(destination) {
-            boardBridge.updateForcedSelectionHighlights([destination])
-        } else {
+        // GameCore.availableMoves() が返す候補の中から対象スタックに一致するものを抽出し、複数ベクトルの全候補をハイライトする
+        let resolvedMoves = core.availableMoves().filter { candidate in
+            candidate.stackID == stack.id && candidate.card.id == card.id
+        }
+        let destinations = Set(resolvedMoves.map { $0.destination }.filter { core.board.contains($0) })
+
+        if destinations.isEmpty {
             boardBridge.updateForcedSelectionHighlights([])
+        } else {
+            boardBridge.updateForcedSelectionHighlights(destinations)
         }
     }
 


### PR DESCRIPTION
## Summary
- enumerate every movement vector when resolving available card moves and expose a playCard(using:) entry point
- update the game board and view models to invoke the resolved-move API and surface all destinations for a stack
- add a movement vector override hook for tests and cover multi-vector moves with new regression cases

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dc98aa978c832c8e1c6885d107c979