### PR TITLE
Fix HighScoreChallengeSelectionView initializer access

### DIFF
--- a/UI/HighScoreChallengeSelectionView.swift
+++ b/UI/HighScoreChallengeSelectionView.swift
@@ -13,7 +13,23 @@ struct HighScoreChallengeSelectionView: View {
     let bestScoreDescription: String
 
     /// 共通の配色を扱うテーマ
-    private var theme = AppTheme()
+    private let theme = AppTheme()
+
+    /// 画面表示に必要な依存関係を受け取りプロパティへ格納する
+    /// - Parameters:
+    ///   - onSelect: モード選択時にタイトル画面へ通知するクロージャ
+    ///   - onClose: ナビゲーションを戻すためのクロージャ
+    ///   - bestScoreDescription: 直近のベストスコアを案内する文字列
+    init(
+        onSelect: @escaping (GameMode) -> Void,
+        onClose: @escaping () -> Void,
+        bestScoreDescription: String
+    ) {
+        // 外部から渡された依存関係をそのまま保持して画面内で利用する
+        self.onSelect = onSelect
+        self.onClose = onClose
+        self.bestScoreDescription = bestScoreDescription
+    }
 
     /// 画面に表示するカード情報の配列
     private var modeCards: [ModeCardData] {


### PR DESCRIPTION
## Summary
- add an explicit initializer for `HighScoreChallengeSelectionView` so it can be constructed from `RootView`
- keep the view's theme dependency internal by storing it as an immutable property

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ddd39c2814832c91d8b916dd07fcc4