### PR TITLE
Add Chapter 5 obstacle stage and impassable tile handling

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -592,6 +592,48 @@ public struct CampaignLibrary {
             stages: [stage41]
         )
 
-        return [chapter1, chapter2, chapter3, chapter4]
+        // MARK: - 5 章のステージ群
+        // 指示された (1,2) と (3,4) の移動不可マスは 1 始まり指定のため、0 始まりへ変換して格納する。
+        let impassablePointsChapter5: Set<GridPoint> = [
+            GridPoint(x: 0, y: 1),
+            GridPoint(x: 2, y: 3)
+        ]
+
+        // 5-1 は障害物を迂回しながら 5×5 を踏破する終盤訓練。移動不可マスでルート判断が難しくなる点を強調する。
+        let stage51 = CampaignStage(
+            id: CampaignStageID(chapter: 5, index: 1),
+            title: "障害物突破演習",
+            summary: "移動不可マスが配置された 5×5 で安全なルートを見極め、障害物を迂回する練習です。",
+            regulation: GameMode.Regulation(
+                boardSize: 5,
+                handSize: 5,
+                nextPreviewCount: 3,
+                allowsStacking: true,
+                deckPreset: .standard,
+                spawnRule: .fixed(BoardGeometry.defaultSpawnPoint(for: 5)),
+                penalties: GameMode.PenaltySettings(
+                    deadlockPenaltyCost: standardPenalties.deadlockPenaltyCost,
+                    manualRedrawPenaltyCost: standardPenalties.manualRedrawPenaltyCost,
+                    manualDiscardPenaltyCost: standardPenalties.manualDiscardPenaltyCost,
+                    revisitPenaltyCost: standardPenalties.revisitPenaltyCost
+                ),
+                impassableTilePoints: impassablePointsChapter5
+            ),
+            // MARK: 2 個目のスター条件: 障害物で狭まったルートでも 27 手以内で踏破しきる判断力を養う
+            secondaryObjective: .finishWithinMoves(maxMoves: 27),
+            // MARK: 3 個目のスター条件: 行き止まり回避とタイムマネジメントを両立し、スコア 500 以下にまとめる
+            scoreTarget: 500,
+            scoreTargetComparison: .lessThan,
+            unlockRequirement: .stageClear(stage41.id)
+        )
+
+        let chapter5 = CampaignChapter(
+            id: 5,
+            title: "障害物訓練", // 新章は移動不可マスの攻略に特化
+            summary: "移動不可マスのルート選択を学ぶ章。",
+            stages: [stage51]
+        )
+
+        return [chapter1, chapter2, chapter3, chapter4, chapter5]
     }
 }

--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -89,7 +89,8 @@ public final class GameCore: ObservableObject {
             size: mode.boardSize,
             initialVisitedPoints: mode.initialVisitedPoints,
             requiredVisitOverrides: mode.additionalVisitRequirements,
-            togglePoints: mode.toggleTilePoints
+            togglePoints: mode.toggleTilePoints,
+            impassablePoints: mode.impassableTilePoints
         )
         current = mode.initialSpawnPoint ?? BoardGeometry.defaultSpawnPoint(for: mode.boardSize)
         deck = Deck(configuration: mode.deckConfiguration)
