### PR TITLE
Add king/knight training deck presets and adjust standard light weights

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -118,6 +118,33 @@ struct Deck {
             )
         }()
 
+        /// 長距離カードの出現率を下げた標準派生デッキ
+        /// - Note: 直線 2 マスと斜め 2 マスのカードだけ重みを下げ、初心者向けに調整する
+        static let standardLight: Configuration = {
+            let allowedMoves = MoveCard.standardSet
+            // 長距離カード 8 種を個別に上書きし、重み 1 で出現頻度を抑える
+            let longRangeCards: [MoveCard] = [
+                .straightUp2,
+                .straightDown2,
+                .straightRight2,
+                .straightLeft2,
+                .diagonalUpRight2,
+                .diagonalDownRight2,
+                .diagonalDownLeft2,
+                .diagonalUpLeft2
+            ]
+            let overrides = Dictionary(uniqueKeysWithValues: longRangeCards.map { ($0, 1) })
+            return Configuration(
+                allowedMoves: allowedMoves,
+                weightProfile: WeightProfile(defaultWeight: 3, overrides: overrides),
+                shouldApplyProbabilityReduction: true,
+                normalWeightMultiplier: 4,
+                reducedWeightMultiplier: 3,
+                reductionDuration: 5,
+                deckSummaryText: "長距離カード抑制型標準デッキ"
+            )
+        }()
+
         /// 標準デッキへ上下左右の選択キングカードを加えた構成
         /// - Note: 標準セットの操作感を維持しながら、選択式カードの導入に慣れてもらうためのプリセット。
         static let standardWithOrthogonalChoices: Configuration = {
@@ -231,6 +258,21 @@ struct Deck {
             )
         }()
 
+        /// キングと桂馬 16 種をまとめた基礎デッキ
+        /// - Note: 長距離カードを除外し、短距離移動の練習に集中しやすくする
+        static let kingAndKnightBasic: Configuration = {
+            let allowedMoves = MoveCard.standardSet.filter { $0.isKingType || $0.isKnightType }
+            return Configuration(
+                allowedMoves: allowedMoves,
+                weightProfile: WeightProfile(defaultWeight: 1),
+                shouldApplyProbabilityReduction: true,
+                normalWeightMultiplier: 4,
+                reducedWeightMultiplier: 3,
+                reductionDuration: 4,
+                deckSummaryText: "キングと桂馬の基礎デッキ"
+            )
+        }()
+
         /// 上下左右を選択できる複数方向カードを含む 5×5 盤向け構成
         static let directionChoice: Configuration = {
             let choiceCards: [MoveCard] = [.kingUpOrDown, .kingLeftOrRight]
@@ -258,6 +300,28 @@ struct Deck {
                 reducedWeightMultiplier: 1,
                 reductionDuration: 0,
                 deckSummaryText: "上下左右の選択キング限定"
+            )
+        }()
+
+        /// キング 4 種と桂馬 4 種のみを収録した限定デッキ
+        /// - Note: 直感的な上下左右移動と跳躍行動だけで構成し、操作習熟を狙う
+        static let kingPlusKnightOnly: Configuration = {
+            let kingMoves: [MoveCard] = [.kingUp, .kingRight, .kingDown, .kingLeft]
+            let knightMoves: [MoveCard] = [
+                .knightUp2Right1,
+                .knightUp2Left1,
+                .knightDown2Right1,
+                .knightDown2Left1
+            ]
+            let moves = kingMoves + knightMoves
+            return Configuration(
+                allowedMoves: moves,
+                weightProfile: WeightProfile(defaultWeight: 1),
+                shouldApplyProbabilityReduction: false,
+                normalWeightMultiplier: 1,
+                reducedWeightMultiplier: 1,
+                reductionDuration: 0,
+                deckSummaryText: "キングと桂馬の限定デッキ"
             )
         }()
 

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -7,10 +7,16 @@ import Foundation
 public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
     /// スタンダードモードと同じ山札構成
     case standard
+    /// 長距離カードの出現頻度を抑えた標準構成
+    case standardLight
     /// クラシカルチャレンジと同じ桂馬のみの構成
     case classicalChallenge
     /// 王将型カードのみの構成（序盤向け超短距離デッキ）
     case kingOnly
