### PR TITLE
Improve how-to-play button contrast

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -1487,9 +1487,11 @@ fileprivate struct TitleScreenView: View {
                 .font(.system(size: 16, weight: .medium, design: .rounded))
                 .frame(maxWidth: .infinity)
         }
-        .buttonStyle(.bordered)
-        .tint(.white.opacity(0.8))
-        .foregroundColor(.white)
+        .buttonStyle(.borderedProminent)
+        // ライト/ダーク双方でアクセントカラーがしっかり視認できるようテーマの色を適用
+        .tint(theme.accentPrimary)
+        // アクセント上の文字色もテーマから参照し、コントラスト要件を満たす
+        .foregroundColor(theme.accentOnPrimary)
         .controlSize(.large)
         .accessibilityIdentifier("title_how_to_play_button")
         // VoiceOver でモーダルが開くことを伝える


### PR DESCRIPTION
## Summary
- switch the how-to-play button to use the prominent bordered style
- apply theme-provided accent colors to maintain contrast in light and dark modes

## Testing
- not run (Xcode UI preview unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de16eee46c832c9d47d838caded1c4