### PR TITLE
Add warning when board tap conflicts require card selection

### DIFF
--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -245,6 +245,17 @@ struct GameView: View {
         } message: { action in
             Text(action.confirmationMessage)
         }
+        // 盤面タップで複数の複数候補カードが同一点を指し示した場合に、手札選択を促す警告アラートを表示する
+        .alert(item: $viewModel.boardTapSelectionWarning) { warning in
+            Alert(
+                title: Text("カード選択が必要です"),
+                message: Text(warning.message),
+                dismissButton: .default(Text("閉じる")) {
+                    // アラート閉鎖後は ViewModel 側の状態をリセットし、同じ警告を再度表示できるようにする
+                    viewModel.clearBoardTapSelectionWarning()
+                }
+            )
+        }
     }
 
     /// メニュー操作を実際に実行する共通処理


### PR DESCRIPTION
## Summary
- add an Identifiable board tap selection warning payload to the game view model and trigger it when multiple multi-vector cards target the same destination without a selected hand card
- present the warning message from GameView via an alert so players are prompted to pick a hand card before tapping the board again
- cover the conflicting multi-candidate scenario with a new integration test to ensure no animation starts and the warning is emitted

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ddc8a3e9ac832ca3d8e732ff26f8b6