+    /// キングと桂馬の基本 16 種を収録した構成
+    case kingAndKnightBasic
+    /// キング 4 種と桂馬 4 種のみで構成した訓練向けデッキ
+    case kingPlusKnightOnly
     /// キング型カードに上下左右の選択肢を加えた構成
     case directionChoice
     /// 標準デッキに上下左右の選択キングを加えた構成
@@ -38,10 +44,16 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
         switch self {
         case .standard:
             return "スタンダード構成"
+        case .standardLight:
+            return "スタンダード軽量構成"
         case .classicalChallenge:
             return "クラシカル構成"
         case .kingOnly:
             return "王将構成"
+        case .kingAndKnightBasic:
+            return "キング＋ナイト基礎構成"
+        case .kingPlusKnightOnly:
+            return "キング＋ナイト限定構成"
         case .directionChoice:
             return "選択式キング構成"
         case .standardWithOrthogonalChoices:
@@ -73,10 +85,16 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
         switch self {
         case .standard:
             return .standard
+        case .standardLight:
+            return .standardLight
         case .classicalChallenge:
             return .classicalChallenge
         case .kingOnly:
             return .kingOnly
+        case .kingAndKnightBasic:
+            return .kingAndKnightBasic
+        case .kingPlusKnightOnly:
+            return .kingPlusKnightOnly
         case .directionChoice:
             return .directionChoice
         case .standardWithOrthogonalChoices:

--- a/Tests/GameTests/CampaignLibraryTests.swift
+++ b/Tests/GameTests/CampaignLibraryTests.swift
@@ -6,6 +6,28 @@ final class CampaignLibraryTests: XCTestCase {
     /// 選択カード系プリセットが期待通りの構成を返すことを確認する
     func testChoiceDeckPresetConfigurations() {
         let presets: [(GameDeckPreset, String, String, Set<MoveCard>)] = [
+            (.standardLight, "スタンダード軽量構成", "長距離カード抑制型標準デッキ", Set(MoveCard.standardSet)),
+            (
+                .kingAndKnightBasic,
+                "キング＋ナイト基礎構成",
+                "キングと桂馬の基礎デッキ",
+                Set(MoveCard.standardSet.filter { $0.isKingType || $0.isKnightType })
+            ),
+            (
+                .kingPlusKnightOnly,
+                "キング＋ナイト限定構成",
+                "キングと桂馬の限定デッキ",
+                Set([
+                    .kingUp,
+                    .kingRight,
+                    .kingDown,
+                    .kingLeft,
+                    .knightUp2Right1,
+                    .knightUp2Left1,
+                    .knightDown2Right1,
+                    .knightDown2Left1
+                ])
+            ),
             (.directionChoice, "選択式キング構成", "選択式キングカード入り", [.kingUpOrDown, .kingLeftOrRight]),
             (.standardWithOrthogonalChoices, "標準＋縦横選択キング構成", "標準＋上下左右選択キング", Set(MoveCard.standardSet).union([.kingUpOrDown, .kingLeftOrRight])),
             (.standardWithDiagonalChoices, "標準＋斜め選択キング構成", "標準＋斜め選択キング", Set(MoveCard.standardSet).union([
@@ -69,6 +91,7 @@ final class CampaignLibraryTests: XCTestCase {
 
             // MARK: 標準セットを内包するプリセットは全カードを含んでいるか検証する
             let presetsRequiringStandard: Set<GameDeckPreset> = [
+                .standardLight,
                 .directionChoice,
                 .standardWithOrthogonalChoices,
                 .standardWithDiagonalChoices,

--- a/Tests/GameTests/DeckTests.swift
+++ b/Tests/GameTests/DeckTests.swift
@@ -25,6 +25,26 @@ final class DeckTests: XCTestCase {
         XCTAssertEqual(uniqueWeights.first, 1, "標準デッキの重みが 1 以外になっています")
     }
 
+    /// スタンダード軽量デッキが長距離カードの重みを抑えているか検証する
+    func testStandardLightDeckConfiguration() {
+        let config = Deck.Configuration.standardLight
+        let allowedMoves = Set(config.allowedMoves)
+        let standardMoves = Set(MoveCard.standardSet)
+
+        // MARK: 標準セットと同じカード群を保持しているか確認
+        XCTAssertEqual(allowedMoves, standardMoves, "スタンダード軽量構成のカード集合が標準セットと一致しません")
+
+        // MARK: 長距離カードの重みが通常カードより低く設定されているか検証
+        let kingWeight = config.weightProfile.weight(for: .kingUp)
+        let longRangeWeight = config.weightProfile.weight(for: .straightUp2)
+        XCTAssertGreaterThan(kingWeight, longRangeWeight, "長距離カードの重みが軽量化されていません")
+        XCTAssertEqual(longRangeWeight, 1, "長距離カードの重みが想定値と異なります")
+        XCTAssertEqual(kingWeight, 3, "キングカードの重みが想定値と異なります")
+
+        // MARK: サマリー文言が仕様通りかチェック
+        XCTAssertEqual(config.deckSummaryText, "長距離カード抑制型標準デッキ")
+    }
+
     /// 標準デッキへ縦横選択カードを追加するプリセットの内容を検証する
     func testStandardWithOrthogonalChoicesDeckConfiguration() {
         let config = Deck.Configuration.standardWithOrthogonalChoices
@@ -215,6 +235,47 @@ final class DeckTests: XCTestCase {
             }
             XCTAssertTrue(card.isKnightType, "桂馬以外のカードが出現: \(card)")
         }
+    }
+
+    /// キングと桂馬 16 種構成デッキの内容を検証する
+    func testKingAndKnightBasicDeckConfiguration() {
+        let config = Deck.Configuration.kingAndKnightBasic
+        let allowedMoves = Set(config.allowedMoves)
+        let expectedMoves = Set(MoveCard.standardSet.filter { $0.isKingType || $0.isKnightType })
+
+        // MARK: キング＋桂馬 16 種が揃っているか確認
+        XCTAssertEqual(allowedMoves, expectedMoves, "キング＋ナイト基礎構成のカード集合が仕様と一致しません")
+
+        // MARK: 重み設定が均一かどうか検証
+        XCTAssertEqual(config.weightProfile.weight(for: .kingUp), 1, "キングカードの重みが均一ではありません")
+        XCTAssertEqual(config.weightProfile.weight(for: .knightUp2Right1), 1, "桂馬カードの重みが均一ではありません")
+
+        // MARK: サマリー文言が仕様通りか確認
+        XCTAssertEqual(config.deckSummaryText, "キングと桂馬の基礎デッキ")
+    }
+
+    /// キングと桂馬のみの限定デッキを検証する
+    func testKingPlusKnightOnlyDeckConfiguration() {
+        let config = Deck.Configuration.kingPlusKnightOnly
+        let expected: Set<MoveCard> = [
+            .kingUp,
+            .kingRight,
+            .kingDown,
+            .kingLeft,
+            .knightUp2Right1,
+            .knightUp2Left1,
+            .knightDown2Right1,
+            .knightDown2Left1
+        ]
+
+        // MARK: 許可カードが 8 種に限定されているか確認
+        XCTAssertEqual(Set(config.allowedMoves), expected, "キング＋ナイト限定構成のカード集合が仕様と一致しません")
+
+        // MARK: 重みが均一に設定されているか確認
+        XCTAssertTrue(expected.allSatisfy { config.weightProfile.weight(for: $0) == 1 }, "限定構成の重みが均一になっていません")
+
+        // MARK: サマリー文言が仕様通りかチェック
+        XCTAssertEqual(config.deckSummaryText, "キングと桂馬の限定デッキ")
     }
 
     /// makeTestDeck で指定した配列が優先的に返され、reset() で再利用できるか確認


### PR DESCRIPTION
## Summary
- add the standardLight, kingAndKnightBasic, and kingPlusKnightOnly presets to GameDeckPreset with localized names
- implement deck configurations that rebalance long-range cards and define the king/knight-only combinations
- expand deck and campaign tests to cover the new presets and summaries

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68df0c19c478832c9102fd6451b2a57e