### PR TITLE
Adjust control row padding fallback for overlay-free cases

### DIFF
--- a/MonoKnightAppTests/GameViewLayoutCalculatorTests.swift
+++ b/MonoKnightAppTests/GameViewLayoutCalculatorTests.swift
@@ -45,5 +45,36 @@ final class GameViewLayoutCalculatorTests: XCTestCase {
         // 記録用の topOverlayHeight にはオーバーレイ量がそのまま反映されていることも確認
         XCTAssertEqual(context.topOverlayHeight, 44, accuracy: 0.001, "オーバーレイ高さの記録値が想定と異なります")
     }
+
+    /// トップオーバーレイが存在せず、セーフエリア測定値と基準値が一致するケースでは
+    /// コントロール行の余白が 16pt へ収束することを確認する
+    func testControlRowPaddingConvergesToBaseWhenOverlayIsZero() {
+        // iPhone（ノッチあり）で RootView 側のセーフエリア計測値と GeometryReader の値が等しいケースを想定
+        let parameters = GameViewLayoutParameters(
+            size: CGSize(width: 390, height: 844),
+            safeAreaTop: 47,
+            safeAreaBottom: 34
+        )
+
+        // トップオーバーレイ 0 / 統計 120pt / 手札 260pt の構成で計算
+        let calculator = GameViewLayoutCalculator(
+            parameters: parameters,
+            horizontalSizeClass: .compact,
+            topOverlayHeight: 0,
+            baseTopSafeAreaInset: 47,
+            statisticsHeight: 120,
+            handSectionHeight: 260
+        )
+
+        let context = calculator.makeContext()
+
+        // 追加余白が発生しないため、コントロール行の余白は 16pt に一致するはず
+        XCTAssertEqual(
+            context.controlRowTopPadding,
+            GameViewLayoutMetrics.controlRowBaseTopPadding,
+            accuracy: 0.001,
+            "コントロール行の余白が基準値からずれています"
+        )
+    }
 }
 

--- a/UI/GameViewLayoutSupport.swift
+++ b/UI/GameViewLayoutSupport.swift
@@ -202,10 +202,13 @@ struct GameViewLayoutCalculator {
         // overlayCompensation（= topOverlayHeight）をそのまま足し込んでしまうと二重で距離が開いてしまう。
         // そこでトップバーで増えた高さを差し引いた残差だけを安全余白として扱い、
         // ステータスバー由来の領域に限って追加のマージン（controlRowSafeAreaAdditionalPadding）を加える。
-        let safeAreaRemainderWithoutOverlay = max(overlayAdjustedTopInset - overlayCompensation, 0)
+        // オーバーレイに依存しないセーフエリア差分のみを抽出し、
+        // 追加で確保すべき余白を算出する。オーバーレイが存在しない場合は 0 となり、
+        // 基準マージン（16pt）へ自然に収束する。
+        let overlayIndependentAdditionalPadding = max(overlayAdjustedTopInset - baseSafeAreaTop, 0)
         let controlRowTopPadding = max(
             GameViewLayoutMetrics.controlRowBaseTopPadding,
-            safeAreaRemainderWithoutOverlay + GameViewLayoutMetrics.controlRowSafeAreaAdditionalPadding
+            overlayIndependentAdditionalPadding + GameViewLayoutMetrics.controlRowSafeAreaAdditionalPadding
         )
 
         // MARK: - 手札セクション下部の余白を決定


### PR DESCRIPTION
## Summary
- update the control row padding calculation to rely on overlay-independent safe area deltas so overlay-free layouts converge to the 16pt baseline
- add a regression test that verifies the baseline padding when the overlay height is zero and the safe area reference matches the geometry

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dd9de402c4832c832c50a6d3b2841c