### PR TITLE
Add choice card decks and campaign updates

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -442,16 +442,17 @@ public struct CampaignLibrary {
         // スタンダード 5×5 をベースに、複数方向候補カードの扱いを学ぶ章
         let standardPenalties = GameMode.standard.penalties
 
+        // 3-1 は上下左右の選択キングに慣れる導入ステージ。まずはペナルティを抑えて丁寧に動いてもらう。
         let stage31 = CampaignStage(
             id: CampaignStageID(chapter: 3, index: 1),
-            title: "選択訓練",
-            summary: "上下・左右の選択式キングカードを活用して盤面全体を踏破しましょう。",
+            title: "縦横選択訓練",
+            summary: "上下左右を選べるキングカードのみで、選択操作の基礎を体感しましょう。",
             regulation: GameMode.Regulation(
                 boardSize: 5,
                 handSize: 5,
                 nextPreviewCount: 3,
                 allowsStacking: true,
-                deckPreset: .directionChoice,
+                deckPreset: .kingOrthogonalChoiceOnly,
                 spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 5)),
                 penalties: GameMode.PenaltySettings(
                     deadlockPenaltyCost: standardPenalties.deadlockPenaltyCost,
@@ -460,16 +461,93 @@ public struct CampaignLibrary {
                     revisitPenaltyCost: standardPenalties.revisitPenaltyCost
                 )
             ),
+            // MARK: 2 個目のスター条件: ペナルティを完全に回避して選択操作を丁寧に行う
             secondaryObjective: .finishWithoutPenalty,
             scoreTarget: 600,
             unlockRequirement: .stageClear(stage21.id)
+        )
+
+        // 3-2 は斜めの選択キングだけで構成し、盤面を縦横斜めの三方向で把握する練習へ発展させる。
+        let stage32 = CampaignStage(
+            id: CampaignStageID(chapter: 3, index: 2),
+            title: "斜め選択応用",
+            summary: "斜め 4 方向の選択キングで角を制圧し、柔軟なルート取りを学びましょう。",
+            regulation: GameMode.Regulation(
+                boardSize: 5,
+                handSize: 5,
+                nextPreviewCount: 3,
+                allowsStacking: true,
+                deckPreset: .kingDiagonalChoiceOnly,
+                spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 5)),
+                penalties: GameMode.PenaltySettings(
+                    deadlockPenaltyCost: standardPenalties.deadlockPenaltyCost,
+                    manualRedrawPenaltyCost: standardPenalties.manualRedrawPenaltyCost,
+                    manualDiscardPenaltyCost: standardPenalties.manualDiscardPenaltyCost,
+                    revisitPenaltyCost: standardPenalties.revisitPenaltyCost
+                )
+            ),
+            // MARK: 2 個目のスター条件: 移動手数 32 以内を要求し、先読みと分岐判断の精度を高める
+            secondaryObjective: .finishWithinMoves(maxMoves: 32),
+            scoreTarget: 580,
+            unlockRequirement: .stageClear(stage31.id)
+        )
+
+        // 3-3 は桂馬の選択カードのみ。斜めだけでは届かないマスを跳躍で埋める判断を身につける段階。
+        let stage33 = CampaignStage(
+            id: CampaignStageID(chapter: 3, index: 3),
+            title: "桂馬選択攻略",
+            summary: "桂馬の 4 方向選択カードでジャンプし、遠距離マスを効率良く踏破しましょう。",
+            regulation: GameMode.Regulation(
+                boardSize: 5,
+                handSize: 5,
+                nextPreviewCount: 3,
+                allowsStacking: true,
+                deckPreset: .knightChoiceOnly,
+                spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 5)),
+                penalties: GameMode.PenaltySettings(
+                    deadlockPenaltyCost: standardPenalties.deadlockPenaltyCost,
+                    manualRedrawPenaltyCost: standardPenalties.manualRedrawPenaltyCost,
+                    manualDiscardPenaltyCost: standardPenalties.manualDiscardPenaltyCost,
+                    revisitPenaltyCost: standardPenalties.revisitPenaltyCost
+                )
+            ),
+            // MARK: 2 個目のスター条件: 桂馬特有のルートを活かし 30 手以内の踏破を目指す
+            secondaryObjective: .finishWithinMoves(maxMoves: 30),
+            scoreTarget: 560,
+            unlockRequirement: .stageClear(stage32.id)
+        )
+
+        // 3-4 は全種類の選択カードを混在させた最終チェック。すべての操作感を統合して素早く判断する。
+        let stage34 = CampaignStage(
+            id: CampaignStageID(chapter: 3, index: 4),
+            title: "総合選択演習",
+            summary: "キングと桂馬の選択カードを総動員し、全方向の応用力を試しましょう。",
+            regulation: GameMode.Regulation(
+                boardSize: 5,
+                handSize: 5,
+                nextPreviewCount: 3,
+                allowsStacking: true,
+                deckPreset: .allChoiceMixed,
+                spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 5)),
+                penalties: GameMode.PenaltySettings(
+                    deadlockPenaltyCost: standardPenalties.deadlockPenaltyCost,
+                    manualRedrawPenaltyCost: standardPenalties.manualRedrawPenaltyCost,
+                    manualDiscardPenaltyCost: standardPenalties.manualDiscardPenaltyCost,
+                    revisitPenaltyCost: standardPenalties.revisitPenaltyCost
+                )
+            ),
+            // MARK: 2 個目のスター条件: 28 手以内で踏破し、多方向カードを自在に使い分けることを促す
+            secondaryObjective: .finishWithinMoves(maxMoves: 28),
+            scoreTarget: 540,
+            scoreTargetComparison: .lessThan,
+            unlockRequirement: .stageClear(stage33.id)
         )
 
         let chapter3 = CampaignChapter(
             id: 3,
             title: "多方向訓練",
             summary: "複数候補カードを使い分ける章。",
-            stages: [stage31]
+            stages: [stage31, stage32, stage33, stage34]
         )
 
         return [chapter1, chapter2, chapter3]

