### PR TITLE
Prevent hand refill loops with limited move signatures

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -6,6 +6,29 @@ import GameplayKit
 /// 山札を重み付き乱数で生成するデッキ構造体
 /// - Note: ゲームモードごとに許可カードや重み付けが異なるため、`Configuration` で挙動を切り替えられるようにしている。
 struct Deck {
+    /// 移動ベクトル配列を集合化する際に利用する内部シグネチャ構造体
+    /// - Note: `MoveVector` 自体は `Hashable` だが、配列として扱う際に毎回ハッシュ計算を記述するのは煩雑なため、ラッパーを用意する
+    private struct MoveSignature: Hashable {
+        /// 比較対象となる移動ベクトル列
+        let vectors: [MoveVector]
+
+        /// 明示的なイニシャライザを設けておき、意図した配列のみを扱う
+        /// - Parameter vectors: 比較したい移動ベクトル配列
+        init(vectors: [MoveVector]) {
+            self.vectors = vectors
+        }
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(vectors.count)
+            for vector in vectors {
+                hasher.combine(vector)
+            }
+        }
+
+        static func == (lhs: MoveSignature, rhs: MoveSignature) -> Bool {
+            lhs.vectors == rhs.vectors
+        }
+    }
     // MARK: - 重みプロファイル
     /// カードの基礎重みと個別上書きをまとめて扱う構造体
     /// - Note: すべてのカードに同一値を設定しつつ、一部カードのみ将来的に重みを調整したいニーズへ対応するための抽象化。
@@ -260,6 +283,14 @@ struct Deck {
         presetOriginal = []
         #endif
         reset() // 乱数源とテスト用配列を初期状態へ戻す
+    }
+
+    /// 設定から得られるユニークな移動シグネチャ数を返す
+    /// - Returns: 許可された移動ベクトル配列の種類数（重複は 1 つにまとめる）
+    func uniqueMoveSignatureCount() -> Int {
+        let signatures = configuration.allowedMoveSignatures.map { MoveSignature(vectors: $0) }
+        let unique = Set(signatures)
+        return unique.count
     }
 
     // MARK: - リセット

--- a/Tests/GameTests/HandManagerTests.swift
+++ b/Tests/GameTests/HandManagerTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import Game
+
+/// HandManager の補充ロジックを検証するテスト群
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+final class HandManagerTests: XCTestCase {
+    /// 任意のカード配列から簡易的な山札設定を生成するヘルパー
+    /// - Parameter moves: 許可したい MoveCard の配列
+    /// - Returns: テスト用に均一重み・抑制なしで構築した設定
+    private func makeConfiguration(moves: [MoveCard]) -> Deck.Configuration {
+        Deck.Configuration(
+            allowedMoves: moves,
+            weightProfile: Deck.WeightProfile(defaultWeight: 1),
+            shouldApplyProbabilityReduction: false,
+            normalWeightMultiplier: 1,
+            reducedWeightMultiplier: 1,
+            reductionDuration: 0,
+            deckSummaryText: "テスト用構成"
+        )
+    }
+
+    /// ユニーク移動パターン数が 2〜4 種類のデッキでも補充処理が完了することを確認する
+    func testRefillHandStacksTerminatesForLimitedUniqueSignatures() {
+        // それぞれ異なるユニーク数になる構成を並べ、ループで一括検証する
+        let scenarios: [(description: String, configuration: Deck.Configuration, preset: [MoveCard])] = [
+            (
+                "2種類の選択キング",
+                .kingOrthogonalChoiceOnly,
+                [.kingUpOrDown, .kingUpOrDown, .kingUpOrDown, .kingLeftOrRight, .kingUpOrDown, .kingLeftOrRight]
+            ),
+            (
+                "3種類の直線移動",
+                makeConfiguration(moves: [.kingUp, .kingRight, .kingDown]),
+                [.kingUp, .kingUp, .kingRight, .kingUp, .kingDown, .kingRight, .kingDown]
+            ),
+            (
+                "4種類の桂馬選択カード",
+                .knightChoiceOnly,
+                [.knightUpwardChoice, .knightUpwardChoice, .knightRightwardChoice, .knightDownwardChoice, .knightLeftwardChoice, .knightRightwardChoice]
+            )
+        ]
+
+        for scenario in scenarios {
+            var deck = Deck.makeTestDeck(cards: scenario.preset, configuration: scenario.configuration)
+            let uniqueCount = deck.uniqueMoveSignatureCount()
+
+            let handManager = HandManager(handSize: 5, nextPreviewCount: 0, allowsCardStacking: true)
+            handManager.refillHandStacks(using: &deck)
+
+            // ユニークシグネチャ数と手札上限の小さい方までしかスタックが作られないことを確認する
+            XCTAssertEqual(
+                handManager.handStacks.count,
+                min(5, uniqueCount),
+                "\(scenario.description) でスタック数が想定と異なります"
+            )
+        }
+    }
+
+    /// preferredInsertionIndices が上限超過していても無限ループに陥らないことを検証する
+    func testRefillHandStacksHandlesExcessPreferredInsertionIndices() {
+        let preset: [MoveCard] = [
+            .kingUpOrDown,
+            .kingLeftOrRight,
+            .kingUpOrDown,
+            .kingUpOrDown,
+            .kingLeftOrRight
+        ]
+        var deck = Deck.makeTestDeck(cards: preset, configuration: .kingOrthogonalChoiceOnly)
+        let uniqueCount = deck.uniqueMoveSignatureCount()
+
+        let handManager = HandManager(handSize: 5, nextPreviewCount: 0, allowsCardStacking: true)
+        handManager.refillHandStacks(using: &deck, preferredInsertionIndices: [0, 1, 2])
+
+        // ユニーク上限（2 種類）を超えるスタックが生成されていないかチェックする
+        XCTAssertEqual(handManager.handStacks.count, min(5, uniqueCount))
+    }
+}


### PR DESCRIPTION
## Summary
- derive the unique move signature count from the deck configuration so hand refill caps at the available patterns
- adjust HandManager refill logic to respect the capped stack count and tighten the safety counter handling
- add HandManager unit tests covering decks with 2–4 unique signatures and excess preferred insertion indices

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68dcf50936e4832cb28d17781b10d728