### PR TITLE
Add toggle for campaign record section

### DIFF
--- a/UI/CampaignRewardSummaryView.swift
+++ b/UI/CampaignRewardSummaryView.swift
@@ -18,6 +18,24 @@ struct CampaignRewardSummaryView: View {
     let theme: AppTheme
     /// どのレイアウトで表示するか
     let context: Context
+    /// 記録セクションを表示するかどうか（ポーズメニューでは非表示にしたいケースがある）
+    let showsRecordSection: Bool
+
+    /// 呼び出し元が必要な情報のみ指定できるよう、 showsRecordSection に既定値を持たせたイニシャライザを用意する
+    init(
+        stage: CampaignStage?,
+        progress: CampaignStageProgress?,
+        theme: AppTheme,
+        context: Context,
+        showsRecordSection: Bool = true
+    ) {
+        // 受け取った値をそのままプロパティへ転記する。記録非表示の用途を考慮し、デフォルト true で従来挙動を維持する
+        self.stage = stage
+        self.progress = progress
+        self.theme = theme
+        self.context = context
+        self.showsRecordSection = showsRecordSection
+    }
 
     /// コンテキストごとの定数をまとめる
     private var metrics: LayoutMetrics { LayoutMetrics(context: context) }
@@ -32,13 +50,16 @@ struct CampaignRewardSummaryView: View {
                 }
             }
 
-            section(title: "これまでの記録") {
-                VStack(alignment: .leading, spacing: metrics.rowSpacing) {
-                    starRow
-                    recordBulletRow(text: "ハイスコア: \(bestScoreText)")
-                    recordBulletRow(text: "最小ペナルティ: \(bestPenaltyText)")
-                    recordBulletRow(text: "最少合計手数: \(bestTotalMoveText)")
-                    recordBulletRow(text: "最短クリアタイム: \(bestElapsedTimeText)")
+            if showsRecordSection {
+                // 記録を隠したい画面（例: ポーズメニュー）向けに、セクション自体を条件付きで表示する
+                section(title: "これまでの記録") {
+                    VStack(alignment: .leading, spacing: metrics.rowSpacing) {
+                        starRow
+                        recordBulletRow(text: "ハイスコア: \(bestScoreText)")
+                        recordBulletRow(text: "最小ペナルティ: \(bestPenaltyText)")
+                        recordBulletRow(text: "最少合計手数: \(bestTotalMoveText)")
+                        recordBulletRow(text: "最短クリアタイム: \(bestElapsedTimeText)")
+                    }
                 }
             }
         }

--- a/UI/PauseMenuView.swift
+++ b/UI/PauseMenuView.swift
@@ -206,12 +206,14 @@ private extension PauseMenuView {
                 Text(summary.stage.summary)
                     .font(.system(size: 14, weight: .regular, design: .rounded))
                     .foregroundStyle(.secondary)
-                // リワード条件・記録の詳細は共通ビューへ委譲し、GamePreparationOverlay と見た目を揃える
+                // リワード条件の詳細は共通ビューへ委譲し、GamePreparationOverlay と見た目を揃える
+                // ポーズ中は戦況整理を優先させるため、過去記録はあえて非表示にする
                 CampaignRewardSummaryView(
                     stage: summary.stage,
                     progress: summary.progress,
                     theme: theme,
-                    context: .list
+                    context: .list,
+                    showsRecordSection: false
                 )
                 .padding(.top, LayoutMetrics.summaryTopPadding)
             }

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -931,7 +931,8 @@ private extension RootView {
                 stage: campaignStage,
                 progress: progress,
                 theme: theme,
-                context: .overlay
+                context: .overlay,
+                showsRecordSection: true
             )
         }
 


### PR DESCRIPTION
## Summary
- add a showsRecordSection flag to CampaignRewardSummaryView and gate the record section behind it
- keep existing contexts showing records by passing showsRecordSection: true
- hide campaign record details in the pause menu and update the surrounding comments

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68de273a63d0832cb9072c3a0247f699