### PR TITLE
Fix return-to-title handling in RootContentView

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -509,7 +509,7 @@ private extension RootView {
                     isReady: isGameReadyForManualStart,
                     onCancel: {
                         // ローディング中にタイトルへ戻りたい場合のハンドラを橋渡しする
-                        handleReturnToTitleRequest()
+                        onReturnToTitle()
                     },
                     onStart: {
                         // ユーザーが明示的に開始したタイミングでローディングを閉じる


### PR DESCRIPTION
## Summary
- route the game preparation cancel action through the injected return-to-title closure to avoid referencing the parent view directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de079d6290832ca6699ea711f33f46