### PR TITLE
Refactor deck weight profile handling

### DIFF
--- a/Tests/GameTests/DeckTests.swift
+++ b/Tests/GameTests/DeckTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 /// 重み付き山札の挙動を検証するテスト
 final class DeckTests: XCTestCase {
-    /// 山札の重み付けが仕様通り（キング 1.5 倍・斜め 2 マスは桂馬の半分）になっているか統計的に確認する
-    func testWeightedRandomPrefersKingMoves() {
+    /// 現行プロファイルでは全カードが均一重みになるため、カテゴリ間の出現率が概ね揃うことを検証する
+    func testWeightedRandomBehavesUniformlyWithDefaultProfile() {
         var deck = Deck(seed: 12345)
         let sampleCount = 20_000 // 十分な試行回数を確保してばらつきを抑える
         var counts: [MoveCard: Int] = [:]
@@ -43,13 +43,12 @@ final class DeckTests: XCTestCase {
         let kingToKnight = kingAverage / knightAverage
         let diagonalToKnight = diagonalAverage / knightAverage
 
-        // 理論上の比率は 3:2 = 1.5。サンプル誤差を考慮し 1.35〜1.65 を許容
-        XCTAssertGreaterThanOrEqual(kingToKnight, 1.35, "王将型の平均出現数が期待値より低い: \(kingToKnight)")
-        XCTAssertLessThanOrEqual(kingToKnight, 1.65, "王将型の平均出現数が期待値より高い: \(kingToKnight)")
+        // 均等重みなので平均値の比率は 1.0 付近になる想定。10〜15% 程度の誤差を許容する
+        XCTAssertGreaterThanOrEqual(kingToKnight, 0.85, "王将型の平均出現数が偏っています: \(kingToKnight)")
+        XCTAssertLessThanOrEqual(kingToKnight, 1.15, "王将型の平均出現数が偏っています: \(kingToKnight)")
 
-        // 斜め 2 マスは 1:2 = 0.5 を目標。許容範囲を 0.4〜0.6 に設定
-        XCTAssertGreaterThanOrEqual(diagonalToKnight, 0.4, "斜め 2 マスカードの平均出現数が期待値より低い: \(diagonalToKnight)")
-        XCTAssertLessThanOrEqual(diagonalToKnight, 0.6, "斜め 2 マスカードの平均出現数が期待値より高い: \(diagonalToKnight)")
+        XCTAssertGreaterThanOrEqual(diagonalToKnight, 0.85, "斜め 2 マスカードの平均出現数が偏っています: \(diagonalToKnight)")
+        XCTAssertLessThanOrEqual(diagonalToKnight, 1.15, "斜め 2 マスカードの平均出現数が偏っています: \(diagonalToKnight)")
     }
 
     /// MoveCard.allCases にキング型 8 種が含まれているかを検証する
@@ -101,9 +100,9 @@ final class DeckTests: XCTestCase {
         XCTAssertTrue(allowedMoves.contains(.kingUpOrDown), "上下選択カードがデッキに含まれていません")
         XCTAssertTrue(allowedMoves.contains(.kingLeftOrRight), "左右選択カードがデッキに含まれていません")
 
-        // 重みが設定されているかを確認（未設定の場合は nil になる）
-        XCTAssertEqual(config.baseWeights[.kingUpOrDown], 3, "上下選択カードの重みが想定外です")
-        XCTAssertEqual(config.baseWeights[.kingLeftOrRight], 3, "左右選択カードの重みが想定外です")
+        // 重みプロファイル経由で均一重みになっているかを確認
+        XCTAssertEqual(config.weightProfile.weight(for: .kingUpOrDown), 1, "上下選択カードの重みが均一ではありません")
+        XCTAssertEqual(config.weightProfile.weight(for: .kingLeftOrRight), 1, "左右選択カードの重みが均一ではありません")
     }
 
     /// 上下左右選択キング専用デッキの設定を確認する
@@ -111,9 +110,8 @@ final class DeckTests: XCTestCase {
         let config = Deck.Configuration.kingOrthogonalChoiceOnly
         XCTAssertEqual(Set(config.allowedMoves), [.kingUpOrDown, .kingLeftOrRight], "許可カードが縦横選択キングのみになっていません")
         XCTAssertEqual(config.deckSummaryText, "上下左右の選択キング限定", "サマリーテキストが仕様と異なります")
-        XCTAssertEqual(config.baseWeights.count, 2, "重み設定が 2 種以上になっています")
-        XCTAssertEqual(config.baseWeights[.kingUpOrDown], 1, "上下選択キングの重みが想定外です")
-        XCTAssertEqual(config.baseWeights[.kingLeftOrRight], 1, "左右選択キングの重みが想定外です")
+        XCTAssertEqual(config.weightProfile.weight(for: .kingUpOrDown), 1, "上下選択キングの重みが均一ではありません")
+        XCTAssertEqual(config.weightProfile.weight(for: .kingLeftOrRight), 1, "左右選択キングの重みが均一ではありません")
     }
 
     /// 斜め選択キング専用デッキの設定を確認する
@@ -126,7 +124,7 @@ final class DeckTests: XCTestCase {
             .kingLeftDiagonalChoice
         ]
         XCTAssertEqual(Set(config.allowedMoves), expected, "許可カードが斜め選択キング 4 種と一致していません")
-        XCTAssertTrue(expected.allSatisfy { config.baseWeights[$0] == 1 }, "斜め選択キングの重みが均等になっていません")
+        XCTAssertTrue(expected.allSatisfy { config.weightProfile.weight(for: $0) == 1 }, "斜め選択キングの重みが均等になっていません")
         XCTAssertEqual(config.deckSummaryText, "斜め選択キング限定", "サマリーテキストが仕様と異なります")
     }
 
@@ -140,7 +138,7 @@ final class DeckTests: XCTestCase {
             .knightLeftwardChoice
         ]
         XCTAssertEqual(Set(config.allowedMoves), expected, "許可カードが桂馬選択 4 種と一致していません")
-        XCTAssertTrue(expected.allSatisfy { config.baseWeights[$0] == 1 }, "桂馬選択カードの重みが均等になっていません")
+        XCTAssertTrue(expected.allSatisfy { config.weightProfile.weight(for: $0) == 1 }, "桂馬選択カードの重みが均等になっていません")
         XCTAssertEqual(config.deckSummaryText, "桂馬選択カード限定", "サマリーテキストが仕様と異なります")
     }
 
@@ -160,7 +158,7 @@ final class DeckTests: XCTestCase {
             .knightLeftwardChoice
         ]
         XCTAssertEqual(Set(config.allowedMoves), expected, "全選択カード混合デッキの内容が一致していません")
-        XCTAssertTrue(expected.allSatisfy { config.baseWeights[$0] == 1 }, "混合デッキ内の重みが均等ではありません")
+        XCTAssertTrue(expected.allSatisfy { config.weightProfile.weight(for: $0) == 1 }, "混合デッキ内の重みが均等ではありません")
         XCTAssertEqual(config.deckSummaryText, "選択カード総合ミックス", "サマリーテキストが仕様と異なります")
     }
 


### PR DESCRIPTION
## Summary
- add `Deck.WeightProfile` to centralize default card weights and overrides across configurations
- update deck presets to build uniform weight profiles and use them when drawing cards
- refresh deck unit tests to follow the new profile API and validate the adjusted expectations

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dcca285994832c9d0ec0e52bcb05af