### PR TITLE
Adjust multi-vector board tap warning detection

### DIFF
--- a/UI/GameViewModel.swift
+++ b/UI/GameViewModel.swift
@@ -463,14 +463,9 @@ final class GameViewModel: ObservableObject {
             let destinationCandidates = availableMoves.filter { $0.destination == request.destination }
 
             if destinationCandidates.count >= 2 {
-                // stackID ごとの候補数を集計し、単一候補カードが存在しない状況かつ複数スタックで競合しているか調べる
-                let candidateCountByStack = Dictionary(
-                    grouping: availableMoves,
-                    by: { $0.stackID }
-                ).mapValues { $0.count }
-
+                // 同一点を指す候補のうち、カード自体が複数方向ベクトルを持つスタックだけを抽出する（盤外で候補数が減っても判定できるようにする）
                 let conflictingStackIDs = destinationCandidates.reduce(into: Set<UUID>()) { partialResult, candidate in
-                    if let count = candidateCountByStack[candidate.stackID], count > 1 {
+                    if candidate.card.move.movementVectors.count > 1 {
                         partialResult.insert(candidate.stackID)
                     }
                 }


### PR DESCRIPTION
## Summary
- refine the board tap conflict check to treat multi-vector cards using their movement vector count and warn when multiple stacks converge on the same tile
- add an integration test that reproduces a corner case where out-of-bounds vectors leave only one reachable direction per multi-vector card while still requiring a warning

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ddcf73bf84832c95f853553a32ef3a