@@ -252,8 +253,9 @@ public final class GameCore: ObservableObject {
             // MoveCard.movementVectors が保持する全候補を展開し、1 ベクトルずつ ResolvedCardMove に変換する
             for vector in topCard.move.movementVectors {
                 let destination = origin.offset(dx: vector.dx, dy: vector.dy)
-                // 盤面外の移動は候補から除外
+                // 盤面外や移動不可マスへの移動は候補から除外
                 guard activeBoard.contains(destination) else { continue }
+                guard !mode.impassableTilePoints.contains(destination) else { continue }
 
                 resolved.append(
                     ResolvedCardMove(
@@ -438,6 +440,7 @@ extension GameCore {
     func handleSpawnSelection(at point: GridPoint) {
         guard mode.requiresSpawnSelection, progress == .awaitingSpawn else { return }
         guard board.contains(point) else { return }
+        guard !mode.impassableTilePoints.contains(point) else { return }
 
         debugLog("スポーン位置を \(point) に確定")
         current = point
@@ -503,13 +506,15 @@ extension GameCore {
                 size: mode.boardSize,
                 initialVisitedPoints: [resolvedCurrent],
                 requiredVisitOverrides: mode.additionalVisitRequirements,
-                togglePoints: mode.toggleTilePoints
+                togglePoints: mode.toggleTilePoints,
+                impassablePoints: mode.impassableTilePoints
             )
         } else {
             core.board = Board(
                 size: mode.boardSize,
                 requiredVisitOverrides: mode.additionalVisitRequirements,
-                togglePoints: mode.toggleTilePoints
+                togglePoints: mode.toggleTilePoints,
+                impassablePoints: mode.impassableTilePoints
             )
         }
         core.current = resolvedCurrent

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -289,6 +289,9 @@ public struct GameMode: Equatable, Identifiable {
         /// - Important: 同じ座標に `additionalVisitRequirements` が存在する場合はトグルが優先され、
         ///   ギミックとして 1 回踏むごとに踏破⇔未踏破が反転する。
         public var toggleTilePoints: Set<GridPoint> = []
+        /// 侵入禁止として扱う移動不可マス集合
+        /// - Important: 複数踏破やトグルよりも優先度が高い制約として扱い、候補手・スポーン位置ともに除外する
+        public var impassableTilePoints: Set<GridPoint> = []
 
         /// レギュレーションを組み立てるためのイニシャライザ
         /// - Parameters:
@@ -308,7 +311,8 @@ public struct GameMode: Equatable, Identifiable {
             spawnRule: SpawnRule,
             penalties: PenaltySettings,
             additionalVisitRequirements: [GridPoint: Int] = [:],
-            toggleTilePoints: Set<GridPoint> = []
+            toggleTilePoints: Set<GridPoint> = [],
+            impassableTilePoints: Set<GridPoint> = []
         ) {
             self.boardSize = boardSize
             self.handSize = handSize
@@ -319,6 +323,7 @@ public struct GameMode: Equatable, Identifiable {
             self.penalties = penalties
             self.additionalVisitRequirements = additionalVisitRequirements
             self.toggleTilePoints = toggleTilePoints
+            self.impassableTilePoints = impassableTilePoints
         }
     }
 
@@ -499,6 +504,8 @@ public struct GameMode: Equatable, Identifiable {
     public var additionalVisitRequirements: [GridPoint: Int] { regulation.additionalVisitRequirements }
     /// トグル挙動を割り当てたマス集合
     public var toggleTilePoints: Set<GridPoint> { regulation.toggleTilePoints }
+    /// 侵入禁止として扱う移動不可マス集合
+    public var impassableTilePoints: Set<GridPoint> { regulation.impassableTilePoints }
 
     /// スタンダードモード（既存仕様）
     public static var standard: GameMode {

--- a/Game/GameScenePalette.swift
+++ b/Game/GameScenePalette.swift
@@ -21,6 +21,8 @@ public struct GameScenePalette {
     /// トグルマスの塗り色
     /// - NOTE: 踏破状態に関わらず専用色を固定し、盤面上でギミックマスを瞬時に識別できるようにする
     public let boardTileToggle: SKColor
+    /// 移動不可マスの塗り色
+    public let boardTileImpassable: SKColor
     /// 駒の塗り色
     public let boardKnight: SKColor
     /// ガイド枠の線色
@@ -34,30 +36,33 @@ public struct GameScenePalette {
     ///   - boardTileUnvisited: 未踏破タイル色
     ///   - boardTileMultiBase: 複数回踏破マスの基準色
     ///   - boardTileMultiStroke: 複数回踏破マス専用の枠線色
-    ///   - boardTileToggle: トグルマスの塗り色
-    ///   - boardKnight: 駒の塗り色
-    ///   - boardGuideHighlight: ガイド枠の線色
-    public init(
-        boardBackground: SKColor,
-        boardGridLine: SKColor,
-        boardTileVisited: SKColor,
-        boardTileUnvisited: SKColor,
-        boardTileMultiBase: SKColor,
-        boardTileMultiStroke: SKColor,
-        boardTileToggle: SKColor,
-        boardKnight: SKColor,
-        boardGuideHighlight: SKColor
-    ) {
-        self.boardBackground = boardBackground
-        self.boardGridLine = boardGridLine
-        self.boardTileVisited = boardTileVisited
-        self.boardTileUnvisited = boardTileUnvisited
-        self.boardTileMultiBase = boardTileMultiBase
-        self.boardTileMultiStroke = boardTileMultiStroke
-        self.boardTileToggle = boardTileToggle
-        self.boardKnight = boardKnight
-        self.boardGuideHighlight = boardGuideHighlight
-    }
+        ///   - boardTileToggle: トグルマスの塗り色
+        ///   - boardTileImpassable: 移動不可マスの塗り色
+        ///   - boardKnight: 駒の塗り色
+        ///   - boardGuideHighlight: ガイド枠の線色
+        public init(
+            boardBackground: SKColor,
+            boardGridLine: SKColor,
+            boardTileVisited: SKColor,
+            boardTileUnvisited: SKColor,
+            boardTileMultiBase: SKColor,
+            boardTileMultiStroke: SKColor,
+            boardTileToggle: SKColor,
+            boardTileImpassable: SKColor,
+            boardKnight: SKColor,
+            boardGuideHighlight: SKColor
+        ) {
+            self.boardBackground = boardBackground
+            self.boardGridLine = boardGridLine
+            self.boardTileVisited = boardTileVisited
+            self.boardTileUnvisited = boardTileUnvisited
+            self.boardTileMultiBase = boardTileMultiBase
+            self.boardTileMultiStroke = boardTileMultiStroke
+            self.boardTileToggle = boardTileToggle
+            self.boardTileImpassable = boardTileImpassable
+            self.boardKnight = boardKnight
+            self.boardGuideHighlight = boardGuideHighlight
+        }
 }
 
 public extension GameScenePalette {
@@ -78,6 +83,8 @@ public extension GameScenePalette {
         boardTileMultiStroke: SKColor(white: 0.2, alpha: 1.0),
         // NOTE: トグルマスは常に存在感を出したいので、未踏破・踏破の状態差に影響されない濃いめのグレーを採用する
         boardTileToggle: SKColor(white: 0.6, alpha: 1.0),
+        // NOTE: 移動不可マスは黒に近いトーンで統一し、障害物であることを即座に理解できるようにする
+        boardTileImpassable: SKColor(white: 0.15, alpha: 1.0),
         boardKnight: SKColor(white: 0.1, alpha: 1.0),
         // NOTE: SwiftUI のライトテーマと同じ彩度を抑えたオレンジを採用し、テーマ適用前でも一貫した強調色を維持する
         boardGuideHighlight: SKColor(red: 0.94, green: 0.41, blue: 0.08, alpha: 0.85)
@@ -96,6 +103,8 @@ public extension GameScenePalette {
         boardTileMultiStroke: SKColor(white: 0.85, alpha: 1.0),
         // NOTE: トグルマスは暗色背景でも埋もれないよう、訪問状態に左右されない明度のグレーを採用
         boardTileToggle: SKColor(white: 0.65, alpha: 1.0),
+        // NOTE: 移動不可マスはライト/ダーク共通で濃いトーンに固定し、障害物の視認性を優先する
+        boardTileImpassable: SKColor(white: 0.08, alpha: 1.0),
         boardKnight: SKColor(white: 0.95, alpha: 1.0),
         // NOTE: ダークテーマに合わせて明度を上げたオレンジを用い、背景の暗さに負けない発光感を演出する
         boardGuideHighlight: SKColor(red: 1.0, green: 0.74, blue: 0.38, alpha: 0.9)

--- a/Tests/GameTests/CampaignLibraryTests.swift
+++ b/Tests/GameTests/CampaignLibraryTests.swift
@@ -131,14 +131,12 @@ final class CampaignLibraryTests: XCTestCase {
         let library = CampaignLibrary.shared
         let stage41ID = CampaignStageID(chapter: 4, index: 1)
 
-        // MARK: 章配列が 4 章まで拡張されているか明示的に確認する
-        XCTAssertEqual(library.chapters.count, 4, "キャンペーンの章数が 4 章構成になっていません")
-        XCTAssertEqual(library.chapters.last?.id, 4, "最終章の ID が 4 になっていません")
-
         guard let stage41 = library.stage(with: stage41ID) else {
             XCTFail("第4章 4-1 の定義が見つかりません")
             return
         }
+
+        XCTAssertTrue(library.chapters.contains(where: { $0.id == 4 }), "第4章が章一覧へ含まれていません")
 
         // MARK: 基本情報（タイトル・サマリー・盤面サイズ）が仕様通りかを検証
         XCTAssertEqual(stage41.title, "反転制御訓練")
@@ -159,5 +157,41 @@ final class CampaignLibraryTests: XCTestCase {
         // MARK: アンロック条件が 3-4 クリアに紐付いているかを確認
         let prerequisiteID = CampaignStageID(chapter: 3, index: 4)
         XCTAssertEqual(stage41.unlockRequirement, .stageClear(prerequisiteID))
+    }
+
+    /// 5 章の移動不可マス訓練が仕様通りに組み込まれているかを確認する
+    func testCampaignStage5Definitions() {
+        let library = CampaignLibrary.shared
+        let stage51ID = CampaignStageID(chapter: 5, index: 1)
+        let stage41ID = CampaignStageID(chapter: 4, index: 1)
+
+        // MARK: 章配列が 5 章まで拡張されているか確認する
+        XCTAssertEqual(library.chapters.count, 5, "キャンペーンの章数が 5 章構成になっていません")
+        XCTAssertEqual(library.chapters.last?.id, 5, "最終章の ID が 5 になっていません")
+
+        guard let stage51 = library.stage(with: stage51ID) else {
+            XCTFail("第5章 5-1 の定義が見つかりません")
+            return
+        }
+
+        // MARK: 基本情報（タイトル・サマリー・盤面サイズ）が障害物訓練を表しているか検証
+        XCTAssertEqual(stage51.title, "障害物突破演習")
+        XCTAssertTrue(stage51.summary.contains("移動不可"), "サマリーに移動不可マスへの言及がありません")
+        XCTAssertEqual(stage51.regulation.boardSize, 5)
+
+        // MARK: 移動不可マスが 0 始まりの (0,1) と (2,3) に設定されているか確認
+        let expectedImpassablePoints: Set<GridPoint> = [
+            GridPoint(x: 0, y: 1),
+            GridPoint(x: 2, y: 3)
+        ]
+        XCTAssertEqual(stage51.regulation.impassableTilePoints, expectedImpassablePoints)
+
+        // MARK: スター条件・スコア条件が仕様通りかを確認
+        XCTAssertEqual(stage51.secondaryObjective, .finishWithinMoves(maxMoves: 27))
+        XCTAssertEqual(stage51.scoreTarget, 500)
+        XCTAssertEqual(stage51.scoreTargetComparison, .lessThan)
+
+        // MARK: アンロック条件が 4-1 クリアに紐付いているかを確認
+        XCTAssertEqual(stage51.unlockRequirement, .stageClear(stage41ID))
     }
 }

--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -88,7 +88,8 @@ final class GameBoardBridgeViewModel: ObservableObject {
             initialBoardSize: mode.boardSize,
             initialVisitedPoints: mode.initialVisitedPoints,
             requiredVisitOverrides: mode.additionalVisitRequirements,
-            togglePoints: mode.toggleTilePoints
+            togglePoints: mode.toggleTilePoints,
+            impassablePoints: mode.impassableTilePoints
         )
         preparedScene.scaleMode = .resizeFill
         preparedScene.gameCore = core
@@ -152,6 +153,7 @@ final class GameBoardBridgeViewModel: ObservableObject {
             // NOTE: マルチ踏破マスの枠線もテーマ側で厳選したハイコントラスト色を適用する
             boardTileMultiStroke: appTheme.skBoardTileMultiStroke,
             boardTileToggle: appTheme.skBoardTileToggle,
+            boardTileImpassable: appTheme.skBoardTileImpassable,
             boardKnight: appTheme.skBoardKnight,
             boardGuideHighlight: appTheme.skBoardGuideHighlight
         )

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -454,6 +454,16 @@ struct AppTheme: DynamicProperty {
         }
     }
 
+    /// 移動不可マスの塗り色（障害物として一目で判別できるよう濃いトーンを採用）
+    var boardTileImpassable: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            return Color(white: 0.08)
+        default:
+            return Color(white: 0.15)
+        }
+    }
+
     /// 駒本体の塗り色（背景に応じて反転させコントラストを維持）
     var boardKnight: Color {
         switch resolvedColorScheme {
@@ -562,6 +572,14 @@ struct AppTheme: DynamicProperty {
         )
     }
 
+    /// SpriteKit 移動不可マス色の UIColor 版
+    var uiBoardTileImpassable: UIColor {
+        dynamicUIColor(
+            light: color(for: .light, keyPath: \.boardTileImpassable),
+            dark: color(for: .dark, keyPath: \.boardTileImpassable)
+        )
+    }
+
     /// SpriteKit 駒の UIColor 版
     var uiBoardKnight: UIColor {
         dynamicUIColor(
@@ -600,6 +618,8 @@ struct AppTheme: DynamicProperty {
 
     /// SpriteKit の SKColor へ変換したトグルマス色
     var skBoardTileToggle: SKColor { SKColor(cgColor: uiBoardTileToggle.cgColor) }
+    /// SpriteKit の SKColor へ変換した移動不可マス色
+    var skBoardTileImpassable: SKColor { SKColor(cgColor: uiBoardTileImpassable.cgColor) }
 
     /// SpriteKit の SKColor へ変換した駒の塗り色
     var skBoardKnight: SKColor { SKColor(cgColor: uiBoardKnight.cgColor) }


### PR DESCRIPTION
## Summary
- add Chapter 5 "障害物突破演習" with impassable tiles, new star/score goals, and updated campaign chapter list
- introduce impassable tile regulation support across board logic, game core, and SpriteKit/AppTheme rendering
- update campaign tests to cover the fifth chapter definitions and impassable tile expectations

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ddefdcec28832cbea5e2a5c727503c