### PR TITLE
Refine multi-visit tile overlay rendering

### DIFF
--- a/Game/GameScenePalette.swift
+++ b/Game/GameScenePalette.swift
@@ -18,12 +18,6 @@ public struct GameScenePalette {
     /// 複数回踏破マス専用の枠線色
     /// - NOTE: 高コントラストな線色を個別に持たせ、ライト/ダーク双方で視認性を確保する
     public let boardTileMultiStroke: SKColor
-    /// 複数回踏破マス用バッジの背景色
-    /// - NOTE: リングと独立して管理し、テーマ変更時にも一貫したコントラストを確保する
-    public let boardTileMultiCounterBackground: SKColor
-    /// 複数回踏破マス用バッジの文字色
-    /// - NOTE: 残回数が即座に読み取れるよう、背景とのコントラストを最大限に取る
-    public let boardTileMultiCounterText: SKColor
     /// トグルマスの塗り色
     /// - NOTE: 踏破状態に関わらず専用色を固定し、盤面上でギミックマスを瞬時に識別できるようにする
     public let boardTileToggle: SKColor
@@ -40,8 +34,6 @@ public struct GameScenePalette {
     ///   - boardTileUnvisited: 未踏破タイル色
     ///   - boardTileMultiBase: 複数回踏破マスの基準色
     ///   - boardTileMultiStroke: 複数回踏破マス専用の枠線色
-    ///   - boardTileMultiCounterBackground: 複数回踏破マス用バッジの背景色
-    ///   - boardTileMultiCounterText: 複数回踏破マス用バッジの文字色
     ///   - boardTileToggle: トグルマスの塗り色
     ///   - boardKnight: 駒の塗り色
     ///   - boardGuideHighlight: ガイド枠の線色
@@ -52,8 +44,6 @@ public struct GameScenePalette {
         boardTileUnvisited: SKColor,
         boardTileMultiBase: SKColor,
         boardTileMultiStroke: SKColor,
-        boardTileMultiCounterBackground: SKColor,
-        boardTileMultiCounterText: SKColor,
         boardTileToggle: SKColor,
         boardKnight: SKColor,
         boardGuideHighlight: SKColor
@@ -64,8 +54,6 @@ public struct GameScenePalette {
         self.boardTileUnvisited = boardTileUnvisited
         self.boardTileMultiBase = boardTileMultiBase
         self.boardTileMultiStroke = boardTileMultiStroke
-        self.boardTileMultiCounterBackground = boardTileMultiCounterBackground
-        self.boardTileMultiCounterText = boardTileMultiCounterText
         self.boardTileToggle = boardTileToggle
         self.boardKnight = boardKnight
         self.boardGuideHighlight = boardGuideHighlight
@@ -87,10 +75,6 @@ public extension GameScenePalette {
         boardTileMultiBase: SKColor(white: 0.86, alpha: 1.0),
         // NOTE: 枠線はアクセント用のチャコールグレーを採用し、背景や塗りに埋もれない視認性を優先する
         boardTileMultiStroke: SKColor(white: 0.2, alpha: 1.0),
-        // NOTE: バッジ背景は濃いトーンで統一し、白文字と組み合わせてライトテーマでも読みやすくする
-        boardTileMultiCounterBackground: SKColor(white: 0.1, alpha: 0.88),
-        // NOTE: 白文字を採用してリングより手前でも十分なコントラストを確保する
-        boardTileMultiCounterText: SKColor(white: 1.0, alpha: 1.0),
         // NOTE: トグルマスは常に存在感を出したいので、未踏破・踏破の状態差に影響されない濃いめのグレーを採用する
         boardTileToggle: SKColor(white: 0.6, alpha: 1.0),
         boardKnight: SKColor(white: 0.1, alpha: 1.0),
@@ -108,10 +92,6 @@ public extension GameScenePalette {
         boardTileMultiBase: SKColor(white: 0.22, alpha: 1.0),
         // NOTE: ダークテーマでは淡いライトグレーを用い、背景が暗くても輪郭がぼやけないようハイコントラストを維持する
         boardTileMultiStroke: SKColor(white: 0.85, alpha: 1.0),
-        // NOTE: バッジ背景は明るいトーンを選び、黒文字と組み合わせて暗所でも視認性を確保する
-        boardTileMultiCounterBackground: SKColor(white: 0.95, alpha: 0.9),
-        // NOTE: ダークテーマでは黒文字を採用してバッジ背景とのコントラストを明確に保つ
-        boardTileMultiCounterText: SKColor(white: 0.1, alpha: 1.0),
         // NOTE: トグルマスは暗色背景でも埋もれないよう、訪問状態に左右されない明度のグレーを採用
         boardTileToggle: SKColor(white: 0.65, alpha: 1.0),
         boardKnight: SKColor(white: 0.95, alpha: 1.0),

--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -151,10 +151,6 @@ final class GameBoardBridgeViewModel: ObservableObject {
             boardTileMultiBase: appTheme.skBoardTileMultiBase,
             // NOTE: マルチ踏破マスの枠線もテーマ側で厳選したハイコントラスト色を適用する
             boardTileMultiStroke: appTheme.skBoardTileMultiStroke,
-            // NOTE: SpriteKit のバッジ背景色も SwiftUI テーマと同期させ、残回数を読みやすく保つ
-            boardTileMultiCounterBackground: appTheme.skBoardTileMultiCounterBackground,
-            // NOTE: テキスト色もテーマ管理下に置き、ライト/ダーク双方でバランスを取る
-            boardTileMultiCounterText: appTheme.skBoardTileMultiCounterText,
             boardTileToggle: appTheme.skBoardTileToggle,
             boardKnight: appTheme.skBoardKnight,
             boardGuideHighlight: appTheme.skBoardGuideHighlight

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -443,26 +443,6 @@ struct AppTheme: DynamicProperty {
         }
     }
 
-    /// 複数回踏破マス用バッジの背景色（ライトでは濃色、ダークでは淡色で反転させる）
-    var boardTileMultiCounterBackground: Color {
-        switch resolvedColorScheme {
-        case .dark:
-            return Color.white.opacity(0.88)
-        default:
-            return Color.black.opacity(0.82)
-        }
-    }
-
-    /// 複数回踏破マス用バッジの文字色（背景とのコントラストを最大化する）
-    var boardTileMultiCounterText: Color {
-        switch resolvedColorScheme {
-        case .dark:
-            return Color.black
-        default:
-            return Color.white
-        }
-    }
-
     /// トグルマスの塗り色（踏破状態に左右されない強調色）
     var boardTileToggle: Color {
         switch resolvedColorScheme {
@@ -573,22 +553,6 @@ struct AppTheme: DynamicProperty {
         )
     }
 
-    /// SpriteKit 複数回踏破マスバッジ背景色の UIColor 版
-    var uiBoardTileMultiCounterBackground: UIColor {
-        dynamicUIColor(
-            light: color(for: .light, keyPath: \.boardTileMultiCounterBackground),
-            dark: color(for: .dark, keyPath: \.boardTileMultiCounterBackground)
-        )
-    }
-
-    /// SpriteKit 複数回踏破マスバッジ文字色の UIColor 版
-    var uiBoardTileMultiCounterText: UIColor {
-        dynamicUIColor(
-            light: color(for: .light, keyPath: \.boardTileMultiCounterText),
-            dark: color(for: .dark, keyPath: \.boardTileMultiCounterText)
-        )
-    }
-
     /// SpriteKit トグルマス色の UIColor 版
     var uiBoardTileToggle: UIColor {
         dynamicUIColor(
@@ -632,16 +596,6 @@ struct AppTheme: DynamicProperty {
 
     /// SpriteKit の SKColor へ変換した複数回踏破マス枠線色
     var skBoardTileMultiStroke: SKColor { SKColor(cgColor: uiBoardTileMultiStroke.cgColor) }
-
-    /// SpriteKit の SKColor へ変換した複数回踏破マスバッジ背景色
-    var skBoardTileMultiCounterBackground: SKColor {
-        SKColor(cgColor: uiBoardTileMultiCounterBackground.cgColor)
-    }
-
-    /// SpriteKit の SKColor へ変換した複数回踏破マスバッジ文字色
-    var skBoardTileMultiCounterText: SKColor {
-        SKColor(cgColor: uiBoardTileMultiCounterText.cgColor)
-    }
 
     /// SpriteKit の SKColor へ変換したトグルマス色
     var skBoardTileToggle: SKColor { SKColor(cgColor: uiBoardTileToggle.cgColor) }


### PR DESCRIPTION
## Summary
- replace the multi-visit ring/counter with a reusable decoration container that splits each tile into triangular progress segments and draws diagonal guides
- stabilize multi-visit base coloring and detect unexpected requirements while simplifying the GameScene palette interface
- remove unused badge colors from the app theme and update the SpriteKit bridge to the streamlined palette

## Testing
- swift test


------
https://chatgpt.com/codex/tasks/task_e_68dd1bd57eec832c9c1d81b1df9ec55e