### PR TITLE
Fix MoveCard canUse to check all movement vectors

### DIFF
--- a/Game/MoveCard.swift
+++ b/Game/MoveCard.swift
@@ -276,10 +276,13 @@ public enum MoveCard: CaseIterable {
     ///   - boardSize: 判定対象となる盤面サイズ
     /// - Returns: 盤内に移動できる場合は true
     public func canUse(from: GridPoint, boardSize: Int) -> Bool {
-        // 代表ベクトルを通じて移動先を求める。複数候補カード追加時もここを起点に分岐を検討する
-        let vector = primaryVector
-        let destination = from.offset(dx: vector.dx, dy: vector.dy)
-        return destination.isInside(boardSize: boardSize)
+        // 複数候補ベクトルのいずれかが盤内に入れば使用可能とみなす
+        // - Note: 既存カードは 1 要素だが、将来カードの拡張で順不同のベクトルが混在しても安全に判定できるようにする
+        return movementVectors.contains { vector in
+            // 各ベクトルで移動した先が盤内に収まるか逐一確認する
+            let destination = from.offset(dx: vector.dx, dy: vector.dy)
+            return destination.isInside(boardSize: boardSize)
+        }
     }
 }
 

--- a/Tests/GameTests/BoardMovementTests.swift
+++ b/Tests/GameTests/BoardMovementTests.swift
@@ -35,4 +35,20 @@ final class BoardMovementTests: XCTestCase {
         XCTAssertEqual(knightCard.movementVectors, [knightVector], "桂馬カードの移動候補が想定と異なります")
         XCTAssertEqual(knightCard.primaryVector, knightVector, "桂馬カードの代表ベクトルが想定と異なります")
     }
+
+    /// 複数候補のうち一部のみ盤内となるケースで canUse が true を返すか確認する
+    func testCanUseWithMultipleMovementCandidates() {
+        // 標準 5x5 盤を前提に左下端からの移動をテストする
+        let boardSize = BoardGeometry.standardSize
+        let origin = GridPoint(x: 0, y: 0)
+        // 最初の候補は盤外、次の候補は盤内となるようベクトルを差し替える
+        let outsideVector = MoveVector(dx: -1, dy: 0)
+        let insideVector = MoveVector(dx: 0, dy: 1)
+        MoveCard.setTestMovementVectors([outsideVector, insideVector], for: .kingRight)
+        // テスト後は副作用を残さないように元の定義へ戻す
+        defer { MoveCard.setTestMovementVectors(nil, for: .kingRight) }
+
+        // 盤内に入る候補が存在するため true を期待する（修正前は false だった想定ケース）
+        XCTAssertTrue(MoveCard.kingRight.canUse(from: origin, boardSize: boardSize))
+    }
 }


### PR DESCRIPTION
## Summary
- ensure MoveCard.canUse iterates through every movement vector candidate before deciding usability
- add a regression test covering a multi-vector card override where only one move stays on the board

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dca404dea4832ca841d08cd1f4cc58