### PR TITLE
Ensure campaign activation overlay persists across view reloads

### DIFF
--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -202,6 +202,8 @@ struct CampaignStageSelectionView: View {
         }
         .buttonStyle(.plain)
         .disabled(!isUnlocked)
+        // UI テストやアクセシビリティから特定ステージを一意に参照できるようにする
+        .accessibilityIdentifier("campaign_stage_button_\(stage.id.displayCode)")
     }
 
     /// 星アイコンを生成する


### PR DESCRIPTION
## Summary
- keep the pending campaign activation work item inside `RootViewStateStore` so view regeneration does not clear it
- adjust the activation scheduling logic and campaign selector accessibility to ensure the manual start button unlocks reliably
- add a UI test that selects campaign 3-1 and waits for the loading overlay to finish before starting the stage

## Testing
- Not run (Xcode simulator is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dceada6250832cb4dc62b3332d07bd