### PR TITLE
Add standard deck presets with choice cards

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -446,13 +446,13 @@ public struct CampaignLibrary {
         let stage31 = CampaignStage(
             id: CampaignStageID(chapter: 3, index: 1),
             title: "縦横選択訓練",
-            summary: "上下左右を選べるキングカードのみで、選択操作の基礎を体感しましょう。",
+            summary: "標準デッキに上下左右を選べるキングカードを加え、選択操作の基礎を体感しましょう。",
             regulation: GameMode.Regulation(
                 boardSize: 5,
                 handSize: 5,
                 nextPreviewCount: 3,
                 allowsStacking: true,
-                deckPreset: .kingOrthogonalChoiceOnly,
+                deckPreset: .standardWithOrthogonalChoices,
                 spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 5)),
                 penalties: GameMode.PenaltySettings(
                     deadlockPenaltyCost: standardPenalties.deadlockPenaltyCost,
@@ -471,13 +471,13 @@ public struct CampaignLibrary {
         let stage32 = CampaignStage(
             id: CampaignStageID(chapter: 3, index: 2),
             title: "斜め選択応用",
-            summary: "斜め 4 方向の選択キングで角を制圧し、柔軟なルート取りを学びましょう。",
+            summary: "標準デッキへ斜め 4 方向の選択キングを加え、角マス制圧のコツを学びましょう。",
             regulation: GameMode.Regulation(
                 boardSize: 5,
                 handSize: 5,
                 nextPreviewCount: 3,
                 allowsStacking: true,
-                deckPreset: .kingDiagonalChoiceOnly,
+                deckPreset: .standardWithDiagonalChoices,
                 spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 5)),
                 penalties: GameMode.PenaltySettings(
                     deadlockPenaltyCost: standardPenalties.deadlockPenaltyCost,
@@ -496,13 +496,13 @@ public struct CampaignLibrary {
         let stage33 = CampaignStage(
             id: CampaignStageID(chapter: 3, index: 3),
             title: "桂馬選択攻略",
-            summary: "桂馬の 4 方向選択カードでジャンプし、遠距離マスを効率良く踏破しましょう。",
+            summary: "標準デッキへ桂馬の選択カードを追加し、遠距離マスを効率良く踏破しましょう。",
             regulation: GameMode.Regulation(
                 boardSize: 5,
                 handSize: 5,
                 nextPreviewCount: 3,
                 allowsStacking: true,
-                deckPreset: .knightChoiceOnly,
+                deckPreset: .standardWithKnightChoices,
                 spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 5)),
                 penalties: GameMode.PenaltySettings(
                     deadlockPenaltyCost: standardPenalties.deadlockPenaltyCost,
@@ -521,13 +521,13 @@ public struct CampaignLibrary {
         let stage34 = CampaignStage(
             id: CampaignStageID(chapter: 3, index: 4),
             title: "総合選択演習",
-            summary: "キングと桂馬の選択カードを総動員し、全方向の応用力を試しましょう。",
+            summary: "標準デッキに全選択カードを加え、全方向の応用力を試しましょう。",
             regulation: GameMode.Regulation(
                 boardSize: 5,
                 handSize: 5,
                 nextPreviewCount: 3,
                 allowsStacking: true,
-                deckPreset: .allChoiceMixed,
+                deckPreset: .standardWithAllChoices,
                 spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 5)),
                 penalties: GameMode.PenaltySettings(
                     deadlockPenaltyCost: standardPenalties.deadlockPenaltyCost,

--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -95,6 +95,91 @@ struct Deck {
             )
         }()
 
+        /// 標準デッキへ上下左右の選択キングカードを加えた構成
+        /// - Note: 標準セットの操作感を維持しながら、選択式カードの導入に慣れてもらうためのプリセット。
+        static let standardWithOrthogonalChoices: Configuration = {
+            let choiceCards: [MoveCard] = [.kingUpOrDown, .kingLeftOrRight]
+            let allowedMoves = MoveCard.standardSet + choiceCards
+            return Configuration(
+                allowedMoves: allowedMoves,
+                weightProfile: WeightProfile(defaultWeight: 1),
+                shouldApplyProbabilityReduction: true,
+                normalWeightMultiplier: 4,
+                reducedWeightMultiplier: 3,
+                reductionDuration: 5,
+                deckSummaryText: "標準＋上下左右選択キング"
+            )
+        }()
+
+        /// 標準デッキへ斜め方向の選択キングカードを追加した構成
+        /// - Note: 角方向の補完を狙う練習向けに、既存カードへ斜め選択を足した形で提供する。
+        static let standardWithDiagonalChoices: Configuration = {
+            let choiceCards: [MoveCard] = [
+                .kingUpwardDiagonalChoice,
+                .kingRightDiagonalChoice,
+                .kingDownwardDiagonalChoice,
+                .kingLeftDiagonalChoice
+            ]
+            let allowedMoves = MoveCard.standardSet + choiceCards
+            return Configuration(
+                allowedMoves: allowedMoves,
+                weightProfile: WeightProfile(defaultWeight: 1),
+                shouldApplyProbabilityReduction: true,
+                normalWeightMultiplier: 4,
+                reducedWeightMultiplier: 3,
+                reductionDuration: 5,
+                deckSummaryText: "標準＋斜め選択キング"
+            )
+        }()
+
+        /// 標準デッキへ桂馬の選択カードを加えた構成
+        /// - Note: 長距離ジャンプを補強しつつ、通常カードのドロー頻度も維持するための折衷案。
+        static let standardWithKnightChoices: Configuration = {
+            let choiceCards: [MoveCard] = [
+                .knightUpwardChoice,
+                .knightRightwardChoice,
+                .knightDownwardChoice,
+                .knightLeftwardChoice
+            ]
+            let allowedMoves = MoveCard.standardSet + choiceCards
+            return Configuration(
+                allowedMoves: allowedMoves,
+                weightProfile: WeightProfile(defaultWeight: 1),
+                shouldApplyProbabilityReduction: true,
+                normalWeightMultiplier: 4,
+                reducedWeightMultiplier: 3,
+                reductionDuration: 5,
+                deckSummaryText: "標準＋桂馬選択カード"
+            )
+        }()
+
+        /// 標準デッキへ全選択カードを網羅的に追加した構成
+        /// - Note: 最終的な多方向対応力を測るため、標準セットに全選択カード 10 種をミックスする。
+        static let standardWithAllChoices: Configuration = {
+            let choiceCards: [MoveCard] = [
+                .kingUpOrDown,
+                .kingLeftOrRight,
+                .kingUpwardDiagonalChoice,
+                .kingRightDiagonalChoice,
+                .kingDownwardDiagonalChoice,
+                .kingLeftDiagonalChoice,
+                .knightUpwardChoice,
+                .knightRightwardChoice,
+                .knightDownwardChoice,
+                .knightLeftwardChoice
+            ]
+            let allowedMoves = MoveCard.standardSet + choiceCards
+            return Configuration(
+                allowedMoves: allowedMoves,
+                weightProfile: WeightProfile(defaultWeight: 1),
+                shouldApplyProbabilityReduction: true,
+                normalWeightMultiplier: 4,
+                reducedWeightMultiplier: 3,
+                reductionDuration: 5,
+                deckSummaryText: "標準＋全選択カード"
+            )
+        }()
+
         /// クラシカルチャレンジ向け設定（桂馬のみ・均等抽選）
         static let classicalChallenge: Configuration = {
             let knightMoves = MoveCard.standardSet.filter { $0.isKnightType }

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -13,6 +13,14 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
     case kingOnly
     /// キング型カードに上下左右の選択肢を加えた構成
     case directionChoice
+    /// 標準デッキに上下左右の選択キングを加えた構成
+    case standardWithOrthogonalChoices
+    /// 標準デッキに斜め選択キングを加えた構成
+    case standardWithDiagonalChoices
+    /// 標準デッキに桂馬の選択カードを加えた構成
+    case standardWithKnightChoices
+    /// 標準デッキにすべての選択カードを加えた構成
+    case standardWithAllChoices
     /// 上下左右の選択キングカードのみで構成した訓練デッキ
     case kingOrthogonalChoiceOnly
     /// 斜め方向の選択キングカードのみで構成した訓練デッキ
@@ -36,6 +44,14 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
             return "王将構成"
         case .directionChoice:
             return "選択式キング構成"
+        case .standardWithOrthogonalChoices:
+            return "標準＋縦横選択キング構成"
+        case .standardWithDiagonalChoices:
+            return "標準＋斜め選択キング構成"
+        case .standardWithKnightChoices:
+            return "標準＋桂馬選択構成"
+        case .standardWithAllChoices:
+            return "標準＋全選択カード構成"
         case .kingOrthogonalChoiceOnly:
             return "上下左右選択キング構成"
         case .kingDiagonalChoiceOnly:
@@ -63,6 +79,14 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
             return .kingOnly
         case .directionChoice:
             return .directionChoice
+        case .standardWithOrthogonalChoices:
+            return .standardWithOrthogonalChoices
+        case .standardWithDiagonalChoices:
+            return .standardWithDiagonalChoices
+        case .standardWithKnightChoices:
+            return .standardWithKnightChoices
+        case .standardWithAllChoices:
+            return .standardWithAllChoices
         case .kingOrthogonalChoiceOnly:
             return .kingOrthogonalChoiceOnly
         case .kingDiagonalChoiceOnly:

--- a/Tests/GameTests/CampaignLibraryTests.swift
+++ b/Tests/GameTests/CampaignLibraryTests.swift
@@ -7,6 +7,31 @@ final class CampaignLibraryTests: XCTestCase {
     func testChoiceDeckPresetConfigurations() {
         let presets: [(GameDeckPreset, String, String, Set<MoveCard>)] = [
             (.directionChoice, "選択式キング構成", "選択式キングカード入り", [.kingUpOrDown, .kingLeftOrRight]),
+            (.standardWithOrthogonalChoices, "標準＋縦横選択キング構成", "標準＋上下左右選択キング", Set(MoveCard.standardSet).union([.kingUpOrDown, .kingLeftOrRight])),
+            (.standardWithDiagonalChoices, "標準＋斜め選択キング構成", "標準＋斜め選択キング", Set(MoveCard.standardSet).union([
+                .kingUpwardDiagonalChoice,
+                .kingRightDiagonalChoice,
+                .kingDownwardDiagonalChoice,
+                .kingLeftDiagonalChoice
+            ])),
+            (.standardWithKnightChoices, "標準＋桂馬選択構成", "標準＋桂馬選択カード", Set(MoveCard.standardSet).union([
+                .knightUpwardChoice,
+                .knightRightwardChoice,
+                .knightDownwardChoice,
+                .knightLeftwardChoice
+            ])),
+            (.standardWithAllChoices, "標準＋全選択カード構成", "標準＋全選択カード", Set(MoveCard.standardSet).union([
+                .kingUpOrDown,
+                .kingLeftOrRight,
+                .kingUpwardDiagonalChoice,
+                .kingRightDiagonalChoice,
+                .kingDownwardDiagonalChoice,
+                .kingLeftDiagonalChoice,
+                .knightUpwardChoice,
+                .knightRightwardChoice,
+                .knightDownwardChoice,
+                .knightLeftwardChoice
+            ])),
             (.kingOrthogonalChoiceOnly, "上下左右選択キング構成", "上下左右の選択キング限定", [.kingUpOrDown, .kingLeftOrRight]),
             (.kingDiagonalChoiceOnly, "斜め選択キング構成", "斜め選択キング限定", [
                 .kingUpwardDiagonalChoice,
@@ -38,8 +63,22 @@ final class CampaignLibraryTests: XCTestCase {
             XCTAssertEqual(preset.displayName, expectedName, "\(preset) の表示名が仕様と異なります")
             XCTAssertEqual(preset.summaryText, expectedSummary, "\(preset) の要約テキストが仕様と異なります")
 
-            let allowedMoves = Set(preset.configuration.allowedMoves)
+            let configuration = preset.configuration
+            let allowedMoves = Set(configuration.allowedMoves)
             XCTAssertTrue(expectedMoves.isSubset(of: allowedMoves), "\(preset) に必要なカードが含まれていません")
+
+            // MARK: 標準セットを内包するプリセットは全カードを含んでいるか検証する
+            let presetsRequiringStandard: Set<GameDeckPreset> = [
+                .directionChoice,
+                .standardWithOrthogonalChoices,
+                .standardWithDiagonalChoices,
+                .standardWithKnightChoices,
+                .standardWithAllChoices
+            ]
+            if presetsRequiringStandard.contains(preset) {
+                let standardMoves = Set(MoveCard.standardSet)
+                XCTAssertTrue(standardMoves.isSubset(of: allowedMoves), "標準カードが欠落しています: \(preset)")
+            }
         }
     }
 
@@ -62,25 +101,25 @@ final class CampaignLibraryTests: XCTestCase {
         }
 
         XCTAssertEqual(stage31.title, "縦横選択訓練")
-        XCTAssertEqual(stage31.regulation.deckPreset, .kingOrthogonalChoiceOnly)
+        XCTAssertEqual(stage31.regulation.deckPreset, .standardWithOrthogonalChoices)
         XCTAssertEqual(stage31.secondaryObjective, .finishWithoutPenalty)
         XCTAssertEqual(stage31.scoreTarget, 600)
         XCTAssertEqual(stage31.unlockRequirement, .stageClear(CampaignStageID(chapter: 2, index: 1)))
 
         XCTAssertEqual(stage32.title, "斜め選択応用")
-        XCTAssertEqual(stage32.regulation.deckPreset, .kingDiagonalChoiceOnly)
+        XCTAssertEqual(stage32.regulation.deckPreset, .standardWithDiagonalChoices)
         XCTAssertEqual(stage32.secondaryObjective, .finishWithinMoves(maxMoves: 32))
         XCTAssertEqual(stage32.scoreTarget, 580)
         XCTAssertEqual(stage32.unlockRequirement, .stageClear(stage31ID))
 
         XCTAssertEqual(stage33.title, "桂馬選択攻略")
-        XCTAssertEqual(stage33.regulation.deckPreset, .knightChoiceOnly)
+        XCTAssertEqual(stage33.regulation.deckPreset, .standardWithKnightChoices)
         XCTAssertEqual(stage33.secondaryObjective, .finishWithinMoves(maxMoves: 30))
         XCTAssertEqual(stage33.scoreTarget, 560)
         XCTAssertEqual(stage33.unlockRequirement, .stageClear(stage32ID))
 
         XCTAssertEqual(stage34.title, "総合選択演習")
-        XCTAssertEqual(stage34.regulation.deckPreset, .allChoiceMixed)
+        XCTAssertEqual(stage34.regulation.deckPreset, .standardWithAllChoices)
         XCTAssertEqual(stage34.secondaryObjective, .finishWithinMoves(maxMoves: 28))
         XCTAssertEqual(stage34.scoreTarget, 540)
         XCTAssertEqual(stage34.scoreTargetComparison, .lessThan)

--- a/Tests/GameTests/DeckTests.swift
+++ b/Tests/GameTests/DeckTests.swift
@@ -25,6 +25,74 @@ final class DeckTests: XCTestCase {
         XCTAssertEqual(uniqueWeights.first, 1, "標準デッキの重みが 1 以外になっています")
     }
 
+    /// 標準デッキへ縦横選択カードを追加するプリセットの内容を検証する
+    func testStandardWithOrthogonalChoicesDeckConfiguration() {
+        let config = Deck.Configuration.standardWithOrthogonalChoices
+        let allowedMoves = Set(config.allowedMoves)
+        let standardMoves = Set(MoveCard.standardSet)
+        // MARK: 標準カード群がすべて含まれていることを確認
+        XCTAssertTrue(standardMoves.isSubset(of: allowedMoves), "標準カードが欠落しています")
+        // MARK: 追加カードが正しく入っているか確認
+        let expectedChoices: Set<MoveCard> = [.kingUpOrDown, .kingLeftOrRight]
+        XCTAssertTrue(expectedChoices.isSubset(of: allowedMoves), "上下左右選択キングが不足しています")
+        // MARK: サマリー文言がプレイヤー向け説明と一致しているか検証
+        XCTAssertEqual(config.deckSummaryText, "標準＋上下左右選択キング")
+    }
+
+    /// 標準デッキへ斜め選択カードを追加するプリセットの内容を検証する
+    func testStandardWithDiagonalChoicesDeckConfiguration() {
+        let config = Deck.Configuration.standardWithDiagonalChoices
+        let allowedMoves = Set(config.allowedMoves)
+        let standardMoves = Set(MoveCard.standardSet)
+        XCTAssertTrue(standardMoves.isSubset(of: allowedMoves), "標準カードが欠落しています")
+        let expectedChoices: Set<MoveCard> = [
+            .kingUpwardDiagonalChoice,
+            .kingRightDiagonalChoice,
+            .kingDownwardDiagonalChoice,
+            .kingLeftDiagonalChoice
+        ]
+        XCTAssertTrue(expectedChoices.isSubset(of: allowedMoves), "斜め選択キングが不足しています")
+        XCTAssertEqual(config.deckSummaryText, "標準＋斜め選択キング")
+    }
+
+    /// 標準デッキへ桂馬選択カードを追加するプリセットの内容を検証する
+    func testStandardWithKnightChoicesDeckConfiguration() {
+        let config = Deck.Configuration.standardWithKnightChoices
+        let allowedMoves = Set(config.allowedMoves)
+        let standardMoves = Set(MoveCard.standardSet)
+        XCTAssertTrue(standardMoves.isSubset(of: allowedMoves), "標準カードが欠落しています")
+        let expectedChoices: Set<MoveCard> = [
+            .knightUpwardChoice,
+            .knightRightwardChoice,
+            .knightDownwardChoice,
+            .knightLeftwardChoice
+        ]
+        XCTAssertTrue(expectedChoices.isSubset(of: allowedMoves), "桂馬選択カードが不足しています")
+        XCTAssertEqual(config.deckSummaryText, "標準＋桂馬選択カード")
+    }
+
+    /// 標準デッキへ全選択カードを追加するプリセットの内容を検証する
+    func testStandardWithAllChoicesDeckConfiguration() {
+        let config = Deck.Configuration.standardWithAllChoices
+        let allowedMoves = Set(config.allowedMoves)
+        let standardMoves = Set(MoveCard.standardSet)
+        XCTAssertTrue(standardMoves.isSubset(of: allowedMoves), "標準カードが欠落しています")
+        let expectedChoices: Set<MoveCard> = [
+            .kingUpOrDown,
+            .kingLeftOrRight,
+            .kingUpwardDiagonalChoice,
+            .kingRightDiagonalChoice,
+            .kingDownwardDiagonalChoice,
+            .kingLeftDiagonalChoice,
+            .knightUpwardChoice,
+            .knightRightwardChoice,
+            .knightDownwardChoice,
+            .knightLeftwardChoice
+        ]
+        XCTAssertTrue(expectedChoices.isSubset(of: allowedMoves), "全選択カードが揃っていません")
+        XCTAssertEqual(config.deckSummaryText, "標準＋全選択カード")
+    }
+
     /// MoveCard.allCases にキング型 8 種が含まれているかを検証する
     func testMoveCardAllCasesContainsKingMoves() {
         // 期待するキング型カードを明示的に列挙し、抜け漏れを防ぐ


### PR DESCRIPTION
## Summary
- add standard deck configurations that layer choice cards on top of the standard move set
- expose the new configurations through `GameDeckPreset` and switch chapter 3 stages to use them
- expand deck and campaign tests to cover the new presets and stage assignments

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dcf4c40ee4832cb60bfa8440f3f3cb