### PR TITLE
Add chapter 4 toggle campaign stage

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -550,6 +550,48 @@ public struct CampaignLibrary {
             stages: [stage31, stage32, stage33, stage34]
         )
 
-        return [chapter1, chapter2, chapter3]
+        // MARK: - 4 章のステージ群
+        // 4-1 では 5×5 盤にトグルマスを導入し、踏破の反転ギミックに慣れてもらう。
+        // - Important: 指示された (1,2) と (3,4) は 1 始まりで提供されたため、内部表現の 0 始まり座標へ読み替える。
+        let togglePointsChapter4: Set<GridPoint> = [
+            GridPoint(x: 0, y: 1),
+            GridPoint(x: 2, y: 3)
+        ]
+
+        let stage41 = CampaignStage(
+            id: CampaignStageID(chapter: 4, index: 1),
+            title: "反転制御訓練", // 章タイトルとの整合を意識した名前にする
+            summary: "トグルマスで踏破状態が切り替わる 5×5 を攻略し、ギミック対応力を養いましょう。",
+            regulation: GameMode.Regulation(
+                boardSize: 5,
+                handSize: 5,
+                nextPreviewCount: 3,
+                allowsStacking: true,
+                deckPreset: .standard,
+                spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 5)),
+                penalties: GameMode.PenaltySettings(
+                    deadlockPenaltyCost: standardPenalties.deadlockPenaltyCost,
+                    manualRedrawPenaltyCost: standardPenalties.manualRedrawPenaltyCost,
+                    manualDiscardPenaltyCost: standardPenalties.manualDiscardPenaltyCost,
+                    revisitPenaltyCost: standardPenalties.revisitPenaltyCost
+                ),
+                toggleTilePoints: togglePointsChapter4
+            ),
+            // MARK: 2 個目のスター条件: ギミックを理解したうえで 30 手以内の踏破を狙う
+            secondaryObjective: .finishWithinMoves(maxMoves: 30),
+            // MARK: 3 個目のスター条件: トグルで増える手数を抑えつつスコア 520 以下でまとめる
+            scoreTarget: 520,
+            // MARK: アンロック条件: 3-4 クリア後に開放し、章間の到達順を保つ
+            unlockRequirement: .stageClear(stage34.id)
+        )
+
+        let chapter4 = CampaignChapter(
+            id: 4,
+            title: "反転応用", // 章全体のテーマとしてトグルギミックを強調
+            summary: "トグルマスの挙動を扱う章。",
+            stages: [stage41]
+        )
+
+        return [chapter1, chapter2, chapter3, chapter4]
     }
 }

--- a/Tests/GameTests/CampaignLibraryTests.swift
+++ b/Tests/GameTests/CampaignLibraryTests.swift
@@ -86,4 +86,39 @@ final class CampaignLibraryTests: XCTestCase {
         XCTAssertEqual(stage34.scoreTargetComparison, .lessThan)
         XCTAssertEqual(stage34.unlockRequirement, .stageClear(stage33ID))
     }
+
+    /// 4 章のトグルギミック導入ステージが仕様通りに組み込まれているかを確認する
+    func testCampaignStage4Definitions() {
+        let library = CampaignLibrary.shared
+        let stage41ID = CampaignStageID(chapter: 4, index: 1)
+
+        // MARK: 章配列が 4 章まで拡張されているか明示的に確認する
+        XCTAssertEqual(library.chapters.count, 4, "キャンペーンの章数が 4 章構成になっていません")
+        XCTAssertEqual(library.chapters.last?.id, 4, "最終章の ID が 4 になっていません")
+
+        guard let stage41 = library.stage(with: stage41ID) else {
+            XCTFail("第4章 4-1 の定義が見つかりません")
+            return
+        }
+
+        // MARK: 基本情報（タイトル・サマリー・盤面サイズ）が仕様通りかを検証
+        XCTAssertEqual(stage41.title, "反転制御訓練")
+        XCTAssertTrue(stage41.summary.contains("トグルマス"), "サマリーにトグルギミックへの言及がありません")
+        XCTAssertEqual(stage41.regulation.boardSize, 5)
+
+        // MARK: トグルマス座標が 0 始まりで (0,1) と (2,3) に設定されているかをチェック
+        let expectedTogglePoints: Set<GridPoint> = [
+            GridPoint(x: 0, y: 1),
+            GridPoint(x: 2, y: 3)
+        ]
+        XCTAssertEqual(stage41.regulation.toggleTilePoints, expectedTogglePoints)
+
+        // MARK: スター条件（手数制限・スコア上限）が定義通りかを確認
+        XCTAssertEqual(stage41.secondaryObjective, .finishWithinMoves(maxMoves: 30))
+        XCTAssertEqual(stage41.scoreTarget, 520)
+
+        // MARK: アンロック条件が 3-4 クリアに紐付いているかを確認
+        let prerequisiteID = CampaignStageID(chapter: 3, index: 4)
+        XCTAssertEqual(stage41.unlockRequirement, .stageClear(prerequisiteID))
+    }
 }


### PR DESCRIPTION
## Summary
- add the fourth campaign chapter featuring a 5×5 toggle tile stage and document its star and unlock conditions in Japanese comments
- include the new chapter in the shared campaign library while preserving the existing unlock progression
- extend the campaign library tests to cover the new chapter’s definitions and toggle configuration

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68dccc93894c832c9bf20c717e8aba89