### PR TITLE
Add toggle tile visit behavior

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -87,7 +87,8 @@ public final class GameCore: ObservableObject {
         board = Board(
             size: mode.boardSize,
             initialVisitedPoints: mode.initialVisitedPoints,
-            requiredVisitOverrides: mode.additionalVisitRequirements
+            requiredVisitOverrides: mode.additionalVisitRequirements,
+            togglePoints: mode.toggleTilePoints
         )
         current = mode.initialSpawnPoint ?? BoardGeometry.defaultSpawnPoint(for: mode.boardSize)
         deck = Deck(configuration: mode.deckConfiguration)
@@ -172,6 +173,8 @@ public final class GameCore: ObservableObject {
             "カード \(card.move) を使用し \(currentPosition) -> \(computedDestination) へ移動 (vector=\(resolvedMove.moveVector))"
         )
 
+        // トグルマスでも「訪問前に踏破済みかどうか」で再訪を判定する。
+        // - Note: 踏破済み状態から踏むと未踏破へ戻るため、次回訪問時はペナルティなしになる。
         let revisiting = board.isVisited(computedDestination)
 
         // 移動処理
@@ -324,7 +327,8 @@ public final class GameCore: ObservableObject {
         board = Board(
             size: mode.boardSize,
             initialVisitedPoints: mode.initialVisitedPoints,
-            requiredVisitOverrides: mode.additionalVisitRequirements
+            requiredVisitOverrides: mode.additionalVisitRequirements,
+            togglePoints: mode.toggleTilePoints
         )
         current = mode.initialSpawnPoint
         moveCount = 0
@@ -494,12 +498,14 @@ extension GameCore {
             core.board = Board(
                 size: mode.boardSize,
                 initialVisitedPoints: [resolvedCurrent],
-                requiredVisitOverrides: mode.additionalVisitRequirements
+                requiredVisitOverrides: mode.additionalVisitRequirements,
+                togglePoints: mode.toggleTilePoints
             )
         } else {
             core.board = Board(
                 size: mode.boardSize,
-                requiredVisitOverrides: mode.additionalVisitRequirements
+                requiredVisitOverrides: mode.additionalVisitRequirements,
+                togglePoints: mode.toggleTilePoints
             )
         }
         core.current = resolvedCurrent

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -218,6 +218,10 @@ public struct GameMode: Equatable, Identifiable {
         public var penalties: PenaltySettings
         /// マスごとの追加踏破回数設定
         public var additionalVisitRequirements: [GridPoint: Int] = [:]
+        /// トグル挙動を適用するマス集合
+        /// - Important: 同じ座標に `additionalVisitRequirements` が存在する場合はトグルが優先され、
+        ///   ギミックとして 1 回踏むごとに踏破⇔未踏破が反転する。
+        public var toggleTilePoints: Set<GridPoint> = []
 
         /// レギュレーションを組み立てるためのイニシャライザ
         /// - Parameters:
@@ -236,7 +240,8 @@ public struct GameMode: Equatable, Identifiable {
             deckPreset: GameDeckPreset,
             spawnRule: SpawnRule,
             penalties: PenaltySettings,
-            additionalVisitRequirements: [GridPoint: Int] = [:]
+            additionalVisitRequirements: [GridPoint: Int] = [:],
+            toggleTilePoints: Set<GridPoint> = []
         ) {
             self.boardSize = boardSize
             self.handSize = handSize
@@ -246,6 +251,7 @@ public struct GameMode: Equatable, Identifiable {
             self.spawnRule = spawnRule
             self.penalties = penalties
             self.additionalVisitRequirements = additionalVisitRequirements
+            self.toggleTilePoints = toggleTilePoints
         }
     }
 
@@ -392,6 +398,8 @@ public struct GameMode: Equatable, Identifiable {
 
     /// 追加踏破回数が必要なマス集合
     public var additionalVisitRequirements: [GridPoint: Int] { regulation.additionalVisitRequirements }
+    /// トグル挙動を割り当てたマス集合
+    public var toggleTilePoints: Set<GridPoint> { regulation.toggleTilePoints }
 
     /// スタンダードモード（既存仕様）
     public static var standard: GameMode {

--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -40,6 +40,10 @@ public final class GameScene: SKScene {
     /// 初期化時に設定する追加踏破回数（複数回踏む必要があるマス）
     private let initialRequiredVisitOverrides: [GridPoint: Int]
 
+    /// 初期化時に設定するトグルマス集合
+    /// - NOTE: ギミックの再生成で情報が失われないよう、初期値として保持しておく
+    private let initialTogglePoints: Set<GridPoint>
+
     /// 現在の盤面状態
     private var board: Board
 
@@ -144,7 +148,8 @@ public final class GameScene: SKScene {
         board = Board(
             size: initialBoardSize,
             initialVisitedPoints: initialVisitedPoints,
-            requiredVisitOverrides: initialRequiredVisitOverrides
+            requiredVisitOverrides: initialRequiredVisitOverrides,
+            togglePoints: initialTogglePoints
         )
         // テーマもデフォルトへ戻し、SpriteKit 専用の配色が未設定のままでも破綻しないようフォールバックを適用
         palette = GameScenePalette.fallback
@@ -187,16 +192,19 @@ public final class GameScene: SKScene {
     public init(
         initialBoardSize: Int,
         initialVisitedPoints: [GridPoint]? = nil,
-        requiredVisitOverrides: [GridPoint: Int] = [:]
+        requiredVisitOverrides: [GridPoint: Int] = [:],
+        togglePoints: Set<GridPoint> = []
     ) {
         let resolvedVisitedPoints = initialVisitedPoints ?? BoardGeometry.defaultInitialVisitedPoints(for: initialBoardSize)
         self.initialBoardSize = initialBoardSize
         self.initialVisitedPoints = resolvedVisitedPoints
         self.initialRequiredVisitOverrides = requiredVisitOverrides
+        self.initialTogglePoints = togglePoints
         self.board = Board(
             size: initialBoardSize,
             initialVisitedPoints: resolvedVisitedPoints,
-            requiredVisitOverrides: requiredVisitOverrides
+            requiredVisitOverrides: requiredVisitOverrides,
+            togglePoints: togglePoints
         )
         super.init(size: .zero)
         // 共通初期化で各種プロパティを統一的にリセットし、生成経路による差異を排除する
@@ -211,10 +219,12 @@ public final class GameScene: SKScene {
         let defaultVisitedPoints = BoardGeometry.defaultInitialVisitedPoints(for: BoardGeometry.standardSize)
         self.initialVisitedPoints = defaultVisitedPoints
         self.initialRequiredVisitOverrides = [:]
+        self.initialTogglePoints = []
         self.board = Board(
             size: BoardGeometry.standardSize,
             initialVisitedPoints: defaultVisitedPoints,
-            requiredVisitOverrides: [:]
+            requiredVisitOverrides: [:],
+            togglePoints: []
         )
         super.init(coder: aDecoder)
         // デコード後も共通初期化を実行し、Storyboard/SwiftUI どちらからでも同じ見た目・挙動となるようにする

--- a/Tests/GameTests/BoardClearTests.swift
+++ b/Tests/GameTests/BoardClearTests.swift
@@ -44,4 +44,25 @@ final class BoardClearTests: XCTestCase {
         XCTAssertTrue(board.isVisited(specialPoint), "2 回目で踏破済みになる")
         XCTAssertEqual(board.remainingCount, 15, "1 マス分だけ残数が減る")
     }
+
+    /// トグルマスが踏むたびに踏破⇔未踏破へ反転するかを確認する
+    func testToggleTileFlipsVisitedState() {
+        let togglePoint = GridPoint(x: 0, y: 0)
+        var board = Board(size: 3, togglePoints: Set([togglePoint]))
+
+        XCTAssertFalse(board.isVisited(togglePoint), "初期状態では未踏破")
+        XCTAssertEqual(board.remainingCount, 9, "3×3 盤なので未踏破数は 9")
+
+        board.markVisited(togglePoint)
+        XCTAssertTrue(board.isVisited(togglePoint), "1 回踏むと踏破済みに変わる")
+        XCTAssertEqual(board.remainingCount, 8, "踏破済みなので残マスが 1 減る")
+
+        board.markVisited(togglePoint)
+        XCTAssertFalse(board.isVisited(togglePoint), "2 回目で未踏破へ戻る")
+        XCTAssertEqual(board.remainingCount, 9, "未踏破へ戻るため残マスが再び増える")
+
+        board.markVisited(togglePoint)
+        XCTAssertTrue(board.isVisited(togglePoint), "3 回目で再び踏破済みになる")
+        XCTAssertEqual(board.remainingCount, 8, "踏破済みになれば残マスが減る")
+    }
 }

--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -84,7 +84,8 @@ final class GameBoardBridgeViewModel: ObservableObject {
         let preparedScene = GameScene(
             initialBoardSize: mode.boardSize,
             initialVisitedPoints: mode.initialVisitedPoints,
-            requiredVisitOverrides: mode.additionalVisitRequirements
+            requiredVisitOverrides: mode.additionalVisitRequirements,
+            togglePoints: mode.toggleTilePoints
         )
         preparedScene.scaleMode = .resizeFill
         preparedScene.gameCore = core


### PR DESCRIPTION
## Summary
- introduce TileState.VisitBehavior with toggle support and update Board to handle toggle tiles including debug output
- expose toggle tile configuration via GameMode/Regulation and propagate it through GameCore, GameScene, and the bridge view model so boards retain toggle settings
- add tests covering toggle tile flip behaviour in BoardClearTests

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dcc98d8f4c832ca7c121c7991f36ae