### PR TITLE
Add campaign chapter 3-1 and direction choice deck

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -438,6 +438,40 @@ public struct CampaignLibrary {
             stages: [stage21]
         )
 
-        return [chapter1, chapter2]
+        // MARK: - 3 章のステージ群
+        // スタンダード 5×5 をベースに、複数方向候補カードの扱いを学ぶ章
+        let standardPenalties = GameMode.standard.penalties
+
+        let stage31 = CampaignStage(
+            id: CampaignStageID(chapter: 3, index: 1),
+            title: "選択訓練",
+            summary: "上下・左右の選択式キングカードを活用して盤面全体を踏破しましょう。",
+            regulation: GameMode.Regulation(
+                boardSize: 5,
+                handSize: 5,
+                nextPreviewCount: 3,
+                allowsStacking: true,
+                deckPreset: .directionChoice,
+                spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 5)),
+                penalties: GameMode.PenaltySettings(
+                    deadlockPenaltyCost: standardPenalties.deadlockPenaltyCost,
+                    manualRedrawPenaltyCost: standardPenalties.manualRedrawPenaltyCost,
+                    manualDiscardPenaltyCost: standardPenalties.manualDiscardPenaltyCost,
+                    revisitPenaltyCost: standardPenalties.revisitPenaltyCost
+                )
+            ),
+            secondaryObjective: .finishWithoutPenalty,
+            scoreTarget: 600,
+            unlockRequirement: .stageClear(stage21.id)
+        )
+
+        let chapter3 = CampaignChapter(
+            id: 3,
+            title: "多方向訓練",
+            summary: "複数候補カードを使い分ける章。",
+            stages: [stage31]
+        )
+
+        return [chapter1, chapter2, chapter3]
     }
 }

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -11,6 +11,8 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
     case classicalChallenge
     /// 王将型カードのみの構成（序盤向け超短距離デッキ）
     case kingOnly
+    /// キング型カードに上下左右の選択肢を加えた構成
+    case directionChoice
 
     /// `Identifiable` 準拠用の ID
     public var id: String { rawValue }
@@ -24,6 +26,8 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
             return "クラシカル構成"
         case .kingOnly:
             return "王将構成"
+        case .directionChoice:
+            return "選択式キング構成"
         }
     }
 
@@ -41,6 +45,8 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
             return .classicalChallenge
         case .kingOnly:
             return .kingOnly
+        case .directionChoice:
+            return .directionChoice
         }
     }
 }

--- a/Game/MoveCard.swift
+++ b/Game/MoveCard.swift
@@ -1,12 +1,13 @@
 import Foundation
 
 /// 駒を移動させるカードの種類を定義する列挙型
