### PR TITLE
Implement multi-move card selection flow

### DIFF
--- a/Game/GameCore+Penalty.swift
+++ b/Game/GameCore+Penalty.swift
@@ -76,7 +76,7 @@ extension GameCore {
         // スポーン待機中は判定不要
         guard progress != .awaitingSpawn, let current = current else { return }
 
-        // availableMoves() 内で primaryVector が評価されるため、将来の複数候補カードでも共通ロジックを維持できる
+        // availableMoves() が複数候補も展開して返すため、ここでは候補一覧をそのまま利用できる
         let usableMoves = availableMoves(handStacks: handStacks, current: current)
         guard usableMoves.isEmpty else { return }
 

--- a/Game/HandManager.swift
+++ b/Game/HandManager.swift
@@ -214,3 +214,20 @@ public final class HandManager: ObservableObject {
         replenishNextPreview(using: &deck)
     }
 }
+
+#if DEBUG
+/// デバッグビルドで手札を直接差し替えるためのサポートメソッド
+extension HandManager {
+    /// テスト用に手札スタックを任意の配列へ上書きする
+    /// - Parameter stacks: 適用したい手札スタック配列
+    func overrideHandStacksForTesting(_ stacks: [HandStack]) {
+        handStacks = stacks
+    }
+
+    /// テスト用に NEXT 表示カードを任意の配列へ上書きする
+    /// - Parameter cards: 適用したいカード配列
+    func overrideNextCardsForTesting(_ cards: [DealtCard]) {
+        nextCards = cards
+    }
+}
+#endif

--- a/Game/Models.swift
+++ b/Game/Models.swift
@@ -224,6 +224,10 @@ public struct BoardTapPlayRequest: Identifiable, Equatable {
     public let stackIndex: Int
     /// アニメーション用に参照するスタック先頭のカード
     public let topCard: DealtCard
+    /// 移動候補が持つベクトル（複数候補カード対応のため保持）
+    public let moveVector: MoveVector
+    /// タップしたマスの座標
+    public let destination: GridPoint
 
     /// 公開イニシャライザ
     /// - Parameters:
@@ -231,11 +235,33 @@ public struct BoardTapPlayRequest: Identifiable, Equatable {
     ///   - stackID: 対象スタックの識別子
     ///   - stackIndex: 手札スロット内での位置
     ///   - topCard: 要求時点での先頭カード
-    public init(id: UUID = UUID(), stackID: UUID, stackIndex: Int, topCard: DealtCard) {
+    ///   - moveVector: タップで選択された移動ベクトル
+    ///   - destination: ベクトル適用後に到達する座標
+    public init(
+        id: UUID = UUID(),
+        stackID: UUID,
+        stackIndex: Int,
+        topCard: DealtCard,
+        moveVector: MoveVector,
+        destination: GridPoint
+    ) {
         self.id = id
         self.stackID = stackID
         self.stackIndex = stackIndex
         self.topCard = topCard
+        self.moveVector = moveVector
+        self.destination = destination
+    }
+
+    /// 要求内容から `ResolvedCardMove` を生成するためのヘルパー
+    public var resolvedMove: ResolvedCardMove {
+        ResolvedCardMove(
+            stackID: stackID,
+            stackIndex: stackIndex,
+            card: topCard,
+            moveVector: moveVector,
+            destination: destination
+        )
     }
 
     /// Equatable 実装


### PR DESCRIPTION
## Summary
- keep track of the selected hand stack and highlight all available destinations until the board tap finalizes the move
- rework the board bridge to accept resolved moves and convert movement vectors into forced highlight grid points
- expand GameCore and MoveCard APIs to enumerate all movement vectors and add integration test coverage for multi-move cards

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dc98af1784832ca515e5799108eefb