### PR TITLE
Fix SwiftUI onChange deprecation warnings

### DIFF
--- a/UI/GameView+Observers.swift
+++ b/UI/GameView+Observers.swift
@@ -48,22 +48,23 @@ extension GameView {
                 viewModel.refreshGuideHighlights()
             }
             // 手札の並び設定が変わったら即座にゲームロジックへ伝え、UI の並びも更新する
-            .onChange(of: handOrderingRawValue) { _, newValue in
+            .onChange(of: handOrderingRawValue, initial: false) { _, newValue in
                 // AppStorage から受け取った新しい手札並び設定を即座に適用し、設定画面とゲーム画面の差異をなくす
                 viewModel.applyHandOrderingStrategy(rawValue: newValue)
             }
             // ガイドモードのオン/オフを切り替えたら即座に ViewModel 側へ委譲する
-            .onChange(of: guideModeEnabled) { _, isEnabled in
-                // 新しいガイドモード状態を SpriteKit へ伝え、盤面表示の補助情報を同期する
+            .onChange(of: guideModeEnabled, initial: false) { _, isEnabled in
+                // 新しいガイドモード状態を SpriteKit へ伝え、盤面表示の助情報を同期する
                 viewModel.updateGuideMode(enabled: isEnabled)
             }
             // ハプティクス設定が切り替わった際も ViewModel へ伝え、サービス呼び出しを統一する
-            .onChange(of: hapticsEnabled) { _, isEnabled in
+            .onChange(of: hapticsEnabled, initial: false) { _, isEnabled in
                 // 旧設定との差分を検知したタイミングでハプティクス制御ロジックを更新し、無効化時の誤振動を防ぐ
                 viewModel.updateHapticsSetting(isEnabled: isEnabled)
             }
             // scenePhase の変化を監視し、キャンペーン時のみタイマーの一時停止/再開を委譲する
-            .onChange(of: scenePhase) { newPhase in
+            .onChange(of: scenePhase, initial: false) { _, newPhase in
+                // 旧値は利用しないため破棄しつつ、新しいライフサイクル状態に応じた挙動だけに集中させる
                 viewModel.handleScenePhaseChange(newPhase)
             }
             // 経過時間を 1 秒ごとに再計算し、リアルタイム表示へ反映


### PR DESCRIPTION
## Summary
- iOS 17 で非推奨になった onChange(of:perform:) 呼び出しを新シグネチャへ更新
- scenePhase 監視時に不要な初期呼び出しを避けつつコメントを補足

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68de263eecf8832ca1cb4e4676af631e