### PR TITLE
Add multi-direction move card accessibility updates

### DIFF
--- a/MonoKnightAppTests/GameHandSectionViewAccessibilityTests.swift
+++ b/MonoKnightAppTests/GameHandSectionViewAccessibilityTests.swift
@@ -1,0 +1,128 @@
+#if canImport(UIKit)
+import XCTest
+import SwiftUI
+import Game
+@testable import MonoKnightApp
+
+/// GameHandSectionView のアクセシビリティ表示を検証するテスト
+/// - Note: 実際の SwiftUI ビューをホストして VoiceOver 用テキストを取得する
+@MainActor
+final class GameHandSectionViewAccessibilityTests: XCTestCase {
+
+    /// 複数候補カードの手札ヒントに方向選択の案内が含まれることを確認する
+    func testHandSlotHintAnnouncesMultipleDirectionChoice() {
+        let core = GameCore(mode: .standard)
+        guard let stack = core.handStacks.first, let topCard = stack.topCard else {
+            XCTFail("初期手札の取得に失敗しました")
+            return
+        }
+
+        let overrideVectors = [
+            MoveVector(dx: 1, dy: 0),
+            MoveVector(dx: -1, dy: 0)
+        ]
+        MoveCard.setTestMovementVectors(overrideVectors, for: topCard.move)
+        defer { MoveCard.setTestMovementVectors(nil, for: topCard.move) }
+
+        let interfaces = GameModuleInterfaces { _ in core }
+        let viewModel = GameViewModel(
+            mode: .standard,
+            gameInterfaces: interfaces,
+            gameCenterService: NoopGameCenterService(),
+            adsService: NoopAdsService(),
+            onRequestReturnToTitle: nil
+        )
+
+        // テスト中は不要なハプティクスやアニメーション効果を抑制しておく
+        viewModel.boardBridge.updateHapticsSetting(isEnabled: false)
+
+        // 先に availableMoves を取得し、期待するハイライト座標を把握する
+        let candidateMoves = core.availableMoves().filter { candidate in
+            candidate.stackID == stack.id && candidate.card.id == topCard.id
+        }
+        XCTAssertEqual(candidateMoves.count, overrideVectors.count, "複数候補カードの availableMoves 数が想定と異なります")
+
+        guard let stackIndex = core.handStacks.firstIndex(where: { $0.id == stack.id }) else {
+            XCTFail("対象スタックの添字を取得できませんでした")
+            return
+        }
+
+        viewModel.handleHandSlotTap(at: stackIndex)
+
+        let expectedHighlights = Set(candidateMoves.map(\.destination))
+        XCTAssertEqual(viewModel.boardBridge.forcedSelectionHighlightPoints, expectedHighlights, "ハイライトされた目的地集合が一致しません")
+
+        // SwiftUI ビューをホストしてアクセシビリティ文言を取得する
+        let host = GameHandSectionHost(viewModel: viewModel, boardBridge: viewModel.boardBridge)
+        let controller = UIHostingController(rootView: host)
+        controller.loadViewIfNeeded()
+        controller.view.frame = CGRect(x: 0, y: 0, width: 360, height: 260)
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+
+        guard let slotView = controller.view.findSubview(withAccessibilityIdentifier: "hand_slot_0") else {
+            XCTFail("手札ビューを取得できませんでした")
+            return
+        }
+
+        let hint = slotView.accessibilityHint ?? ""
+        XCTAssertTrue(hint.contains("盤面で移動方向を決めてください"), "複数候補時の方向選択案内が欠落しています: \(hint)")
+        XCTAssertTrue(hint.contains("候補は 2 方向"), "候補数の読み上げが欠落しています: \(hint)")
+    }
+}
+
+// MARK: - テスト用ホストビュー
+private struct GameHandSectionHost: View {
+    @ObservedObject var viewModel: GameViewModel
+    @ObservedObject var boardBridge: GameBoardBridgeViewModel
+    let theme = AppTheme()
+    @Namespace private var namespace
+
+    var body: some View {
+        GameHandSectionView(
+            theme: theme,
+            viewModel: viewModel,
+            boardBridge: boardBridge,
+            cardAnimationNamespace: namespace,
+            handSlotCount: 5,
+            bottomInset: 0,
+            bottomPadding: GameViewLayoutMetrics.handSectionBasePadding
+        )
+        .environment(\.horizontalSizeClass, .compact)
+    }
+}
+
+// MARK: - テスト用ユーティリティ
+@MainActor
+private final class NoopGameCenterService: GameCenterServiceProtocol {
+    var isAuthenticated: Bool = true
+    func authenticateLocalPlayer(completion: ((Bool) -> Void)?) { completion?(true) }
+    func submitScore(_ score: Int, for modeIdentifier: GameMode.Identifier) {}
+    func showLeaderboard(for modeIdentifier: GameMode.Identifier) {}
+}
+
+@MainActor
+private final class NoopAdsService: AdsServiceProtocol {
+    func showInterstitial() {}
+    func resetPlayFlag() {}
+    func disableAds() {}
+    func requestTrackingAuthorization() async {}
+    func requestConsentIfNeeded() async {}
+    func refreshConsentStatus() async {}
+}
+
+private extension UIView {
+    /// 指定したアクセシビリティ識別子を持つサブビューを深さ優先で探索する
+    func findSubview(withAccessibilityIdentifier identifier: String) -> UIView? {
+        if accessibilityIdentifier == identifier { return self }
+        for subview in subviews {
+            if let match = subview.findSubview(withAccessibilityIdentifier: identifier) {
+                return match
+            }
+        }
+        return nil
+    }
+}
+#endif