--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -148,6 +148,87 @@ struct Deck {
                 deckSummaryText: "選択式キングカード入り"
             )
         }()
+
+        /// キング型の上下左右選択カードのみで構成した訓練用デッキ
+        static let kingOrthogonalChoiceOnly: Configuration = {
+            let moves: [MoveCard] = [.kingUpOrDown, .kingLeftOrRight]
+            let weights = Dictionary(uniqueKeysWithValues: moves.map { ($0, 1) })
+            return Configuration(
+                allowedMoves: moves,
+                baseWeights: weights,
+                shouldApplyProbabilityReduction: false,
+                normalWeightMultiplier: 1,
+                reducedWeightMultiplier: 1,
+                reductionDuration: 0,
+                deckSummaryText: "上下左右の選択キング限定"
+            )
+        }()
+
+        /// 斜め方向のキング選択カード 4 種のみを収録した上級者向けデッキ
+        static let kingDiagonalChoiceOnly: Configuration = {
+            let moves: [MoveCard] = [
+                .kingUpwardDiagonalChoice,
+                .kingRightDiagonalChoice,
+                .kingDownwardDiagonalChoice,
+                .kingLeftDiagonalChoice
+            ]
+            let weights = Dictionary(uniqueKeysWithValues: moves.map { ($0, 1) })
+            return Configuration(
+                allowedMoves: moves,
+                baseWeights: weights,
+                shouldApplyProbabilityReduction: false,
+                normalWeightMultiplier: 1,
+                reducedWeightMultiplier: 1,
+                reductionDuration: 0,
+                deckSummaryText: "斜め選択キング限定"
+            )
+        }()
+
+        /// 桂馬の向きごとに選択肢を持つカードだけを集めた練習デッキ
+        static let knightChoiceOnly: Configuration = {
+            let moves: [MoveCard] = [
+                .knightUpwardChoice,
+                .knightRightwardChoice,
+                .knightDownwardChoice,
+                .knightLeftwardChoice
+            ]
+            let weights = Dictionary(uniqueKeysWithValues: moves.map { ($0, 1) })
+            return Configuration(
+                allowedMoves: moves,
+                baseWeights: weights,
+                shouldApplyProbabilityReduction: false,
+                normalWeightMultiplier: 1,
+                reducedWeightMultiplier: 1,
+                reductionDuration: 0,
+                deckSummaryText: "桂馬選択カード限定"
+            )
+        }()
+
+        /// すべての選択式カードを均等配分で混在させた総合練習デッキ
+        static let allChoiceMixed: Configuration = {
+            let moves: [MoveCard] = [
+                .kingUpOrDown,
+                .kingLeftOrRight,
+                .kingUpwardDiagonalChoice,
+                .kingRightDiagonalChoice,
+                .kingDownwardDiagonalChoice,
+                .kingLeftDiagonalChoice,
+                .knightUpwardChoice,
+                .knightRightwardChoice,
+                .knightDownwardChoice,
+                .knightLeftwardChoice
+            ]
+            let weights = Dictionary(uniqueKeysWithValues: moves.map { ($0, 1) })
+            return Configuration(
+                allowedMoves: moves,
+                baseWeights: weights,
+                shouldApplyProbabilityReduction: false,
+                normalWeightMultiplier: 1,
+                reducedWeightMultiplier: 1,
+                reductionDuration: 0,
+                deckSummaryText: "選択カード総合ミックス"
+            )
+        }()
     }
 
     // MARK: - プロパティ

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -13,6 +13,14 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
     case kingOnly
     /// キング型カードに上下左右の選択肢を加えた構成
     case directionChoice
