### PR TITLE
Show how to play screen in full screen

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -1420,8 +1420,9 @@ fileprivate struct TitleScreenView: View {
                     navigationDestinationView(for: target)
                 }
         }
-        .sheet(isPresented: $isPresentingHowToPlay) {
-            howToPlaySheetContent
+        .fullScreenCover(isPresented: $isPresentingHowToPlay) {
+            // MARK: - 遊び方画面は全画面で表示し、iPhone でもコンテンツが埋もれないようにする
+            howToPlayFullScreenContent
         }
         .onChange(of: isPresentingHowToPlay) { _, newValue in
             debugLog("TitleScreenView.isPresentingHowToPlay 更新: \(newValue)")
@@ -1730,14 +1731,11 @@ fileprivate struct TitleScreenView: View {
     }
 
     @ViewBuilder
-    private var howToPlaySheetContent: some View {
+    private var howToPlayFullScreenContent: some View {
         NavigationStack {
+            // MARK: - ナビゲーションバーを持たせて閉じるボタンを自然に配置する
             HowToPlayView(showsCloseButton: true)
         }
-        .presentationDetents(
-            horizontalSizeClass == .regular ? [.large] : [.medium, .large]
-        )
-        .presentationDragIndicator(.visible)
     }
 
     private func handleTileTapLogging(for target: TitleNavigationTarget) {


### PR DESCRIPTION
## Summary
- present the how-to-play instructions as a full-screen cover from the title screen
- keep the embedded NavigationStack so the close button remains available

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68de1834c824832caf528ab93e21aef5