### PR TITLE
Hide default back button on high score selection

### DIFF
--- a/UI/HighScoreChallengeSelectionView.swift
+++ b/UI/HighScoreChallengeSelectionView.swift
@@ -65,6 +65,8 @@ struct HighScoreChallengeSelectionView: View {
         .background(theme.backgroundPrimary.ignoresSafeArea())
         .navigationTitle("ハイスコア")
         .navigationBarTitleDisplayMode(.inline)
+        // 標準の戻るボタンを非表示にして、ツールバーの戻る導線へ挙動を統一する
+        .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 backButton


### PR DESCRIPTION
## Summary
- hide the standard navigation back button on the high score selection view so the toolbar button provides the sole back navigation

## Testing
- not run (simulator unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de167b9d60832ca3e7f3942a5285d0