### PR TITLE
Add campaign-specific pause handling for session timer

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -373,6 +373,20 @@ public final class GameCore: ObservableObject {
         elapsedSeconds = sessionTimer.elapsedSeconds
     }
 
+    /// 一時停止ボタンなどからの操作でタイマーを停止する
+    /// - Parameter referenceDate: 一時停止が発生した時刻（テスト時に明示指定したい場合に利用）
+    public func pauseTimer(referenceDate: Date = Date()) {
+        // プレイ中以外では停止させる必要がないため、進行状態を確認した上で処理する
+        guard progress == .playing else { return }
+        sessionTimer.beginPause(at: referenceDate)
+    }
+
+    /// 停止中のタイマーを再開する
+    /// - Parameter referenceDate: 再開する時刻（テストでは任意の値を指定できるようにする）
+    public func resumeTimer(referenceDate: Date = Date()) {
+        sessionTimer.endPause(at: referenceDate)
+    }
+
     /// クリア時点の経過時間を確定させる
     /// - Parameter referenceDate: テスト時などに任意の終了時刻を指定したい場合に利用
     private func finalizeElapsedTimeIfNeeded(referenceDate: Date = Date()) {
@@ -566,6 +580,13 @@ extension GameCore {
     func setStartDateForTesting(_ newStartDate: Date) {
         // リアルタイム計測は GameSessionTimer を経由して算出されるため、テストから開始時刻を操作可能にしておく。
         sessionTimer.overrideStartDateForTesting(newStartDate)
+    }
+
+    /// 任意の時刻を基準にライブ計測値を取得するテスト専用ヘルパー
+    /// - Parameter referenceDate: 計測に利用したい時刻
+    /// - Returns: 指定時点での経過秒数
+    func liveElapsedSecondsForTesting(asOf referenceDate: Date) -> Int {
+        sessionTimer.liveElapsedSeconds(asOf: referenceDate)
     }
 }
 #endif

--- a/UI/GameView+Observers.swift
+++ b/UI/GameView+Observers.swift
@@ -62,6 +62,10 @@ extension GameView {
                 // 旧設定との差分を検知したタイミングでハプティクス制御ロジックを更新し、無効化時の誤振動を防ぐ
                 viewModel.updateHapticsSetting(isEnabled: isEnabled)
             }
+            // scenePhase の変化を監視し、キャンペーン時のみタイマーの一時停止/再開を委譲する
+            .onChange(of: scenePhase) { newPhase in
+                viewModel.handleScenePhaseChange(newPhase)
+            }
             // 経過時間を 1 秒ごとに再計算し、リアルタイム表示へ反映
             .onReceive(viewModel.elapsedTimer) { _ in
                 viewModel.updateDisplayedElapsedTime()

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -23,6 +23,9 @@ struct GameView: View {
     /// - Note: 監視系ロジックを別ファイルへ分割しているため、`fileprivate` にするとアクセスできずビルドエラーとなる。
     ///         そのためアクセスレベルはデフォルト（internal）のままにして、同一モジュール内の拡張から安全に参照できるようにしている。
     @Environment(\.colorScheme) var colorScheme
+    /// シーンフェーズを監視し、アプリが非アクティブになったタイミングでタイマー制御を委譲する
+    /// - Note: 監視ロジックは `GameView+Observers` 側で適用するため、同一モジュール内から参照できるようアクセスレベルを維持する
+    @Environment(\.scenePhase) var scenePhase
     /// デバイスの横幅サイズクラスを取得し、iPad などレギュラー幅でのモーダル挙動を調整する
     /// - Note: レイアウト計算用の拡張（`GameView+Layout`）でも参照するため、アクセスレベルは internal に緩和している
     @Environment(\.horizontalSizeClass) var horizontalSizeClass


### PR DESCRIPTION
## Summary
- add pause tracking to `GameSessionTimer` and expose begin/end pause helpers
- provide `GameCore`/`GameViewModel` APIs to pause or resume timers for campaign play and react to scene phase changes
- update SwiftUI observers and unit tests to cover pause menu and background timing differences between campaign and leaderboard modes

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68de1b7085c4832cb8bcd31c4f876b3c