### PR TITLE
盤面タップ経由のカードプレイで解決済み移動を使用

### DIFF
--- a/Game/Models.swift
+++ b/Game/Models.swift
@@ -218,24 +218,30 @@ public enum GameProgress {
 public struct BoardTapPlayRequest: Identifiable, Equatable {
     /// 各リクエストを一意に識別するための ID
     public let id: UUID
-    /// 盤面タップ時に対応する手札スタックの識別子
-    public let stackID: UUID
-    /// `GameCore.playCard(at:)` に渡すインデックス
-    public let stackIndex: Int
-    /// アニメーション用に参照するスタック先頭のカード
-    public let topCard: DealtCard
+    /// タップ結果から確定した移動内容をそのまま保持する
+    /// - Important: `ResolvedCardMove` 自体にスタック ID・インデックス・カード情報・移動先がまとまっているため、
+    ///              ここで保持しておくことで UI 側で再解決せずに済む。
+    public let resolvedMove: ResolvedCardMove
+
+    /// タップ要求に紐づくスタック識別子
+    /// - Note: `resolvedMove` から値を参照する読み取り専用プロパティとする
+    public var stackID: UUID { resolvedMove.stackID }
+    /// 元の `GameCore.playCard(at:)` 互換のインデックス情報
+    public var stackIndex: Int { resolvedMove.stackIndex }
+    /// アニメーション用のトップカード情報
+    public var topCard: DealtCard { resolvedMove.card }
+    /// 選択された移動ベクトル
+    public var moveVector: MoveVector { resolvedMove.moveVector }
+    /// タップで確定した移動先座標
+    public var destination: GridPoint { resolvedMove.destination }
 
     /// 公開イニシャライザ
     /// - Parameters:
     ///   - id: 外部で識別子を指定したい場合に利用（省略時は自動生成）
-    ///   - stackID: 対象スタックの識別子
-    ///   - stackIndex: 手札スロット内での位置
-    ///   - topCard: 要求時点での先頭カード
-    public init(id: UUID = UUID(), stackID: UUID, stackIndex: Int, topCard: DealtCard) {
+    ///   - resolvedMove: UI 側で利用したい移動確定情報
+    public init(id: UUID = UUID(), resolvedMove: ResolvedCardMove) {
         self.id = id
-        self.stackID = stackID
-        self.stackIndex = stackIndex
-        self.topCard = topCard
+        self.resolvedMove = resolvedMove
     }
 
     /// Equatable 実装

--- a/Tests/GameTests/GameCoreTests.swift
+++ b/Tests/GameTests/GameCoreTests.swift
@@ -73,6 +73,48 @@ final class GameCoreTests: XCTestCase {
         ])
     }
 
+    /// playCard(using:) が ResolvedCardMove の destination を忠実に適用することを検証
+    func testPlayCardUsingResolvedMoveAppliesDestination() {
+        let deck = Deck.makeTestDeck(cards: [
+            .kingUp,
+            .kingRight,
+            .kingDown,
+            .kingLeft,
+            .kingUpLeft,
+            .straightUp2,
+            .straightRight2,
+            .straightDown2
+        ])
+        let core = GameCore.makeTestInstance(deck: deck)
+
+        guard let current = core.current else {
+            XCTFail("現在位置が未設定です")
+            return
+        }
+
+        guard let stack = core.handStacks.first,
+              let topCard = stack.topCard else {
+            XCTFail("トップカードを取得できませんでした")
+            return
+        }
+
+        let targetPoint = current.offset(dx: 1, dy: 0)
+        XCTAssertTrue(core.board.contains(targetPoint), "ターゲット座標が盤面外です")
+
+        let resolvedMove = ResolvedCardMove(
+            stackID: stack.id,
+            stackIndex: 0,
+            card: topCard,
+            moveVector: MoveVector(dx: 1, dy: 0),
+            destination: targetPoint
+        )
+
+        core.playCard(using: resolvedMove)
+
+        XCTAssertEqual(core.current, targetPoint, "ResolvedCardMove の destination が反映されていません")
+        XCTAssertEqual(core.moveCount, 1, "playCard(using:) 実行後の手数が増えていません")
+    }
+
     /// 手詰まり後に再び手詰まりが発生した場合でも追加ペナルティが加算されないことを確認
     func testConsecutiveDeadlockDoesNotAddExtraPenalty() {
         // --- テスト用デッキ構築 ---

--- a/UI/GameViewModel.swift
+++ b/UI/GameViewModel.swift
@@ -309,6 +309,12 @@ final class GameViewModel: ObservableObject {
 
     /// 盤面タップに応じたプレイ要求を処理する
     func handleBoardTapPlayRequest(_ request: BoardTapPlayRequest) {
+        // 盤面外のリクエストが万一届いた場合は UI 側で安全に破棄する
+        guard core.board.contains(request.destination) else {
+            core.clearBoardTapPlayRequest(request.id)
+            return
+        }
+
         boardBridge.handleBoardTapPlayRequest(request)
     }
 


### PR DESCRIPTION
## Summary
- BoardTapPlayRequest に ResolvedCardMove を保持し、destination / moveVector を UI へ渡す
- GameCore.playCard(using:) を追加して UI 側からの解決済み移動をそのまま適用
- GameBoardBridgeViewModel と GameViewModel を更新し、盤面タップ演出・カード適用テストを拡充

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dc98adc5f0832c8ff2a8cafd8d9178