### PR TITLE
Update board guide highlight colors

### DIFF
--- a/Game/GameScenePalette.swift
+++ b/Game/GameScenePalette.swift
@@ -54,8 +54,8 @@ public extension GameScenePalette {
         boardTileVisited: SKColor(white: 0.75, alpha: 1.0),
         boardTileUnvisited: SKColor(white: 0.98, alpha: 1.0),
         boardKnight: SKColor(white: 0.1, alpha: 1.0),
-        // NOTE: SpriteKit 側も SwiftUI と同様に濃いグレーを採用し、ダークテーマへの切替前でも過度なコントラストにならないよう配慮する
-        boardGuideHighlight: SKColor(white: 0.2, alpha: 0.45)
+        // NOTE: SwiftUI のライトテーマと同じ彩度を抑えたオレンジを採用し、テーマ適用前でも一貫した強調色を維持する
+        boardGuideHighlight: SKColor(red: 0.94, green: 0.41, blue: 0.08, alpha: 0.85)
     )
 
     /// ダークテーマ適用前後でのデバッグ確認用のフォールバック
@@ -65,7 +65,8 @@ public extension GameScenePalette {
         boardTileVisited: SKColor(white: 0.35, alpha: 1.0),
         boardTileUnvisited: SKColor(white: 0.12, alpha: 1.0),
         boardKnight: SKColor(white: 0.95, alpha: 1.0),
-        boardGuideHighlight: SKColor(white: 0.85, alpha: 0.55)
+        // NOTE: ダークテーマに合わせて明度を上げたオレンジを用い、背景の暗さに負けない発光感を演出する
+        boardGuideHighlight: SKColor(red: 1.0, green: 0.74, blue: 0.38, alpha: 0.9)
     )
 }
 #endif

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -432,17 +432,18 @@ struct AppTheme: DynamicProperty {
     }
 
     /// ガイドモードで候補マスを照らす際の基準色
-    /// - Note: グリッド線と同系統のグレーを採用し、盤面全体のモノトーン基調を崩さない
+    /// - Note: HIG のコントラスト要件を満たしつつ盤面のモノトーンを邪魔しないよう、彩度を抑えたオレンジをテーマ別に用意する
     var boardGuideHighlight: Color {
         switch resolvedColorScheme {
         case .dark:
-            // ダークテーマでは boardGridLine（白 75%）を基準にしつつ、視認性を確保するため透過率をやや高める
-            return boardGridLine.opacity(0.5)
+            // ダークテーマでは暗所で浮きすぎないよう、明度を上げたオレンジをベースに透過率を高めて輪郭をくっきりさせる
+            let guideStrokeBase = Color(red: 1.0, green: 0.74, blue: 0.38)
+            return guideStrokeBase.opacity(0.9)
         default:
-            // ライトテーマでは純粋な黒だと輪郭が強すぎるため、少しだけ明度を持たせた濃いグレーを採用する
-            // NOTE: `Color(white: 0.2)` で RGB(51,51,51) 相当の色味を用意し、透過度で軽やかさを調整する
-            let guideStrokeBase = Color(white: 0.2)
-            return guideStrokeBase.opacity(0.45)
+            // ライトテーマでは背景が明るいので、彩度を抑えた濃いめのオレンジを採用し、透過で軽やかさを残す
+            // NOTE: RGB(240, 104, 20) 相当の色味を透過 0.85 で用いることで、盤面に馴染みつつ視認性を確保する
+            let guideStrokeBase = Color(red: 0.94, green: 0.41, blue: 0.08)
+            return guideStrokeBase.opacity(0.85)
         }
     }
 


### PR DESCRIPTION
## Summary
- update the board guide highlight color in AppTheme to new orange accents for light and dark schemes
- align the SpriteKit fallback palette highlight colors with the updated theme tones

## Testing
- not run (manual verification required for guide/forced highlight rendering)


------
https://chatgpt.com/codex/tasks/task_e_68dcacf82a28832c820acfb21155f734