### PR TITLE
Adjust board tile contrast for board tiles

### DIFF
--- a/Game/GameScenePalette.swift
+++ b/Game/GameScenePalette.swift
@@ -75,11 +75,11 @@ public extension GameScenePalette {
     static let fallbackLight = GameScenePalette(
         boardBackground: SKColor(white: 0.94, alpha: 1.0),
         boardGridLine: SKColor(white: 0.15, alpha: 1.0),
-        // NOTE: SwiftUI 側の踏破済みカラー変更に合わせ、濃いグレー (18%) を踏破完了時の基準に統一する
-        boardTileVisited: SKColor(white: 0.82, alpha: 1.0),
-        boardTileUnvisited: SKColor(white: 0.95, alpha: 1.0),
-        // NOTE: マルチ踏破のベースは未踏破と同じトーンを採用し、段階演出はオーバーレイで表現する
-        boardTileMultiBase: SKColor(white: 0.95, alpha: 1.0),
+        // NOTE: SwiftUI のライトテーマと同じく黒成分 30% (≈70% ホワイト) へ合わせ、未踏破との差分 (約27.5%) を明示的に確保する
+        boardTileVisited: SKColor(white: 0.70, alpha: 1.0),
+        boardTileUnvisited: SKColor(white: 0.975, alpha: 1.0),
+        // NOTE: マルチ踏破のベースも未踏破と同じ 97.5% ホワイトに揃え、進捗演出をオーバーレイ側へ集約する
+        boardTileMultiBase: SKColor(white: 0.975, alpha: 1.0),
         // NOTE: 枠線はアクセント用のチャコールグレーを採用し、背景や塗りに埋もれない視認性を優先する
         boardTileMultiStroke: SKColor(white: 0.2, alpha: 1.0),
         // NOTE: トグルマスは常に存在感を出したいので、未踏破・踏破の状態差に影響されない濃いめのグレーを採用する
@@ -95,11 +95,11 @@ public extension GameScenePalette {
     static let fallbackDark = GameScenePalette(
         boardBackground: SKColor(white: 0.05, alpha: 1.0),
         boardGridLine: SKColor(white: 0.75, alpha: 1.0),
-        // NOTE: ダークテーマでも踏破済みは 28% の白に統一し、完了時の判別を確実にする
-        boardTileVisited: SKColor(white: 0.28, alpha: 1.0),
-        boardTileUnvisited: SKColor(white: 0.18, alpha: 1.0),
-        // NOTE: マルチ踏破のベース色も未踏破トーンに合わせ、踏破オーバーレイとのメリハリを最大化する
-        boardTileMultiBase: SKColor(white: 0.18, alpha: 1.0),
+        // NOTE: ダークテーマは白成分 38% を基準にし、未踏破との差分 (約33%) を確実に保って踏破完了のコントラストを向上させる
+        boardTileVisited: SKColor(white: 0.38, alpha: 1.0),
+        boardTileUnvisited: SKColor(white: 0.05, alpha: 1.0),
+        // NOTE: マルチ踏破のベースも未踏破と同じ 5% ホワイトへ寄せ、進行オーバーレイによる変化を明確化する
+        boardTileMultiBase: SKColor(white: 0.05, alpha: 1.0),
         // NOTE: ダークテーマでは淡いライトグレーを用い、背景が暗くても輪郭がぼやけないようハイコントラストを維持する
         boardTileMultiStroke: SKColor(white: 0.85, alpha: 1.0),
         // NOTE: トグルマスは暗色背景でも埋もれないよう、訪問状態に左右されない明度のグレーを採用

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -405,11 +405,11 @@ struct AppTheme: DynamicProperty {
     var boardTileVisited: Color {
         switch resolvedColorScheme {
         case .dark:
-            // ダークテーマではマルチ踏破の完了色と統一し、踏破完了時の色変化を明確にする
-            return Color.white.opacity(0.28)
+            // ダークテーマでは白成分を 38% まで引き上げ、未踏破との差分 (約33%) を確保して踏破完了時の変化をより強調する
+            return Color.white.opacity(0.38)
         default:
-            // ライトテーマでも同じ思想で 18% の黒を重ね、踏破済みマスの濃いグレーを共通化する
-            return Color.black.opacity(0.18)
+            // ライトテーマでは黒成分を 30% まで増やし、未踏破との差分 (約27.5%) を担保してコントラストを底上げする
+            return Color.black.opacity(0.30)
         }
     }
 
@@ -417,11 +417,11 @@ struct AppTheme: DynamicProperty {
     var boardTileUnvisited: Color {
         switch resolvedColorScheme {
         case .dark:
-            // 暗所でもマスの輪郭を把握しやすいよう、うっすらと光が当たった程度の 8% まで持ち上げる
-            return Color.white.opacity(0.08)
+            // ダークテーマでは白成分を 5% まで抑え、踏破済みとの差分 (約33%) を維持しつつ背景になじませる
+            return Color.white.opacity(0.05)
         default:
-            // まったくの透明だと盤面の境界が迷子になるため、わずかに灰色を乗せた 5% を採用する
-            return Color.black.opacity(0.05)
+            // ライトテーマでは黒成分を 2.5% 付与し、踏破済みとの差分 (約27.5%) を保ちながら盤面の奥行きを残す
+            return Color.black.opacity(0.025)
         }
     }
 


### PR DESCRIPTION
## Summary
- deepen visited tile tone in the light theme and lighten the unvisited tone to secure a ~27.5% brightness gap
- raise visited tile white component and lower unvisited tone in the dark theme to secure a ~33% contrast gap
- document the intent and target brightness differences in both SwiftUI and SpriteKit palettes for future theme updates

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de0674c958832cb267605d589785bd