-/// - Note: 周囲 1 マスのキング型 8 種、ナイト型 8 種、距離 2 の直線/斜め 8 種の計 24 種をサポート
+/// - Note: 周囲 1 マスのキング型 8 種、ナイト型 8 種、距離 2 の直線/斜め 8 種の計 24 種に加え、キャンペーン専用の複数方向カードをサポート
 /// - Note: SwiftUI モジュールからも扱うため `public` とし、全ケース配列も公開する
 public enum MoveCard: CaseIterable {
-    // MARK: - 全ケース一覧
-    /// `CaseIterable` の自動生成は internal となるため、外部モジュールからも全種類を参照できるよう明示的に公開配列を定義する
-    public static let allCases: [MoveCard] = [
+    // MARK: - 定義済みセット
+    /// 標準デッキで採用している 24 種類のカード集合
+    /// - Important: 新しいカードを追加した際もスタンダード構成へ混入しないよう、この配列を基準に管理する
+    public static let standardSet: [MoveCard] = [
         .kingUp,
         .kingUpRight,
         .kingRight,
@@ -33,6 +34,14 @@ public enum MoveCard: CaseIterable {
         .diagonalUpLeft2
     ]
 
+    // MARK: - 全ケース一覧
+    /// `CaseIterable` の自動生成は internal となるため、外部モジュールからも全種類を参照できるよう明示的に公開配列を定義する
+    /// - Note: スタンダードセットに複数方向カードを加えた順序で公開する
+    public static let allCases: [MoveCard] = standardSet + [
+        .kingUpOrDown,
+        .kingLeftOrRight
+    ]
+
     // MARK: - ケース定義
     /// キング型: 上に 1
     case kingUp
@@ -50,6 +59,10 @@ public enum MoveCard: CaseIterable {
     case kingLeft
     /// キング型: 左上に 1
     case kingUpLeft
+    /// キング型: 上下いずれか 1 マスの選択移動
+    case kingUpOrDown
+    /// キング型: 左右いずれか 1 マスの選択移動
+    case kingLeftOrRight
 
     /// ナイト型: 上に 2、右に 1
     case knightUp2Right1
@@ -126,6 +139,18 @@ public enum MoveCard: CaseIterable {
             return [MoveVector(dx: -1, dy: 0)]
         case .kingUpLeft:
             return [MoveVector(dx: -1, dy: 1)]
+        case .kingUpOrDown:
+            // 上下方向のいずれかを後から選択するため 2 候補を返す
+            return [
+                MoveVector(dx: 0, dy: 1),
+                MoveVector(dx: 0, dy: -1)
+            ]
+        case .kingLeftOrRight:
+            // 左右方向のいずれかを後から選択するため 2 候補を返す
+            return [
+                MoveVector(dx: 1, dy: 0),
+                MoveVector(dx: -1, dy: 0)
+            ]
         case .knightUp2Right1:
             return [MoveVector(dx: 1, dy: 2)]
         case .knightUp2Left1:
@@ -199,6 +224,12 @@ public enum MoveCard: CaseIterable {
         case .kingUpLeft:
             // キング型: 左上方向へ 1 マス移動
             return "左上1"
+        case .kingUpOrDown:
+            // キング型: 上下のどちらか 1 マスを選択する特別カード
+            return "上下1 (選択)"
+        case .kingLeftOrRight:
+            // キング型: 左右のどちらか 1 マスを選択する特別カード
+            return "左右1 (選択)"
         case .knightUp2Right1: return "上2右1"
         case .knightUp2Left1: return "上2左1"
         case .knightUp1Right2: return "上1右2"
@@ -230,7 +261,9 @@ public enum MoveCard: CaseIterable {
              .kingDown,
              .kingDownLeft,
              .kingLeft,
-             .kingUpLeft:
+             .kingUpLeft,
+             .kingUpOrDown,
+             .kingLeftOrRight:
             return true
         default:
             return false

--- a/Tests/GameTests/BoardMovementTests.swift
+++ b/Tests/GameTests/BoardMovementTests.swift
@@ -36,6 +36,21 @@ final class BoardMovementTests: XCTestCase {
         XCTAssertEqual(knightCard.primaryVector, knightVector, "桂馬カードの代表ベクトルが想定と異なります")
     }
 
+    /// 複数方向候補カードが 2 方向のベクトルを保持し、primaryVector が先頭を指すかを確認する
+    func testMultiDirectionCardProvidesTwoCandidates() {
+        let verticalChoice = MoveCard.kingUpOrDown
+        XCTAssertEqual(verticalChoice.movementVectors.count, 2, "上下選択カードの候補数が 2 ではありません")
+        XCTAssertEqual(verticalChoice.movementVectors[0], MoveVector(dx: 0, dy: 1), "上下選択カードの先頭ベクトルが上方向になっていません")
+        XCTAssertEqual(verticalChoice.movementVectors[1], MoveVector(dx: 0, dy: -1), "上下選択カードの 2 番目ベクトルが下方向になっていません")
+        XCTAssertEqual(verticalChoice.primaryVector, MoveVector(dx: 0, dy: 1), "上下選択カードの primaryVector が想定外です")
+
+        let horizontalChoice = MoveCard.kingLeftOrRight
+        XCTAssertEqual(horizontalChoice.movementVectors.count, 2, "左右選択カードの候補数が 2 ではありません")
+        XCTAssertEqual(horizontalChoice.movementVectors[0], MoveVector(dx: 1, dy: 0), "左右選択カードの先頭ベクトルが右方向になっていません")
+        XCTAssertEqual(horizontalChoice.movementVectors[1], MoveVector(dx: -1, dy: 0), "左右選択カードの 2 番目ベクトルが左方向になっていません")
+        XCTAssertEqual(horizontalChoice.primaryVector, MoveVector(dx: 1, dy: 0), "左右選択カードの primaryVector が想定外です")
+    }
+
     /// 複数候補のうち一部のみ盤内となるケースで canUse が true を返すか確認する
     func testCanUseWithMultipleMovementCandidates() {
         // 標準 5x5 盤を前提に左下端からの移動をテストする

--- a/Tests/GameTests/CampaignLibraryTests.swift
+++ b/Tests/GameTests/CampaignLibraryTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import Game
+
+/// キャンペーン関連の定義を確認するテスト
+final class CampaignLibraryTests: XCTestCase {
+    /// directionChoice プリセットが新カードを含む設定を返すことを確認する
+    func testDirectionChoicePresetConfiguration() {
+        let preset = GameDeckPreset.directionChoice
+        let config = preset.configuration
+
+        // 表示名と要約テキストが期待通りか確認
+        XCTAssertEqual(preset.displayName, "選択式キング構成", "表示名が想定外です")
+        XCTAssertEqual(preset.summaryText, "選択式キングカード入り", "サマリーテキストが想定外です")
+
+        // 設定に新カードが含まれているか検証
+        XCTAssertTrue(config.allowedMoves.contains(.kingUpOrDown), "上下選択カードがプリセット設定に含まれていません")
+        XCTAssertTrue(config.allowedMoves.contains(.kingLeftOrRight), "左右選択カードがプリセット設定に含まれていません")
+    }
+
+    /// 3-1 ステージが directionChoice デッキを使用し、仕様通りの条件を持つことを確認する
+    func testCampaignStage31Definition() {
+        let library = CampaignLibrary.shared
+        let stageID = CampaignStageID(chapter: 3, index: 1)
+        guard let stage = library.stage(with: stageID) else {
+            XCTFail("3-1 ステージが CampaignLibrary に見つかりません")
+            return
+        }
+
+        XCTAssertEqual(stage.title, "選択訓練", "ステージ名が仕様と一致していません")
+        XCTAssertEqual(stage.regulation.boardSize, 5, "盤面サイズが 5×5 ではありません")
+        XCTAssertEqual(stage.regulation.deckPreset, .directionChoice, "使用デッキが directionChoice ではありません")
+        XCTAssertEqual(stage.secondaryObjective, .finishWithoutPenalty, "二つ目のスター条件が想定外です")
+        XCTAssertEqual(stage.scoreTarget, 600, "スコアターゲットが想定外です")
+
+        // アンロック条件が 2-1 のクリアであることを確認
+        let expectedUnlock = CampaignStageUnlockRequirement.stageClear(CampaignStageID(chapter: 2, index: 1))
+        XCTAssertEqual(stage.unlockRequirement, expectedUnlock, "アンロック条件が 2-1 クリアになっていません")
+    }
+}


### PR DESCRIPTION
## Summary
- add multi-direction MoveCard options for campaign and keep the standard set unchanged
- introduce the directionChoice deck preset and define campaign chapter 3-1 that uses it
- expand unit tests to cover the new cards, deck preset, and campaign definitions

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dcbf70247c832c9c59e82567e38d62