--- a/MonoKnightAppTests/MoveCardIllustrationViewAccessibilityTests.swift
+++ b/MonoKnightAppTests/MoveCardIllustrationViewAccessibilityTests.swift
@@ -1,0 +1,54 @@
+#if canImport(UIKit)
+import XCTest
+import SwiftUI
+import Game
+@testable import MonoKnightApp
+
+/// MoveCardIllustrationView のアクセシビリティ挙動を検証するテスト
+/// - Note: VoiceOver の読み上げ内容が複数候補カードでも自然な文面になるか確認する
+@MainActor
+final class MoveCardIllustrationViewAccessibilityTests: XCTestCase {
+
+    /// 複数候補カードでは盤面で方向を選ぶ旨が案内されることを確認する
+    func testHandModeAccessibilityHintMentionsDirectionChoiceWhenMultipleCandidatesExist() {
+        let overrideVectors = [
+            MoveVector(dx: 1, dy: 0),
+            MoveVector(dx: -1, dy: 0),
+            MoveVector(dx: 0, dy: 1)
+        ]
+        MoveCard.setTestMovementVectors(overrideVectors, for: .kingRight)
+        defer { MoveCard.setTestMovementVectors(nil, for: .kingRight) }
+
+        let view = MoveCardIllustrationView(card: .kingRight, mode: .hand)
+        let controller = UIHostingController(rootView: view)
+        controller.loadViewIfNeeded()
+        controller.view.frame = CGRect(x: 0, y: 0, width: 120, height: 180)
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+
+        let hint = controller.view.accessibilityHint ?? ""
+        XCTAssertTrue(hint.contains("盤面で移動方向を決めてください"), "複数候補時に方向選択を促す文言が含まれていません")
+        XCTAssertTrue(hint.contains("候補は 3 方向"), "候補数の案内が含まれていません: \(hint)")
+    }
+
+    /// 複数候補カードではラベル末尾に補足が追加されることを確認する
+    func testHandModeAccessibilityLabelAddsMultipleDirectionSuffix() {
+        let overrideVectors = [
+            MoveVector(dx: 2, dy: 0),
+            MoveVector(dx: -2, dy: 0)
+        ]
+        MoveCard.setTestMovementVectors(overrideVectors, for: .straightRight2)
+        defer { MoveCard.setTestMovementVectors(nil, for: .straightRight2) }
+
+        let view = MoveCardIllustrationView(card: .straightRight2, mode: .hand)
+        let controller = UIHostingController(rootView: view)
+        controller.loadViewIfNeeded()
+        controller.view.frame = CGRect(x: 0, y: 0, width: 120, height: 180)
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+
+        let label = controller.view.accessibilityLabel ?? ""
+        XCTAssertTrue(label.contains("複数方向の候補あり"), "複数候補を示す補足がラベルに含まれていません: \(label)")
+    }
+}
+#endif

--- a/UI/GameHandSectionView.swift
+++ b/UI/GameHandSectionView.swift
@@ -216,18 +216,39 @@ private extension GameHandSectionView {
 
     /// VoiceOver のヒント文を生成する
     private func accessibilityHint(for stack: HandStack, isUsable: Bool, isDiscardMode: Bool) -> String {
+        // MARK: - 候補数と残枚数の算出
+        let candidateCount = stack.representativeVectors?.count ?? 0
         if isDiscardMode {
             return "ダブルタップでこの種類のカードをすべて捨て札にし、新しいカードを補充します。"
         }
 
         if isUsable {
-            if stack.count > 1 {
-                return "ダブルタップで先頭カードを使用します。スタックの残り \(stack.count - 1) 枚は同じ方向で待機します。"
+            // 候補が複数ある場合は盤面で方向を選択する必要があることを強調する
+            if candidateCount > 1 {
+                let remainingDescription: String
+                if stack.count > 1 {
+                    remainingDescription = "残り \(stack.count - 1) 枚も同じ候補を共有します。"
+                } else {
+                    remainingDescription = "スタックは 1 枚だけです。"
+                }
+                let baseMessage = "ダブルタップでカードを選択し、盤面で移動方向を決めてください。候補は \(candidateCount) 方向です。"
+                return baseMessage + remainingDescription
             } else {
-                return "ダブルタップでこの方向に移動します。スタックは 1 枚だけです。"
+                if stack.count > 1 {
+                    return "ダブルタップで先頭カードを使用します。スタックの残り \(stack.count - 1) 枚は同じ方向で待機します。"
+                } else {
+                    return "ダブルタップでこの方向に移動します。スタックは 1 枚だけです。"
+                }
             }
         } else {
-            return "盤外のため使用できません。スタックの \(stack.count) 枚はそのまま保持されます。"
+            // 使用不可時も候補数に応じて状況を具体的に伝える
+            if candidateCount > 1 {
+                return "盤外のため使用できません。候補は \(candidateCount) 方向ありますが、いずれも盤面外です。スタックの \(stack.count) 枚はそのまま保持されます。"
+            } else if candidateCount == 1 {
+                return "盤外のため使用できません。スタックの \(stack.count) 枚はそのまま保持されます。"
+            } else {
+                return "盤外のため使用できません。移動候補が未設定のカードです。スタックの \(stack.count) 枚はそのまま保持されます。"
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- render all movement vectors in MoveCardIllustrationView and adjust VoiceOver strings based on candidate count
- update hand slot accessibility hints to describe multi-direction selection flow on the board
- add view-hosted accessibility tests that verify multi-direction hints and highlight coverage

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dcacf03cd4832ca01dc30d806b48b5