### PR TITLE
Add palette colors for toggle and multi-visit tiles

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -512,15 +512,18 @@ public final class GameScene: SKScene {
     /// - Parameter state: 現在のマス状態
     /// - Returns: 未踏破〜踏破済みまでの進捗に応じて補間された色
     private func tileFillColor(for state: TileState) -> SKColor {
-        if state.isVisited {
-            return palette.boardTileVisited
+        switch state.visitBehavior {
+        case .toggle:
+            // トグルマスは踏破状態に関わらず専用色で固定し、ギミックの存在を明確に示す
+            return palette.boardTileToggle
+        case .multi(required: _):
+            // 複数回踏む必要があるマスは進捗率に応じて基準色→踏破済み色へ補間し、残回数の把握を助ける
+            let progress = CGFloat(state.completionProgress)
+            return palette.boardTileMultiBase.interpolated(to: palette.boardTileVisited, fraction: progress)
+        case .single:
+            // 通常マスは従来通りの配色で未踏破と踏破済みを切り替える
+            return state.isVisited ? palette.boardTileVisited : palette.boardTileUnvisited
         }
-        guard state.requiresMultipleVisits else {
-            return palette.boardTileUnvisited
-        }
-
-        let progress = CGFloat(state.completionProgress)
-        return palette.boardTileUnvisited.interpolated(to: palette.boardTileVisited, fraction: progress)
     }
 
     /// 盤面ハイライトの種類ごとの集合をまとめて更新する

--- a/Game/GameScenePalette.swift
+++ b/Game/GameScenePalette.swift
@@ -12,6 +12,12 @@ public struct GameScenePalette {
     public let boardTileVisited: SKColor
     /// 未踏破タイルの塗り色
     public let boardTileUnvisited: SKColor
+    /// 複数回踏破マスの基準色
+    /// - NOTE: 未踏破色とは別に持つことで、進捗に応じた補間でも濁りが生じないようにする
+    public let boardTileMultiBase: SKColor
+    /// トグルマスの塗り色
+    /// - NOTE: 踏破状態に関わらず専用色を固定し、盤面上でギミックマスを瞬時に識別できるようにする
+    public let boardTileToggle: SKColor
     /// 駒の塗り色
     public let boardKnight: SKColor
     /// ガイド枠の線色
@@ -23,6 +29,8 @@ public struct GameScenePalette {
     ///   - boardGridLine: グリッド線色
     ///   - boardTileVisited: 踏破済みタイル色
     ///   - boardTileUnvisited: 未踏破タイル色
+    ///   - boardTileMultiBase: 複数回踏破マスの基準色
+    ///   - boardTileToggle: トグルマスの塗り色
     ///   - boardKnight: 駒の塗り色
     ///   - boardGuideHighlight: ガイド枠の線色
     public init(
@@ -30,6 +38,8 @@ public struct GameScenePalette {
         boardGridLine: SKColor,
         boardTileVisited: SKColor,
         boardTileUnvisited: SKColor,
+        boardTileMultiBase: SKColor,
+        boardTileToggle: SKColor,
         boardKnight: SKColor,
         boardGuideHighlight: SKColor
     ) {
@@ -37,6 +47,8 @@ public struct GameScenePalette {
         self.boardGridLine = boardGridLine
         self.boardTileVisited = boardTileVisited
         self.boardTileUnvisited = boardTileUnvisited
+        self.boardTileMultiBase = boardTileMultiBase
+        self.boardTileToggle = boardTileToggle
         self.boardKnight = boardKnight
         self.boardGuideHighlight = boardGuideHighlight
     }
@@ -53,6 +65,10 @@ public extension GameScenePalette {
         boardGridLine: SKColor(white: 0.15, alpha: 1.0),
         boardTileVisited: SKColor(white: 0.75, alpha: 1.0),
         boardTileUnvisited: SKColor(white: 0.98, alpha: 1.0),
+        // NOTE: 複数回踏破マスでは段階的に暗くなるグレートーンを基準とし、踏破進捗の差が分かりやすいようにする
+        boardTileMultiBase: SKColor(white: 0.86, alpha: 1.0),
+        // NOTE: トグルマスは常に存在感を出したいので、未踏破・踏破の状態差に影響されない濃いめのグレーを採用する
+        boardTileToggle: SKColor(white: 0.6, alpha: 1.0),
         boardKnight: SKColor(white: 0.1, alpha: 1.0),
         // NOTE: SwiftUI のライトテーマと同じ彩度を抑えたオレンジを採用し、テーマ適用前でも一貫した強調色を維持する
         boardGuideHighlight: SKColor(red: 0.94, green: 0.41, blue: 0.08, alpha: 0.85)
@@ -64,6 +80,10 @@ public extension GameScenePalette {
         boardGridLine: SKColor(white: 0.75, alpha: 1.0),
         boardTileVisited: SKColor(white: 0.35, alpha: 1.0),
         boardTileUnvisited: SKColor(white: 0.12, alpha: 1.0),
+        // NOTE: ライトテーマ同様にグレートーンを段階的に変化させ、暗所でも進捗を追いやすくする
+        boardTileMultiBase: SKColor(white: 0.22, alpha: 1.0),
+        // NOTE: トグルマスは暗色背景でも埋もれないよう、訪問状態に左右されない明度のグレーを採用
+        boardTileToggle: SKColor(white: 0.65, alpha: 1.0),
         boardKnight: SKColor(white: 0.95, alpha: 1.0),
         // NOTE: ダークテーマに合わせて明度を上げたオレンジを用い、背景の暗さに負けない発光感を演出する
         boardGuideHighlight: SKColor(red: 1.0, green: 0.74, blue: 0.38, alpha: 0.9)

--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -144,6 +144,9 @@ final class GameBoardBridgeViewModel: ObservableObject {
             boardGridLine: appTheme.skBoardGridLine,
             boardTileVisited: appTheme.skBoardTileVisited,
             boardTileUnvisited: appTheme.skBoardTileUnvisited,
+            // NOTE: 特殊マスが視覚的に分かるよう、SwiftUI 側で決めた配色をそのまま転写する
+            boardTileMultiBase: appTheme.skBoardTileMultiBase,
+            boardTileToggle: appTheme.skBoardTileToggle,
             boardKnight: appTheme.skBoardKnight,
             boardGuideHighlight: appTheme.skBoardGuideHighlight
         )

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -421,6 +421,26 @@ struct AppTheme: DynamicProperty {
         }
     }
 
+    /// 複数回踏破マスの基準色（進捗表示用に未踏破色よりもワントーン濃く設定）
+    var boardTileMultiBase: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            return Color.white.opacity(0.18)
+        default:
+            return Color.black.opacity(0.1)
+        }
+    }
+
+    /// トグルマスの塗り色（踏破状態に左右されない強調色）
+    var boardTileToggle: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            return Color.white.opacity(0.5)
+        default:
+            return Color.black.opacity(0.32)
+        }
+    }
+
     /// 駒本体の塗り色（背景に応じて反転させコントラストを維持）
     var boardKnight: Color {
         switch resolvedColorScheme {
@@ -505,6 +525,22 @@ struct AppTheme: DynamicProperty {
         )
     }
 
+    /// SpriteKit 複数回踏破マス基準色の UIColor 版
+    var uiBoardTileMultiBase: UIColor {
+        dynamicUIColor(
+            light: color(for: .light, keyPath: \.boardTileMultiBase),
+            dark: color(for: .dark, keyPath: \.boardTileMultiBase)
+        )
+    }
+
+    /// SpriteKit トグルマス色の UIColor 版
+    var uiBoardTileToggle: UIColor {
+        dynamicUIColor(
+            light: color(for: .light, keyPath: \.boardTileToggle),
+            dark: color(for: .dark, keyPath: \.boardTileToggle)
+        )
+    }
+
     /// SpriteKit 駒の UIColor 版
     var uiBoardKnight: UIColor {
         dynamicUIColor(
@@ -534,6 +570,12 @@ struct AppTheme: DynamicProperty {
 
     /// SpriteKit の SKColor へ変換した未踏破マス色
     var skBoardTileUnvisited: SKColor { SKColor(cgColor: uiBoardTileUnvisited.cgColor) }
+
+    /// SpriteKit の SKColor へ変換した複数回踏破マス基準色
+    var skBoardTileMultiBase: SKColor { SKColor(cgColor: uiBoardTileMultiBase.cgColor) }
+
+    /// SpriteKit の SKColor へ変換したトグルマス色
+    var skBoardTileToggle: SKColor { SKColor(cgColor: uiBoardTileToggle.cgColor) }
 
     /// SpriteKit の SKColor へ変換した駒の塗り色
     var skBoardKnight: SKColor { SKColor(cgColor: uiBoardKnight.cgColor) }


### PR DESCRIPTION
## Summary
- add dedicated SpriteKit palette colors for toggle and multi-visit tiles, including fallback values
- adjust tile fill logic to respect visit behavior and interpolate from the new multi-visit base color
- surface the new palette entries from AppTheme and pass them through the SpriteKit bridge

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dcd33f6394832cad90d7476e6cdc92