### PR TITLE
Update campaign stage selection toolbar controls

### DIFF
--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -14,12 +14,8 @@ struct CampaignStageSelectionView: View {
     let onClose: () -> Void
     /// ナビゲーションバーに閉じるボタンを表示するかどうか
     let showsCloseButton: Bool
-    /// ホームボタンを表示するかどうか（デフォルトで表示）
-    let showsHomeButton: Bool
     /// ステージ決定時のハンドラ
     let onSelectStage: (CampaignStage) -> Void
-    /// ホームボタン押下時のハンドラ
-    private let onTapHome: () -> Void
 
     /// テーマカラー
     private var theme = AppTheme()
@@ -32,17 +28,13 @@ struct CampaignStageSelectionView: View {
     ///   - onClose: ビューを閉じるためのコールバック
     ///   - onSelectStage: ステージ選択確定時に呼び出されるコールバック
     ///   - showsCloseButton: ナビゲーションバーへ「閉じる」ボタンを表示するかどうか
-    ///   - showsHomeButton: 画面上部にホームへ戻るボタンを表示するかどうか
-    ///   - onTapHome: ホームボタン押下時に実行する処理（未指定時は `onClose` と同一挙動）
     init(
         campaignLibrary: CampaignLibrary,
         progressStore: CampaignProgressStore,
         selectedStageID: CampaignStageID?,
         onClose: @escaping () -> Void,
         onSelectStage: @escaping (CampaignStage) -> Void,
-        showsCloseButton: Bool = true,
-        showsHomeButton: Bool = true,
-        onTapHome: (() -> Void)? = nil
+        showsCloseButton: Bool = true
     ) {
         // @ObservedObject プロパティはラッパー経由で代入する必要があるため、明示的に初期化する
         self.campaignLibrary = campaignLibrary
@@ -51,8 +43,6 @@ struct CampaignStageSelectionView: View {
         self.onClose = onClose
         self.onSelectStage = onSelectStage
         self.showsCloseButton = showsCloseButton
-        self.showsHomeButton = showsHomeButton
-        self.onTapHome = onTapHome ?? onClose
     }
 
     var body: some View {
@@ -75,46 +65,14 @@ struct CampaignStageSelectionView: View {
         }
         .navigationTitle("キャンペーン")
         .navigationBarBackButtonHidden(true)
-        .safeAreaInset(edge: .top) {
-            if showsCloseButton || showsHomeButton {
-                HStack(spacing: 12) {
-                    if showsHomeButton {
-                        Button {
-                            // ホームに戻る際の挙動を記録し、ナビゲーションの想定外遷移を追跡しやすくする
-                            debugLog("CampaignStageSelectionView.toolbar: ホームボタン押下 -> Title画面へ戻る要求")
-                            onTapHome()
-                        } label: {
-                            Label("ホーム", systemImage: "house.fill")
-                                .font(.system(size: 15, weight: .semibold, design: .rounded))
-                                .foregroundStyle(theme.textPrimary)
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 8)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                        .fill(theme.backgroundElevated.opacity(0.9))
-                                )
-                        }
-                        .accessibilityLabel("ホーム画面に戻る")
-                        .buttonStyle(.plain)
-                    }
-
-                    Spacer()
-
-                    if showsCloseButton {
-                        Button("閉じる") {
-                            // ナビゲーションスタックをポップする契機を記録し、手動クローズのトレースを取りやすくする
-                            debugLog("CampaignStageSelectionView.toolbar: 閉じるボタン押下 -> NavigationStackポップ要求")
-                            onClose()
-                        }
-                        .buttonStyle(.plain)
-                    }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                backButton
+            }
+            if showsCloseButton {
+                ToolbarItem(placement: .cancellationAction) {
+                    closeButton
                 }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 10)
-                .background(.thinMaterial)
-            } else {
-                // safeAreaInset の ResultBuilder が Void を返さないよう、非表示時は EmptyView を明示する
-                EmptyView()
             }
         }
         // ステージ一覧の表示状態を追跡し、遷移の成否をログで確認できるようにする
@@ -319,5 +277,32 @@ struct CampaignStageSelectionView: View {
         }
     }
 
+}
+
+// MARK: - ツールバー構成要素
+
+private extension CampaignStageSelectionView {
+    /// タイトル画面へ戻るための独自戻るボタン
+    var backButton: some View {
+        Button {
+            // ユーザーが戻る操作を行ったタイミングをログに残し、意図しない遷移がないか追跡しやすくする
+            debugLog("CampaignStageSelectionView.toolbar: 戻るボタン押下 -> NavigationStackポップ要求")
+            onClose()
+        } label: {
+            Label("戻る", systemImage: "chevron.backward")
+                .font(.system(size: 15, weight: .medium, design: .rounded))
+        }
+        .accessibilityIdentifier("campaign_stage_back_button")
+    }
+
+    /// モーダル表示時に使用する「閉じる」ボタン
+    var closeButton: some View {
+        Button("閉じる") {
+            // モーダルの閉鎖契機を明示的に記録し、想定外の dismiss が起きた際の比較材料とする
+            debugLog("CampaignStageSelectionView.toolbar: 閉じるボタン押下 -> NavigationStackポップ要求")
+            onClose()
+        }
+        .buttonStyle(.plain)
+    }
 }
 

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -1686,8 +1686,7 @@ fileprivate struct TitleScreenView: View {
                         DispatchQueue.main.async {
                             triggerImmediateStart(for: mode, context: context)
                         }
-                    },
-                    showsCloseButton: false
+                    }
                 )
                 .onAppear {
                     debugLog("TitleScreenView: NavigationDestination.campaign 表示 -> 現在のスタック数=\(navigationPath.count)")


### PR DESCRIPTION
## Summary
- キャンペーンステージ選択画面からホームボタン関連のプロパティと safe area UI を削除
- ツールバーに戻るボタンと閉じるボタンを配置して HighScoreSelection と挙動を揃える
- 初期化シグネチャ変更に合わせて RootView の呼び出しを更新

## Testing
- not run (UI のロジック変更のみ)


------
https://chatgpt.com/codex/tasks/task_e_68de1a5f5d48832c82f72ef1ec837773