### PR TITLE
Enable immediate theme refresh in settings view

### DIFF
--- a/UI/SettingsView.swift
+++ b/UI/SettingsView.swift
@@ -466,6 +466,10 @@ struct SettingsView: View {
                     storeAlert = .purchaseCompleted
                 }
             }
+            // 設定画面表示中でも `@AppStorage` の更新に合わせてカラースキームを反映させ、閉じる操作を待たずにテーマ変更が視覚化されるようにする。
+            .preferredColorScheme(
+                ThemePreference(rawValue: preferredColorSchemeRawValue)?.preferredColorScheme
+            )
         }
         // デバッグ用パスコード入力成功時に状態を明示するアラートを表示し、検証モードへの切り替えを周知する。
         .alert("全ステージを解放しました", isPresented: $isDebugUnlockSuccessAlertPresented) {


### PR DESCRIPTION
## Summary
- apply the preferred color scheme modifier to the settings navigation stack so theme changes render immediately while the screen is open

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de05ad31c0832ca2957ee7a2114918