### PR TITLE
Add home navigation buttons to gameplay and result screens

### DIFF
--- a/UI/GameBoardControlRowView.swift
+++ b/UI/GameBoardControlRowView.swift
@@ -129,6 +129,7 @@ private extension GameBoardControlRowView {
             manualDiscardButton
             manualPenaltyButton
             pauseButton
+            returnToTitleButton
         }
     }
 
@@ -214,6 +215,32 @@ private extension GameBoardControlRowView {
         .accessibilityIdentifier("pause_menu_button")
         .accessibilityLabel(Text("ポーズメニュー"))
         .accessibilityHint(Text("プレイを一時停止して設定やリセットを確認します"))
+    }
+
+    /// タイトルへ戻るボタン
+    /// - Note: リセットと同等の破壊的操作になるため、必ず確認ダイアログを経由させる
+    var returnToTitleButton: some View {
+        Button {
+            // 直接終了せず確認ダイアログを表示して誤操作を防ぐ
+            viewModel.requestReturnToTitle()
+        } label: {
+            Image(systemName: "house")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundColor(theme.menuIconForeground)
+                .frame(width: 44, height: 44)
+                .background(
+                    Circle()
+                        .fill(theme.menuIconBackground)
+                )
+                .overlay(
+                    Circle()
+                        .stroke(theme.menuIconBorder, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("return_to_title_button")
+        .accessibilityLabel(Text("ホームへ戻る"))
+        .accessibilityHint(Text("プレイを終了してタイトル画面へ戻ります"))
     }
 
     /// 統計バッジ 1 枚分の共通レイアウト

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -193,6 +193,10 @@ struct GameView: View {
                     // ViewModel 側でリセットと広告フラグの再設定をまとめて処理する
                     viewModel.handleResultRetry()
                 },
+                onReturnToTitle: {
+                    // ホーム復帰時の初期化と遷移要求を ViewModel 側で統一的に処理する
+                    viewModel.handleResultReturnToTitle()
+                },
                 gameCenterService: viewModel.gameCenterService,
                 adsService: viewModel.adsService
             )

--- a/UI/GameViewModel.swift
+++ b/UI/GameViewModel.swift
@@ -513,6 +513,12 @@ final class GameViewModel: ObservableObject {
         pendingMenuAction = .manualPenalty(penaltyCost: core.mode.manualRedrawPenaltyCost)
     }
 
+    /// ホームボタンの押下をトリガーに、タイトルへ戻る確認ダイアログを表示する
+    /// - Note: 直接リセットを実行せず、一度 pendingMenuAction へ格納して既存の確認フローを流用する
+    func requestReturnToTitle() {
+        pendingMenuAction = .returnToTitle
+    }
+
     /// ポーズメニューを表示する
     /// - Note: ログ出力もここでまとめて行い、UI 側の責務を軽量化する
     func presentPauseMenu() {
@@ -585,6 +591,13 @@ final class GameViewModel: ObservableObject {
     /// 結果画面からリトライを選択した際の共通処理
     func handleResultRetry() {
         resetSessionForNewPlay()
+    }
+
+    /// リザルト画面からホームへ戻るリクエストを受け取った際の共通処理
+    /// - Note: リトライ時と同じ初期化を行った上で、ルートビューへ遷移要求を転送する
+    func handleResultReturnToTitle() {
+        resetSessionForNewPlay()
+        onRequestReturnToTitle?()
     }
 
     /// 手札選択状態を初期化し、盤面ハイライトを消去する

--- a/UI/ResultView.swift
+++ b/UI/ResultView.swift
@@ -34,6 +34,8 @@ struct ResultView: View {
     let onSelectCampaignStage: ((CampaignStage) -> Void)?
     /// 再戦処理を外部から受け取るクロージャ
     let onRetry: () -> Void
+    /// ホームへ戻る操作を外部へ依頼するクロージャ（未指定の場合はボタンを表示しない）
+    let onReturnToTitle: (() -> Void)?
 
     /// Game Center 連携を扱うサービス（プロトコル型で受け取る）
     /// `init` 時にのみ代入し、以後は再代入しないがテスト用に差し替えられるよう `var` で定義
@@ -70,7 +72,8 @@ struct ResultView: View {
         campaignClearRecord: CampaignStageClearRecord? = nil,
         newlyUnlockedStages: [CampaignStage] = [],
         onSelectCampaignStage: ((CampaignStage) -> Void)? = nil,
-        onRetry: @escaping () -> Void
+        onRetry: @escaping () -> Void,
+        onReturnToTitle: (() -> Void)? = nil
     ) {
         // 既定値はメインアクター上で解決し、Game Center サービスの状態を同期させる
         let resolvedIsAuthenticated = isGameCenterAuthenticated ?? GameCenterService.shared.isAuthenticated
@@ -87,6 +90,7 @@ struct ResultView: View {
             newlyUnlockedStages: newlyUnlockedStages,
             onSelectCampaignStage: onSelectCampaignStage,
             onRetry: onRetry,
+            onReturnToTitle: onReturnToTitle,
             gameCenterService: GameCenterService.shared,
             adsService: AdsService.shared
         )
@@ -105,6 +109,7 @@ struct ResultView: View {
         newlyUnlockedStages: [CampaignStage] = [],
         onSelectCampaignStage: ((CampaignStage) -> Void)? = nil,
         onRetry: @escaping () -> Void,
+        onReturnToTitle: (() -> Void)? = nil,
 
         gameCenterService: GameCenterServiceProtocol,
         adsService: AdsServiceProtocol
@@ -130,6 +135,7 @@ struct ResultView: View {
         self.newlyUnlockedStages = newlyUnlockedStages
         self.onSelectCampaignStage = onSelectCampaignStage
         self.onRetry = onRetry
+        self.onReturnToTitle = onReturnToTitle
         self.gameCenterService = resolvedGameCenterService
         self.adsService = resolvedAdsService
     }
@@ -188,6 +194,21 @@ struct ResultView: View {
                 // MARK: - キャンペーン用のリワード達成表示
                 if let record = campaignClearRecord {
                     campaignRewardSummary(for: record)
+                }
+
+                // MARK: - ホームボタン（指定がある場合のみ表示）
+                if let onReturnToTitle {
+                    Button {
+                        // 成功ハプティクスで操作完了をフィードバックする
+                        if hapticsEnabled {
+                            UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        }
+                        onReturnToTitle()
+                    } label: {
+                        Label("ホームへ戻る", systemImage: "house")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
                 }
 
                 // MARK: - リトライボタン


### PR DESCRIPTION
## Summary
- add a home button to the in-game control cluster that routes through the existing confirmation flow
- provide an optional home button on the result screen that resets state and asks the root view to return to title
- centralize the view model logic for both in-game and result screen home navigation requests

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dd98849fdc832ca2ee96359a9386a2