### PR TITLE
Update board tile palette to new grayscale spec

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -592,8 +592,8 @@ public final class GameScene: SKScene {
             // トグルマスは踏破状態に関わらず専用色で固定し、ギミックの存在を明確に示す
             return palette.boardTileToggle
         case .multi:
-            // 四分割三角形で進捗を示すため、ベースの塗りは固定色とし、全セグメント完了時に踏破済み色へ切り替える
-            return state.isVisited ? palette.boardTileVisited : palette.boardTileMultiBase
+            // 四分割三角形で進捗を示すため、ベースの塗りは未踏破色を維持し、全セグメント完了時に踏破済み色へ切り替える
+            return state.isVisited ? palette.boardTileVisited : palette.boardTileUnvisited
         case .single:
             // 通常マスは従来通りの配色で未踏破と踏破済みを切り替える
             return state.isVisited ? palette.boardTileVisited : palette.boardTileUnvisited
@@ -730,8 +730,8 @@ public final class GameScene: SKScene {
 
         // 部分踏破の残量を視覚的に把握しやすいよう、塗り色を 3 段階に分ける
         let completedColor = palette.boardTileVisited.withAlphaComponent(0.95)
-        let pendingColor = palette.boardTileMultiBase.withAlphaComponent(0.9)
-        let inactiveColor = palette.boardTileMultiBase.withAlphaComponent(0.55)
+        let pendingColor = palette.boardTileUnvisited.withAlphaComponent(0.9)
+        let inactiveColor = palette.boardTileUnvisited.withAlphaComponent(0.55)
 
         for (index, triangle) in MultiVisitTriangle.allCases.enumerated() {
             guard let segmentNode = decoration.segments[triangle] else { continue }

--- a/Game/GameScenePalette.swift
+++ b/Game/GameScenePalette.swift
@@ -69,10 +69,11 @@ public extension GameScenePalette {
     static let fallbackLight = GameScenePalette(
         boardBackground: SKColor(white: 0.94, alpha: 1.0),
         boardGridLine: SKColor(white: 0.15, alpha: 1.0),
-        boardTileVisited: SKColor(white: 0.68, alpha: 1.0),
+        // NOTE: SwiftUI 側の踏破済みカラー変更に合わせ、濃いグレー (18%) を踏破完了時の基準に統一する
+        boardTileVisited: SKColor(white: 0.82, alpha: 1.0),
         boardTileUnvisited: SKColor(white: 0.95, alpha: 1.0),
-        // NOTE: SwiftUI テーマの 18% 相当（白 82% 付近）に合わせ、踏破済みとの明確な階調差をキープする
-        boardTileMultiBase: SKColor(white: 0.82, alpha: 1.0),
+        // NOTE: マルチ踏破のベースは未踏破と同じトーンを採用し、段階演出はオーバーレイで表現する
+        boardTileMultiBase: SKColor(white: 0.95, alpha: 1.0),
         // NOTE: 枠線はアクセント用のチャコールグレーを採用し、背景や塗りに埋もれない視認性を優先する
         boardTileMultiStroke: SKColor(white: 0.2, alpha: 1.0),
         // NOTE: トグルマスは常に存在感を出したいので、未踏破・踏破の状態差に影響されない濃いめのグレーを採用する
@@ -86,10 +87,11 @@ public extension GameScenePalette {
     static let fallbackDark = GameScenePalette(
         boardBackground: SKColor(white: 0.05, alpha: 1.0),
         boardGridLine: SKColor(white: 0.75, alpha: 1.0),
-        boardTileVisited: SKColor(white: 0.52, alpha: 1.0),
+        // NOTE: ダークテーマでも踏破済みは 28% の白に統一し、完了時の判別を確実にする
+        boardTileVisited: SKColor(white: 0.28, alpha: 1.0),
         boardTileUnvisited: SKColor(white: 0.18, alpha: 1.0),
-        // NOTE: SwiftUI テーマと同様に 28% 程度の白を採用し、暗背景でも踏破段階が判別しやすい基準色に統一する
-        boardTileMultiBase: SKColor(white: 0.28, alpha: 1.0),
+        // NOTE: マルチ踏破のベース色も未踏破トーンに合わせ、踏破オーバーレイとのメリハリを最大化する
+        boardTileMultiBase: SKColor(white: 0.18, alpha: 1.0),
         // NOTE: ダークテーマでは淡いライトグレーを用い、背景が暗くても輪郭がぼやけないようハイコントラストを維持する
         boardTileMultiStroke: SKColor(white: 0.85, alpha: 1.0),
         // NOTE: トグルマスは暗色背景でも埋もれないよう、訪問状態に左右されない明度のグレーを採用

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -401,15 +401,15 @@ struct AppTheme: DynamicProperty {
         }
     }
 
-    /// 踏破済みマスの塗り色（透明度で差を付け視認性を確保）
+    /// 踏破済みマスの塗り色（マルチ踏破マス完了時とトーンを揃える）
     var boardTileVisited: Color {
         switch resolvedColorScheme {
         case .dark:
-            // ダークテーマでは背景とのメリハリを強めるため、半透明の白を大きめに設定する
-            return Color.white.opacity(0.52)
+            // ダークテーマではマルチ踏破の完了色と統一し、踏破完了時の色変化を明確にする
+            return Color.white.opacity(0.28)
         default:
-            // ライトテーマでは未踏破との差がひと目で分かる濃さ（約 32%）まで不透明度を引き上げる
-            return Color.black.opacity(0.32)
+            // ライトテーマでも同じ思想で 18% の黒を重ね、踏破済みマスの濃いグレーを共通化する
+            return Color.black.opacity(0.18)
         }
     }
 
@@ -425,16 +425,11 @@ struct AppTheme: DynamicProperty {
         }
     }
 
-    /// 複数回踏破マスの基準色（進捗表示用に未踏破色よりもワントーン濃く設定）
+    /// 複数回踏破マスの基準色（未踏破マスと同じトーンから段階演出をスタートさせる）
     var boardTileMultiBase: Color {
-        switch resolvedColorScheme {
-        case .dark:
-            // 部分踏破中の進捗を段階的に表すため、未踏破より明るく踏破済みより暗い 28% を中心値に設定
-            return Color.white.opacity(0.28)
-        default:
-            // ライトテーマも同じ思想で、未踏破 5% と踏破済み 32% の中間となる 18% を基準色とする
-            return Color.black.opacity(0.18)
-        }
+        // NOTE: マルチ踏破の進捗段階はオーバーレイで表現するため、ベース色は未踏破マスと同一にする
+        //       これにより、踏破完了時に踏破済みカラーへ切り替わるコントラストが最大化される
+        return boardTileUnvisited
     }
 
     /// 複数回踏破マス専用の枠線色（高コントラストのグレートーンを採用）


### PR DESCRIPTION
## Summary
- align the visited tile colors with the darker gray specification in both SwiftUI and SpriteKit fallbacks
- derive multi-visit base colors from the unvisited tone so progress overlays start from the same baseline
- update SpriteKit multi-tile shading logic to rely on the refreshed palette choices

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68dd9bfbaeb4832c85cab5e891651acb