+    /// 上下左右の選択キングカードのみで構成した訓練デッキ
+    case kingOrthogonalChoiceOnly
+    /// 斜め方向の選択キングカードのみで構成した訓練デッキ
+    case kingDiagonalChoiceOnly
+    /// 桂馬の選択カードのみで構成した訓練デッキ
+    case knightChoiceOnly
+    /// すべての選択カードを混合した総合デッキ
+    case allChoiceMixed
 
     /// `Identifiable` 準拠用の ID
     public var id: String { rawValue }
@@ -28,6 +36,14 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
             return "王将構成"
         case .directionChoice:
             return "選択式キング構成"
+        case .kingOrthogonalChoiceOnly:
+            return "上下左右選択キング構成"
+        case .kingDiagonalChoiceOnly:
+            return "斜め選択キング構成"
+        case .knightChoiceOnly:
+            return "桂馬選択構成"
+        case .allChoiceMixed:
+            return "選択カード総合構成"
         }
     }
 
@@ -47,6 +63,14 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
             return .kingOnly
         case .directionChoice:
             return .directionChoice
+        case .kingOrthogonalChoiceOnly:
+            return .kingOrthogonalChoiceOnly
+        case .kingDiagonalChoiceOnly:
+            return .kingDiagonalChoiceOnly
+        case .knightChoiceOnly:
+            return .knightChoiceOnly
+        case .allChoiceMixed:
+            return .allChoiceMixed
         }
     }
 }

