### PR TITLE
Improve board tile contrast for multi-visit tiles

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -726,12 +726,27 @@ public final class GameScene: SKScene {
         let initialFill = max(0, min(4, 4 - requiredVisits))
         let completedVisits = max(0, min(requiredVisits, requiredVisits - clampedRemaining))
         let filledSegmentCount = max(0, min(4, initialFill + completedVisits))
+        let activeSegmentCount = max(0, min(4, initialFill + requiredVisits))
+
+        // 部分踏破の残量を視覚的に把握しやすいよう、塗り色を 3 段階に分ける
+        let completedColor = palette.boardTileVisited.withAlphaComponent(0.95)
+        let pendingColor = palette.boardTileMultiBase.withAlphaComponent(0.9)
+        let inactiveColor = palette.boardTileMultiBase.withAlphaComponent(0.55)
 
         for (index, triangle) in MultiVisitTriangle.allCases.enumerated() {
             guard let segmentNode = decoration.segments[triangle] else { continue }
-            segmentNode.fillColor = index < filledSegmentCount
-                ? palette.boardTileVisited
-                : palette.boardTileMultiBase
+
+            if index < filledSegmentCount {
+                // 既に踏破したセグメントは踏破済みカラーで強調表示する
+                segmentNode.fillColor = completedColor
+            } else if index < activeSegmentCount {
+                // まだ踏破していない残り回数は基準色を濃く残し、未達成領域として認識しやすくする
+                segmentNode.fillColor = pendingColor
+            } else {
+                // 要求回数を超える領域は淡くし、進捗対象外であることを明示する
+                segmentNode.fillColor = inactiveColor
+            }
+
             segmentNode.isHidden = false
         }
 

--- a/Game/GameScenePalette.swift
+++ b/Game/GameScenePalette.swift
@@ -69,10 +69,10 @@ public extension GameScenePalette {
     static let fallbackLight = GameScenePalette(
         boardBackground: SKColor(white: 0.94, alpha: 1.0),
         boardGridLine: SKColor(white: 0.15, alpha: 1.0),
-        boardTileVisited: SKColor(white: 0.75, alpha: 1.0),
-        boardTileUnvisited: SKColor(white: 0.98, alpha: 1.0),
-        // NOTE: 複数回踏破マスでは段階的に暗くなるグレートーンを基準とし、踏破進捗の差が分かりやすいようにする
-        boardTileMultiBase: SKColor(white: 0.86, alpha: 1.0),
+        boardTileVisited: SKColor(white: 0.68, alpha: 1.0),
+        boardTileUnvisited: SKColor(white: 0.95, alpha: 1.0),
+        // NOTE: SwiftUI テーマの 18% 相当（白 82% 付近）に合わせ、踏破済みとの明確な階調差をキープする
+        boardTileMultiBase: SKColor(white: 0.82, alpha: 1.0),
         // NOTE: 枠線はアクセント用のチャコールグレーを採用し、背景や塗りに埋もれない視認性を優先する
         boardTileMultiStroke: SKColor(white: 0.2, alpha: 1.0),
         // NOTE: トグルマスは常に存在感を出したいので、未踏破・踏破の状態差に影響されない濃いめのグレーを採用する
@@ -86,10 +86,10 @@ public extension GameScenePalette {
     static let fallbackDark = GameScenePalette(
         boardBackground: SKColor(white: 0.05, alpha: 1.0),
         boardGridLine: SKColor(white: 0.75, alpha: 1.0),
-        boardTileVisited: SKColor(white: 0.35, alpha: 1.0),
-        boardTileUnvisited: SKColor(white: 0.12, alpha: 1.0),
-        // NOTE: ライトテーマ同様にグレートーンを段階的に変化させ、暗所でも進捗を追いやすくする
-        boardTileMultiBase: SKColor(white: 0.22, alpha: 1.0),
+        boardTileVisited: SKColor(white: 0.52, alpha: 1.0),
+        boardTileUnvisited: SKColor(white: 0.18, alpha: 1.0),
+        // NOTE: SwiftUI テーマと同様に 28% 程度の白を採用し、暗背景でも踏破段階が判別しやすい基準色に統一する
+        boardTileMultiBase: SKColor(white: 0.28, alpha: 1.0),
         // NOTE: ダークテーマでは淡いライトグレーを用い、背景が暗くても輪郭がぼやけないようハイコントラストを維持する
         boardTileMultiStroke: SKColor(white: 0.85, alpha: 1.0),
         // NOTE: トグルマスは暗色背景でも埋もれないよう、訪問状態に左右されない明度のグレーを採用

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -405,9 +405,11 @@ struct AppTheme: DynamicProperty {
     var boardTileVisited: Color {
         switch resolvedColorScheme {
         case .dark:
-            return Color.white.opacity(0.35)
+            // ダークテーマでは背景とのメリハリを強めるため、半透明の白を大きめに設定する
+            return Color.white.opacity(0.52)
         default:
-            return Color.black.opacity(0.18)
+            // ライトテーマでは未踏破との差がひと目で分かる濃さ（約 32%）まで不透明度を引き上げる
+            return Color.black.opacity(0.32)
         }
     }
 
@@ -415,9 +417,11 @@ struct AppTheme: DynamicProperty {
     var boardTileUnvisited: Color {
         switch resolvedColorScheme {
         case .dark:
-            return Color.white.opacity(0.05)
+            // 暗所でもマスの輪郭を把握しやすいよう、うっすらと光が当たった程度の 8% まで持ち上げる
+            return Color.white.opacity(0.08)
         default:
-            return Color.black.opacity(0.03)
+            // まったくの透明だと盤面の境界が迷子になるため、わずかに灰色を乗せた 5% を採用する
+            return Color.black.opacity(0.05)
         }
     }
 
@@ -425,9 +429,11 @@ struct AppTheme: DynamicProperty {
     var boardTileMultiBase: Color {
         switch resolvedColorScheme {
         case .dark:
-            return Color.white.opacity(0.18)
+            // 部分踏破中の進捗を段階的に表すため、未踏破より明るく踏破済みより暗い 28% を中心値に設定
+            return Color.white.opacity(0.28)
         default:
-            return Color.black.opacity(0.1)
+            // ライトテーマも同じ思想で、未踏破 5% と踏破済み 32% の中間となる 18% を基準色とする
+            return Color.black.opacity(0.18)
         }
     }
 


### PR DESCRIPTION
## Summary
- raise the opacity of visited, unvisited, and multi-visit board tiles in the shared theme to provide clearer contrast in both light and dark modes
- synchronize the SpriteKit fallback palette with the updated contrast values so the board remains consistent before the theme loads
- refine multi-visit decoration filling to use three-step coloring that highlights completed, pending, and inactive segments

## Testing
- not run (UI color adjustments)


------
https://chatgpt.com/codex/tasks/task_e_68dd96c72198832c9992617851b033cf