### PR TITLE
Rework Game Center authentication flow

### DIFF
--- a/MonoKnight.xcodeproj/project.pbxproj
+++ b/MonoKnight.xcodeproj/project.pbxproj
@@ -43,8 +43,9 @@
 		72CF38052E7162E20093B180 /* ErrorReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F92E7162E20093B180 /* ErrorReporter.swift */; };
 		72CF38072E7162E20093B180 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF38002E7162E20093B180 /* GameView.swift */; };
 		72CF380B2E7162E20093B180 /* AdsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37F82E7162E20093B180 /* AdsService.swift */; };
-		72CF380C2E7162E20093B180 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF38032E7162E20093B180 /* SettingsView.swift */; };
-		72CF380E2E7162E20093B180 /* ServiceMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37FB2E7162E20093B180 /* ServiceMocks.swift */; };
+                72CF380C2E7162E20093B180 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF38032E7162E20093B180 /* SettingsView.swift */; };
+                34AB7338806A42E0A3B80A97 /* GameCenterSignInPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9170D4E6844EE280264226 /* GameCenterSignInPrompt.swift */; };
+                72CF380E2E7162E20093B180 /* ServiceMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37FB2E7162E20093B180 /* ServiceMocks.swift */; };
 		72CF380F2E7162E20093B180 /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF38012E7162E20093B180 /* ResultView.swift */; };
 		72CF38102E7162E20093B180 /* ConsentFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37FE2E7162E20093B180 /* ConsentFlowView.swift */; };
 		72CF38112E7162E20093B180 /* GameCenterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CF37FA2E7162E20093B180 /* GameCenterService.swift */; };
@@ -128,8 +129,9 @@
 		72CF38002E7162E20093B180 /* GameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameView.swift; sourceTree = "<group>"; };
 		72CF38012E7162E20093B180 /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
 		72CF38022E7162E20093B180 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
-		72CF38032E7162E20093B180 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		72F554A72E7E40100098A1B0 /* MoveCardIllustrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveCardIllustrationView.swift; sourceTree = "<group>"; };
+                72CF38032E7162E20093B180 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+                5B9170D4E6844EE280264226 /* GameCenterSignInPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameCenterSignInPrompt.swift; sourceTree = "<group>"; };
+                72F554A72E7E40100098A1B0 /* MoveCardIllustrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveCardIllustrationView.swift; sourceTree = "<group>"; };
 		72F554A92E7E60850098A1B0 /* HowToPlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HowToPlayView.swift; sourceTree = "<group>"; };
 		72F554AA2E7E60850098A1B0 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		E765BB522E83469000C78E4F /* Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig; sourceTree = "<group>"; };
@@ -271,8 +273,9 @@
 				726642FC2E85DA9D003EA325 /* GameView+Observers.swift */,
 				72185F572E84B4B80057458C /* GameViewLayoutSupport.swift */,
 				7266429D2E849763003EA325 /* GameViewModel.swift */,
-				726642FD2E85DA9D003EA325 /* GameViewPreferenceKeys.swift */,
-				72F554A92E7E60850098A1B0 /* HowToPlayView.swift */,
+                                726642FD2E85DA9D003EA325 /* GameViewPreferenceKeys.swift */,
+                                5B9170D4E6844EE280264226 /* GameCenterSignInPrompt.swift */,
+                                72F554A92E7E60850098A1B0 /* HowToPlayView.swift */,
 				72F554A72E7E40100098A1B0 /* MoveCardIllustrationView.swift */,
 				726642FE2E85DA9D003EA325 /* PauseMenuView.swift */,
 				726642FF2E85DA9D003EA325 /* PenaltyBannerView.swift */,
@@ -494,8 +497,9 @@
 				726643022E85DA9D003EA325 /* GameView+Observers.swift in Sources */,
 				726643032E85DA9D003EA325 /* GameView+Logging.swift in Sources */,
 				726643042E85DA9D003EA325 /* GameView+Layout.swift in Sources */,
-				726643052E85DA9D003EA325 /* GameViewPreferenceKeys.swift in Sources */,
-				72185F592E84B50F0057458C /* DebugLog.swift in Sources */,
+                                726643052E85DA9D003EA325 /* GameViewPreferenceKeys.swift in Sources */,
+                                34AB7338806A42E0A3B80A97 /* GameCenterSignInPrompt.swift in Sources */,
+                                72185F592E84B50F0057458C /* DebugLog.swift in Sources */,
 				7266429A2E848E9A003EA325 /* InterstitialAdController.swift in Sources */,
 				72CF380B2E7162E20093B180 /* AdsService.swift in Sources */,
 				72185F522E84B44F0057458C /* CrashFeedbackCollector.swift in Sources */,

