### PR TITLE
Prioritize single-vector card selection on board taps

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -268,6 +268,26 @@ public final class GameCore: ObservableObject {
         return resolved
     }
 
+    /// 盤面タップ時に使用する移動候補を優先順位付きで選び出す
+    /// - Parameter point: ユーザーがタップした盤面座標
+    /// - Returns: 優先順位ロジックを適用した `ResolvedCardMove`（該当なしの場合は nil）
+    func resolvedMoveForBoardTap(at point: GridPoint) -> ResolvedCardMove? {
+        // availableMoves() からタップ地点へ到達できる候補だけを抽出する
+        let matchingMoves = availableMoves().filter { $0.destination == point }
+
+        // 候補が存在しない場合は nil を返して終了する
+        guard !matchingMoves.isEmpty else { return nil }
+
+        // moveVector の候補数が 1 つだけのカード（通常カード）を優先する
+        // - Important: 複数候補カードが存在しても、ユーザーの想定に近い通常カードを優先して消費する
+        if let singleVectorMove = matchingMoves.first(where: { $0.card.move.movementVectors.count == 1 }) {
+            return singleVectorMove
+        }
+
+        // 通常カードが存在しない場合は availableMoves() の並び順（座標→スタック順）に従って最初の候補を返す
+        return matchingMoves.first
+    }
+
     /// 盤面タップ由来のアニメーション要求を UI 側で処理したあとに呼び出す
     /// - Parameter id: 消したいリクエストの識別子（不一致の場合は何もしない）
     public func clearBoardTapPlayRequest(_ id: UUID) {
@@ -368,17 +388,16 @@ extension GameCore: GameCoreProtocol {
         // デバッグログ: タップされたマスを表示
         debugLog("マス \(point) をタップ")
 
-        // availableMoves() で求めた候補の中から座標一致を検索する
-        if let resolved = availableMoves().first(where: { $0.destination == point }) {
-            boardTapPlayRequest = BoardTapPlayRequest(
-                stackID: resolved.stackID,
-                stackIndex: resolved.stackIndex,
-                topCard: resolved.card,
-                destination: resolved.destination,
-                moveVector: resolved.moveVector
-            )
-        }
-        // 候補に該当しない場合は何もしない（無効タップ）
+        // 優先順位付きの候補を算出し、該当するものがあればアニメーション要求を発行する
+        guard let resolved = resolvedMoveForBoardTap(at: point) else { return }
+
+        boardTapPlayRequest = BoardTapPlayRequest(
+            stackID: resolved.stackID,
+            stackIndex: resolved.stackIndex,
+            topCard: resolved.card,
+            destination: resolved.destination,
+            moveVector: resolved.moveVector
+        )
     }
 }
 #endif

--- a/Tests/GameTests/GameCoreTests.swift
+++ b/Tests/GameTests/GameCoreTests.swift
@@ -224,6 +224,52 @@ final class GameCoreTests: XCTestCase {
         XCTAssertFalse(core.board.isVisited(GridPoint(x: 2, y: 3)), "未選択方向まで踏破扱いになっている")
     }
 
+    /// 盤面タップで複数候補と通常カードが同じマスへ到達できる場合、通常カードが優先されることを確認
+    func testHandleTapPrefersSingleVectorCardWhenDestinationOverlaps() {
+        // キング上カードへ 2 方向ベクトルを付与し、複数候補カードと通常カードの競合状況を作り出す
+        MoveCard.setTestMovementVectors([
+            MoveVector(dx: 0, dy: 1),
+            MoveVector(dx: 1, dy: 1)
+        ], for: .kingUp)
+        defer { MoveCard.setTestMovementVectors(nil, for: .kingUp) }
+
+        // 先頭スタックに複数候補カード、2 番目に通常カードが来るようにデッキを並べる
+        let deck = Deck.makeTestDeck(cards: [
+            .kingUp,
+            .kingUpRight,
+            .kingDown,
+            .kingLeft,
+            .kingUpLeft,
+            .straightUp2,
+            .straightRight2,
+            .straightDown2
+        ])
+        let core = GameCore.makeTestInstance(deck: deck, current: GridPoint(x: 2, y: 2))
+
+        // (3,3) のマスは通常カード（キング右上）と複数候補カード双方で到達可能
+        let destination = GridPoint(x: 3, y: 3)
+
+        guard let resolved = core.resolvedMoveForBoardTap(at: destination) else {
+            XCTFail("盤面タップ候補の算出に失敗しました")
+            return
+        }
+
+        // 優先順位ロジックにより、通常カード（キング右上）が選択されることを検証
+        XCTAssertEqual(resolved.stackIndex, 1, "通常カードのスタックが優先されていません")
+        XCTAssertEqual(resolved.card.move, .kingUpRight, "通常カードが選択されていません")
+        XCTAssertEqual(resolved.moveVector, MoveVector(dx: 1, dy: 1), "通常カードのベクトルが設定されていません")
+
+#if canImport(SpriteKit)
+        // SpriteKit 利用環境では handleTap(at:) 経由でも同じ候補が選択されることを確認する
+        core.handleTap(at: destination)
+        guard let request = core.boardTapPlayRequest else {
+            XCTFail("BoardTapPlayRequest が生成されていません")
+            return
+        }
+        XCTAssertEqual(request.resolvedMove, resolved, "handleTap(at:) の結果が優先順位と一致していません")
+#endif
+    }
+
     /// reset() が初期状態に戻すかを確認
     func testResetReturnsToInitialState() {
         // 上と同じデッキ構成で GameCore を生成し、ペナルティ適用後の状態から開始


### PR DESCRIPTION
## Summary
- update GameCore to prioritize single-vector cards when resolving board tap destinations and expose the shared helper
- cover the priority logic with a regression test that recreates overlapping normal and multi-vector moves

## Testing
- swift test --filter GameCoreTests

------
https://chatgpt.com/codex/tasks/task_e_68dca40dcfbc832cb303c6d40bec3bcc