--- a/Game/MoveCard.swift
+++ b/Game/MoveCard.swift
@@ -39,7 +39,15 @@ public enum MoveCard: CaseIterable {
     /// - Note: スタンダードセットに複数方向カードを加えた順序で公開する
     public static let allCases: [MoveCard] = standardSet + [
         .kingUpOrDown,
-        .kingLeftOrRight
+        .kingLeftOrRight,
+        .kingUpwardDiagonalChoice,
+        .kingRightDiagonalChoice,
+        .kingDownwardDiagonalChoice,
+        .kingLeftDiagonalChoice,
+        .knightUpwardChoice,
+        .knightRightwardChoice,
+        .knightDownwardChoice,
+        .knightLeftwardChoice
     ]
 
     // MARK: - ケース定義
@@ -63,6 +71,14 @@ public enum MoveCard: CaseIterable {
     case kingUpOrDown
     /// キング型: 左右いずれか 1 マスの選択移動
     case kingLeftOrRight
+    /// キング型: 上方向の斜め 2 方向（右上・左上）から選択するカード
+    case kingUpwardDiagonalChoice
+    /// キング型: 右方向の斜め 2 方向（右上・右下）から選択するカード
+    case kingRightDiagonalChoice
+    /// キング型: 下方向の斜め 2 方向（右下・左下）から選択するカード
+    case kingDownwardDiagonalChoice
+    /// キング型: 左方向の斜め 2 方向（左上・左下）から選択するカード
+    case kingLeftDiagonalChoice
 
     /// ナイト型: 上に 2、右に 1
     case knightUp2Right1
@@ -80,6 +96,14 @@ public enum MoveCard: CaseIterable {
     case knightDown1Right2
     /// ナイト型: 下に 1、左に 2
     case knightDown1Left2
+    /// ナイト型: 上方向 2 種（上2右1/上2左1）から選択するカード
+    case knightUpwardChoice
+    /// ナイト型: 右方向 2 種（上1右2/下1右2）から選択するカード
+    case knightRightwardChoice
+    /// ナイト型: 下方向 2 種（下2右1/下2左1）から選択するカード
+    case knightDownwardChoice
+    /// ナイト型: 左方向 2 種（上1左2/下1左2）から選択するカード
+    case knightLeftwardChoice
 
     /// 直線: 上に 2
     case straightUp2
@@ -151,6 +175,30 @@ public enum MoveCard: CaseIterable {
                 MoveVector(dx: 1, dy: 0),
                 MoveVector(dx: -1, dy: 0)
             ]
+        case .kingUpwardDiagonalChoice:
+            // 上方向の斜め 2 方向（右上・左上）をまとめて扱うカード
+            return [
+                MoveVector(dx: 1, dy: 1),
+                MoveVector(dx: -1, dy: 1)
+            ]
+        case .kingRightDiagonalChoice:
+            // 右方向へ伸びる斜め 2 方向（右上・右下）をまとめて扱うカード
+            return [
+                MoveVector(dx: 1, dy: 1),
+                MoveVector(dx: 1, dy: -1)
+            ]
+        case .kingDownwardDiagonalChoice:
+            // 下方向の斜め 2 方向（右下・左下）をまとめて扱うカード
+            return [
+                MoveVector(dx: 1, dy: -1),
+                MoveVector(dx: -1, dy: -1)
+            ]
+        case .kingLeftDiagonalChoice:
+            // 左方向の斜め 2 方向（左上・左下）をまとめて扱うカード
+            return [
+                MoveVector(dx: -1, dy: 1),
+                MoveVector(dx: -1, dy: -1)
+            ]
         case .knightUp2Right1:
             return [MoveVector(dx: 1, dy: 2)]
         case .knightUp2Left1:
@@ -167,6 +215,30 @@ public enum MoveCard: CaseIterable {
             return [MoveVector(dx: 2, dy: -1)]
         case .knightDown1Left2:
             return [MoveVector(dx: -2, dy: -1)]
+        case .knightUpwardChoice:
+            // 上方向の桂馬 2 種をまとめた特別カード
+            return [
+                MoveVector(dx: 1, dy: 2),
+                MoveVector(dx: -1, dy: 2)
+            ]
+        case .knightRightwardChoice:
+            // 右方向の桂馬 2 種をまとめた特別カード
+            return [
+                MoveVector(dx: 2, dy: 1),
+                MoveVector(dx: 2, dy: -1)
+            ]
+        case .knightDownwardChoice:
+            // 下方向の桂馬 2 種をまとめた特別カード
+            return [
+                MoveVector(dx: 1, dy: -2),
+                MoveVector(dx: -1, dy: -2)
+            ]
+        case .knightLeftwardChoice:
+            // 左方向の桂馬 2 種をまとめた特別カード
+            return [
+                MoveVector(dx: -2, dy: 1),
+                MoveVector(dx: -2, dy: -1)
+            ]
         case .straightUp2:
             return [MoveVector(dx: 0, dy: 2)]
         case .straightDown2:
@@ -230,6 +302,18 @@ public enum MoveCard: CaseIterable {
         case .kingLeftOrRight:
             // キング型: 左右のどちらか 1 マスを選択する特別カード
             return "左右1 (選択)"
+        case .kingUpwardDiagonalChoice:
+            // キング型: 左右の上斜めから好みの方向を選ぶ特別カード
+            return "上斜め1 (選択)"
+        case .kingRightDiagonalChoice:
+            // キング型: 上下の右斜めから好みの方向を選ぶ特別カード
+            return "右斜め1 (選択)"
+        case .kingDownwardDiagonalChoice:
+            // キング型: 左右の下斜めから好みの方向を選ぶ特別カード
+            return "下斜め1 (選択)"
+        case .kingLeftDiagonalChoice:
+            // キング型: 上下の左斜めから好みの方向を選ぶ特別カード
+            return "左斜め1 (選択)"
         case .knightUp2Right1: return "上2右1"
         case .knightUp2Left1: return "上2左1"
         case .knightUp1Right2: return "上1右2"
@@ -238,6 +322,18 @@ public enum MoveCard: CaseIterable {
         case .knightDown2Left1: return "下2左1"
         case .knightDown1Right2: return "下1右2"
         case .knightDown1Left2: return "下1左2"
+        case .knightUpwardChoice:
+            // 桂馬型: 上方向 2 種から好みを選べる特別カード
+            return "上桂 (選択)"
+        case .knightRightwardChoice:
+            // 桂馬型: 右方向 2 種から好みを選べる特別カード
+            return "右桂 (選択)"
+        case .knightDownwardChoice:
+            // 桂馬型: 下方向 2 種から好みを選べる特別カード
+            return "下桂 (選択)"
+        case .knightLeftwardChoice:
+            // 桂馬型: 左方向 2 種から好みを選べる特別カード
+            return "左桂 (選択)"
         case .straightUp2: return "上2"
         case .straightDown2: return "下2"
         case .straightRight2: return "右2"
@@ -263,7 +359,11 @@ public enum MoveCard: CaseIterable {
              .kingLeft,
              .kingUpLeft,
              .kingUpOrDown,
-             .kingLeftOrRight:
+             .kingLeftOrRight,
+             .kingUpwardDiagonalChoice,
+             .kingRightDiagonalChoice,
+             .kingDownwardDiagonalChoice,
+             .kingLeftDiagonalChoice:
             return true
         default:
             return false
@@ -281,7 +381,11 @@ public enum MoveCard: CaseIterable {
              .knightDown2Right1,
              .knightDown2Left1,
              .knightDown1Right2,
-             .knightDown1Left2:
+             .knightDown1Left2,
+             .knightUpwardChoice,
+             .knightRightwardChoice,
+             .knightDownwardChoice,
+             .knightLeftwardChoice:
             return true
         default:
             return false

--- a/Tests/GameTests/CampaignLibraryTests.swift
+++ b/Tests/GameTests/CampaignLibraryTests.swift
@@ -3,37 +3,87 @@ import XCTest
 
 /// キャンペーン関連の定義を確認するテスト
 final class CampaignLibraryTests: XCTestCase {
-    /// directionChoice プリセットが新カードを含む設定を返すことを確認する
-    func testDirectionChoicePresetConfiguration() {
-        let preset = GameDeckPreset.directionChoice
-        let config = preset.configuration
+    /// 選択カード系プリセットが期待通りの構成を返すことを確認する
+    func testChoiceDeckPresetConfigurations() {
+        let presets: [(GameDeckPreset, String, String, Set<MoveCard>)] = [
+            (.directionChoice, "選択式キング構成", "選択式キングカード入り", [.kingUpOrDown, .kingLeftOrRight]),
+            (.kingOrthogonalChoiceOnly, "上下左右選択キング構成", "上下左右の選択キング限定", [.kingUpOrDown, .kingLeftOrRight]),
+            (.kingDiagonalChoiceOnly, "斜め選択キング構成", "斜め選択キング限定", [
+                .kingUpwardDiagonalChoice,
+                .kingRightDiagonalChoice,
+                .kingDownwardDiagonalChoice,
+                .kingLeftDiagonalChoice
+            ]),
+            (.knightChoiceOnly, "桂馬選択構成", "桂馬選択カード限定", [
+                .knightUpwardChoice,
+                .knightRightwardChoice,
+                .knightDownwardChoice,
+                .knightLeftwardChoice
+            ]),
+            (.allChoiceMixed, "選択カード総合構成", "選択カード総合ミックス", [
+                .kingUpOrDown,
+                .kingLeftOrRight,
+                .kingUpwardDiagonalChoice,
+                .kingRightDiagonalChoice,
+                .kingDownwardDiagonalChoice,
+                .kingLeftDiagonalChoice,
+                .knightUpwardChoice,
+                .knightRightwardChoice,
+                .knightDownwardChoice,
+                .knightLeftwardChoice
+            ])
+        ]
 
-        // 表示名と要約テキストが期待通りか確認
-        XCTAssertEqual(preset.displayName, "選択式キング構成", "表示名が想定外です")
-        XCTAssertEqual(preset.summaryText, "選択式キングカード入り", "サマリーテキストが想定外です")
+        for (preset, expectedName, expectedSummary, expectedMoves) in presets {
+            XCTAssertEqual(preset.displayName, expectedName, "\(preset) の表示名が仕様と異なります")
+            XCTAssertEqual(preset.summaryText, expectedSummary, "\(preset) の要約テキストが仕様と異なります")
 
-        // 設定に新カードが含まれているか検証
-        XCTAssertTrue(config.allowedMoves.contains(.kingUpOrDown), "上下選択カードがプリセット設定に含まれていません")
-        XCTAssertTrue(config.allowedMoves.contains(.kingLeftOrRight), "左右選択カードがプリセット設定に含まれていません")
+            let allowedMoves = Set(preset.configuration.allowedMoves)
+            XCTAssertTrue(expectedMoves.isSubset(of: allowedMoves), "\(preset) に必要なカードが含まれていません")
+        }
     }
 
-    /// 3-1 ステージが directionChoice デッキを使用し、仕様通りの条件を持つことを確認する
-    func testCampaignStage31Definition() {
+    /// 3 章のステージが段階的に難度を増しているかをまとめて検証する
+    func testCampaignStage3Definitions() {
         let library = CampaignLibrary.shared
-        let stageID = CampaignStageID(chapter: 3, index: 1)
-        guard let stage = library.stage(with: stageID) else {
-            XCTFail("3-1 ステージが CampaignLibrary に見つかりません")
+        let stage31ID = CampaignStageID(chapter: 3, index: 1)
+        let stage32ID = CampaignStageID(chapter: 3, index: 2)
+        let stage33ID = CampaignStageID(chapter: 3, index: 3)
+        let stage34ID = CampaignStageID(chapter: 3, index: 4)
+
+        guard
+            let stage31 = library.stage(with: stage31ID),
+            let stage32 = library.stage(with: stage32ID),
+            let stage33 = library.stage(with: stage33ID),
+            let stage34 = library.stage(with: stage34ID)
+        else {
+            XCTFail("第3章のステージ定義に不足があります")
             return
         }
 
-        XCTAssertEqual(stage.title, "選択訓練", "ステージ名が仕様と一致していません")
-        XCTAssertEqual(stage.regulation.boardSize, 5, "盤面サイズが 5×5 ではありません")
-        XCTAssertEqual(stage.regulation.deckPreset, .directionChoice, "使用デッキが directionChoice ではありません")
-        XCTAssertEqual(stage.secondaryObjective, .finishWithoutPenalty, "二つ目のスター条件が想定外です")
-        XCTAssertEqual(stage.scoreTarget, 600, "スコアターゲットが想定外です")
+        XCTAssertEqual(stage31.title, "縦横選択訓練")
+        XCTAssertEqual(stage31.regulation.deckPreset, .kingOrthogonalChoiceOnly)
+        XCTAssertEqual(stage31.secondaryObjective, .finishWithoutPenalty)
+        XCTAssertEqual(stage31.scoreTarget, 600)
+        XCTAssertEqual(stage31.unlockRequirement, .stageClear(CampaignStageID(chapter: 2, index: 1)))
 
-        // アンロック条件が 2-1 のクリアであることを確認
-        let expectedUnlock = CampaignStageUnlockRequirement.stageClear(CampaignStageID(chapter: 2, index: 1))
-        XCTAssertEqual(stage.unlockRequirement, expectedUnlock, "アンロック条件が 2-1 クリアになっていません")
+        XCTAssertEqual(stage32.title, "斜め選択応用")
+        XCTAssertEqual(stage32.regulation.deckPreset, .kingDiagonalChoiceOnly)
+        XCTAssertEqual(stage32.secondaryObjective, .finishWithinMoves(maxMoves: 32))
+        XCTAssertEqual(stage32.scoreTarget, 580)
+        XCTAssertEqual(stage32.unlockRequirement, .stageClear(stage31ID))
+
+        XCTAssertEqual(stage33.title, "桂馬選択攻略")
+        XCTAssertEqual(stage33.regulation.deckPreset, .knightChoiceOnly)
+        XCTAssertEqual(stage33.secondaryObjective, .finishWithinMoves(maxMoves: 30))
+        XCTAssertEqual(stage33.scoreTarget, 560)
+        XCTAssertEqual(stage33.unlockRequirement, .stageClear(stage32ID))
+
+        XCTAssertEqual(stage34.title, "総合選択演習")
+        XCTAssertEqual(stage34.regulation.deckPreset, .allChoiceMixed)
+        XCTAssertEqual(stage34.secondaryObjective, .finishWithinMoves(maxMoves: 28))
+        XCTAssertEqual(stage34.scoreTarget, 540)
+        XCTAssertEqual(stage34.scoreTargetComparison, .lessThan)
+        XCTAssertEqual(stage34.unlockRequirement, .stageClear(stage33ID))
     }
 }

--- a/Tests/GameTests/DeckTests.swift
+++ b/Tests/GameTests/DeckTests.swift
@@ -65,7 +65,11 @@ final class DeckTests: XCTestCase {
             .kingLeft,
             .kingUpLeft,
             .kingUpOrDown,
-            .kingLeftOrRight
+            .kingLeftOrRight,
+            .kingUpwardDiagonalChoice,
+            .kingRightDiagonalChoice,
+            .kingDownwardDiagonalChoice,
+            .kingLeftDiagonalChoice
         ]
 
         // allCases の結果を集合化して比較し、山札構築時に含まれることを保証する
@@ -80,6 +84,14 @@ final class DeckTests: XCTestCase {
         XCTAssertEqual(MoveCard.standardSet.count, 24, "スタンダードセットの枚数が 24 枚から変化しています")
         XCTAssertFalse(MoveCard.standardSet.contains(.kingUpOrDown), "選択式カードがスタンダードセットへ混入しています")
         XCTAssertFalse(MoveCard.standardSet.contains(.kingLeftOrRight), "選択式カードがスタンダードセットへ混入しています")
+        XCTAssertFalse(MoveCard.standardSet.contains(.kingUpwardDiagonalChoice), "選択式カードがスタンダードセットへ混入しています")
+        XCTAssertFalse(MoveCard.standardSet.contains(.kingRightDiagonalChoice), "選択式カードがスタンダードセットへ混入しています")
+        XCTAssertFalse(MoveCard.standardSet.contains(.kingDownwardDiagonalChoice), "選択式カードがスタンダードセットへ混入しています")
+        XCTAssertFalse(MoveCard.standardSet.contains(.kingLeftDiagonalChoice), "選択式カードがスタンダードセットへ混入しています")
+        XCTAssertFalse(MoveCard.standardSet.contains(.knightUpwardChoice), "選択式カードがスタンダードセットへ混入しています")
+        XCTAssertFalse(MoveCard.standardSet.contains(.knightRightwardChoice), "選択式カードがスタンダードセットへ混入しています")
+        XCTAssertFalse(MoveCard.standardSet.contains(.knightDownwardChoice), "選択式カードがスタンダードセットへ混入しています")
+        XCTAssertFalse(MoveCard.standardSet.contains(.knightLeftwardChoice), "選択式カードがスタンダードセットへ混入しています")
     }
 
     /// directionChoice 構成が新カードを含み、重みも設定されていることを検証する
@@ -92,6 +104,64 @@ final class DeckTests: XCTestCase {
         // 重みが設定されているかを確認（未設定の場合は nil になる）
         XCTAssertEqual(config.baseWeights[.kingUpOrDown], 3, "上下選択カードの重みが想定外です")
         XCTAssertEqual(config.baseWeights[.kingLeftOrRight], 3, "左右選択カードの重みが想定外です")
+    }
+
+    /// 上下左右選択キング専用デッキの設定を確認する
+    func testKingOrthogonalChoiceOnlyDeckConfiguration() {
+        let config = Deck.Configuration.kingOrthogonalChoiceOnly
+        XCTAssertEqual(Set(config.allowedMoves), [.kingUpOrDown, .kingLeftOrRight], "許可カードが縦横選択キングのみになっていません")
+        XCTAssertEqual(config.deckSummaryText, "上下左右の選択キング限定", "サマリーテキストが仕様と異なります")
+        XCTAssertEqual(config.baseWeights.count, 2, "重み設定が 2 種以上になっています")
+        XCTAssertEqual(config.baseWeights[.kingUpOrDown], 1, "上下選択キングの重みが想定外です")
+        XCTAssertEqual(config.baseWeights[.kingLeftOrRight], 1, "左右選択キングの重みが想定外です")
+    }
+
+    /// 斜め選択キング専用デッキの設定を確認する
+    func testKingDiagonalChoiceOnlyDeckConfiguration() {
+        let config = Deck.Configuration.kingDiagonalChoiceOnly
+        let expected: Set<MoveCard> = [
+            .kingUpwardDiagonalChoice,
+            .kingRightDiagonalChoice,
+            .kingDownwardDiagonalChoice,
+            .kingLeftDiagonalChoice
+        ]
+        XCTAssertEqual(Set(config.allowedMoves), expected, "許可カードが斜め選択キング 4 種と一致していません")
+        XCTAssertTrue(expected.allSatisfy { config.baseWeights[$0] == 1 }, "斜め選択キングの重みが均等になっていません")
+        XCTAssertEqual(config.deckSummaryText, "斜め選択キング限定", "サマリーテキストが仕様と異なります")
+    }
+
+    /// 桂馬選択専用デッキの設定を確認する
+    func testKnightChoiceOnlyDeckConfiguration() {
+        let config = Deck.Configuration.knightChoiceOnly
+        let expected: Set<MoveCard> = [
+            .knightUpwardChoice,
+            .knightRightwardChoice,
+            .knightDownwardChoice,
+            .knightLeftwardChoice
+        ]
+        XCTAssertEqual(Set(config.allowedMoves), expected, "許可カードが桂馬選択 4 種と一致していません")
+        XCTAssertTrue(expected.allSatisfy { config.baseWeights[$0] == 1 }, "桂馬選択カードの重みが均等になっていません")
+        XCTAssertEqual(config.deckSummaryText, "桂馬選択カード限定", "サマリーテキストが仕様と異なります")
+    }
+
+    /// 全選択カード混合デッキの設定を確認する
+    func testAllChoiceMixedDeckConfiguration() {
+        let config = Deck.Configuration.allChoiceMixed
+        let expected: Set<MoveCard> = [
+            .kingUpOrDown,
+            .kingLeftOrRight,
+            .kingUpwardDiagonalChoice,
+            .kingRightDiagonalChoice,
+            .kingDownwardDiagonalChoice,
+            .kingLeftDiagonalChoice,
+            .knightUpwardChoice,
+            .knightRightwardChoice,
+            .knightDownwardChoice,
+            .knightLeftwardChoice
+        ]
+        XCTAssertEqual(Set(config.allowedMoves), expected, "全選択カード混合デッキの内容が一致していません")
+        XCTAssertTrue(expected.allSatisfy { config.baseWeights[$0] == 1 }, "混合デッキ内の重みが均等ではありません")
+        XCTAssertEqual(config.deckSummaryText, "選択カード総合ミックス", "サマリーテキストが仕様と異なります")
     }
 
     /// クラシカルチャレンジ設定では桂馬カードのみが配られるか検証する


### PR DESCRIPTION
## Summary
- add diagonal and knight selection MoveCard cases with dedicated names and metadata
- introduce deck presets for orthogonal, diagonal, knight-only, and mixed selection cards and expose them via GameDeckPreset
- expand campaign chapter 3 with new staged progression using the new decks and update tests accordingly

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dcc746d8c4832cab28f30efb59198f