--- a/Tests/GameUITests/GameCenterAdsUITests.swift
+++ b/Tests/GameUITests/GameCenterAdsUITests.swift
@@ -17,20 +17,34 @@ final class GameCenterAdsUITests: XCTestCase {
         app.launch()
         
         // --- Game Center 認証フローの確認 ---
-        // サインインボタンが表示されるまで待機
-        // アクセシビリティ識別子 "gc_sign_in_button" を対象
-        let signInButton = app.buttons["gc_sign_in_button"]
-        XCTAssertTrue(signInButton.waitForExistence(timeout: 5),
-                      "Game Center のサインインボタンが表示されません")
-        
-        // ボタンをタップしてサインインを実行
-        signInButton.tap()
-        
-        // サインイン完了を示すラベルが表示されるかを確認
-        let authedLabel = app.staticTexts["gc_authenticated"]
-        XCTAssertTrue(authedLabel.waitForExistence(timeout: 10),
-                      "Game Center 認証が完了しません")
-        
+        // タイトル画面右上の設定ボタンを開き、設定画面経由でサインインを実施する
+        let settingsButton = app.buttons["設定"]
+        XCTAssertTrue(settingsButton.waitForExistence(timeout: 5),
+                      "タイトル画面の設定ボタンが見つかりません")
+        settingsButton.tap()
+
+        let gcSettingsButton = app.buttons["settings_gc_sign_in_button"]
+        XCTAssertTrue(gcSettingsButton.waitForExistence(timeout: 5),
+                      "設定画面の Game Center サインインボタンが表示されません")
+        gcSettingsButton.tap()
+
+        // 認証成功時のアラートが表示されるか確認し、閉じる
+        let gcAlert = app.alerts["Game Center"]
+        XCTAssertTrue(gcAlert.waitForExistence(timeout: 5),
+                      "Game Center 認証結果のアラートが表示されません")
+        gcAlert.buttons["OK"].tap()
+
+        // ステータスラベルがサインイン済みの状態になっていることを確認
+        let statusLabel = app.staticTexts["settings_gc_status_label"]
+        XCTAssertTrue(statusLabel.waitForExistence(timeout: 5),
+                      "Game Center 認証状態ラベルが更新されません")
+
+        // 設定画面を閉じてゲーム画面へ戻る
+        let closeSettingsButton = app.buttons["設定画面を閉じる"]
+        XCTAssertTrue(closeSettingsButton.waitForExistence(timeout: 2),
+                      "設定画面を閉じるボタンが見つかりません")
+        closeSettingsButton.tap()
+
         // --- インタースティシャル広告表示の確認 ---
         // 結果画面へ遷移するボタンをタップし、広告表示トリガーとする
         // アクセシビリティ識別子 "show_result" を想定

--- a/UI/GameCenterSignInPrompt.swift
+++ b/UI/GameCenterSignInPrompt.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Game Center へのサインインをユーザーへ促す際の理由を整理した列挙体
+/// - Important: 画面間でメッセージ内容を共有するために `Identifiable` を分離した構造体と組み合わせて利用する
+enum GameCenterSignInPromptReason {
+    /// アプリ起動時の自動認証が失敗した場合に表示する
+    case initialAuthenticationFailed
+    /// ランキング表示を要求したが未認証のため開けない場合に使用する
+    case leaderboardRequestedWhileUnauthenticated
+    /// スコア送信を試みたが未認証でスキップした際に利用する
+    case scoreSubmissionSkipped
+    /// 再試行でも認証に失敗したときに案内する
+    case retryFailed
+
+    /// ユーザーへ提示する本文メッセージ
+    var message: String {
+        switch self {
+        case .initialAuthenticationFailed:
+            return "Game Center へのサインインに失敗しました。通信環境を確認のうえ、再試行するか設定画面からサインインしてください。"
+        case .leaderboardRequestedWhileUnauthenticated:
+            return "ランキングを表示するには Game Center へサインインする必要があります。設定画面からサインインを実行してから再度お試しください。"
+        case .scoreSubmissionSkipped:
+            return "Game Center にサインインしていないため、今回のスコアはランキングへ送信されませんでした。設定画面からサインインすると次回以降は自動送信されます。"
+        case .retryFailed:
+            return "Game Center へのサインインに再度失敗しました。しばらく時間を置くか、設定画面から改めてサインインをお試しください。"
+        }
+    }
+}
+
+/// サインイン促しダイアログの再表示を容易にするためのラッパー
+/// - Note: 同じ理由であっても毎回固有の ID を発行し、SwiftUI の `.alert(item:)` で連続表示できるようにする
+struct GameCenterSignInPrompt: Identifiable {
+    /// アラート識別用の一意 ID
+    let id = UUID()
+    /// ユーザーへ提示する理由種別
+    let reason: GameCenterSignInPromptReason
+}


### PR DESCRIPTION
## Summary
- remove the top bar sign-in button and surface Game Center prompts via alerts
- add a Game Center section to the settings screen with manual sign-in controls
- plumb Game Center authentication state through game/result views and update UI tests for the new flow

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dcd9d93fac832c8d3e9632fba1d007