### PR TITLE
Update chapter 1 campaign stages and add deck presets

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -231,6 +231,43 @@ struct Deck {
             )
         }()
 
+        /// 王将 4 種と桂馬 4 種だけを抽選する導入用構成
+        /// - Note: 3×3 盤でも扱いやすい短距離カードを厳選し、ナイト初学者の負荷を下げる。
+        static let kingPlusKnightOnly: Configuration = {
+            let kingMoves: [MoveCard] = [.kingUp, .kingRight, .kingDown, .kingLeft]
+            let knightMoves: [MoveCard] = [
+                .knightUp2Right1,
+                .knightUp2Left1,
+                .knightDown2Right1,
+                .knightDown2Left1
+            ]
+            let allowedMoves = kingMoves + knightMoves
+            return Configuration(
+                allowedMoves: allowedMoves,
+                weightProfile: WeightProfile(defaultWeight: 1),
+                shouldApplyProbabilityReduction: false,
+                normalWeightMultiplier: 1,
+                reducedWeightMultiplier: 1,
+                reductionDuration: 0,
+                deckSummaryText: "王将4種＋桂馬4種"
+            )
+        }()
+
+        /// 王将 8 種と桂馬 8 種で構成した基本セット
+        /// - Note: 標準デッキ導入前の練習として、長距離カードを除外して挙動を学びやすくする。
+        static let kingAndKnightBasic: Configuration = {
+            let allowedMoves = MoveCard.standardSet.filter { $0.isKingType || $0.isKnightType }
+            return Configuration(
+                allowedMoves: allowedMoves,
+                weightProfile: WeightProfile(defaultWeight: 1),
+                shouldApplyProbabilityReduction: true,
+                normalWeightMultiplier: 4,
+                reducedWeightMultiplier: 3,
+                reductionDuration: 5,
+                deckSummaryText: "キング8種＋桂馬8種"
+            )
+        }()
+
         /// 上下左右を選択できる複数方向カードを含む 5×5 盤向け構成
         static let directionChoice: Configuration = {
             let choiceCards: [MoveCard] = [.kingUpOrDown, .kingLeftOrRight]
@@ -244,6 +281,32 @@ struct Deck {
                 reducedWeightMultiplier: 3,
                 reductionDuration: 5,
                 deckSummaryText: "選択式キングカード入り"
+            )
+        }()
+
+        /// 標準デッキから長距離カードの比率を下げたライト構成
+        /// - Note: 初期章で扱いやすいよう、直線 2 マスと斜め 2 マスの重みを半減させる。
+        static let standardLight: Configuration = {
+            let longRangeCards: [MoveCard] = [
+                .straightUp2,
+                .straightDown2,
+                .straightRight2,
+                .straightLeft2,
+                .diagonalUpRight2,
+                .diagonalDownRight2,
+                .diagonalDownLeft2,
+                .diagonalUpLeft2
+            ]
+            var overrides: [MoveCard: Int] = [:]
+            longRangeCards.forEach { overrides[$0] = 1 }
+            return Configuration(
+                allowedMoves: MoveCard.standardSet,
+                weightProfile: WeightProfile(defaultWeight: 2, overrides: overrides),
+                shouldApplyProbabilityReduction: true,
+                normalWeightMultiplier: 4,
+                reducedWeightMultiplier: 3,
+                reductionDuration: 5,
+                deckSummaryText: "標準（長距離減衰）"
             )
         }()
 

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -11,8 +11,14 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
     case classicalChallenge
     /// 王将型カードのみの構成（序盤向け超短距離デッキ）
     case kingOnly
+    /// 王将と桂馬を軽量構成で混在させたデッキ
+    case kingPlusKnightOnly
+    /// 王将 8 種と桂馬 8 種で構成した基本デッキ
+    case kingAndKnightBasic
     /// キング型カードに上下左右の選択肢を加えた構成
     case directionChoice
+    /// 標準デッキから長距離カードの出現頻度を抑えたライト構成
+    case standardLight
     /// 標準デッキに上下左右の選択キングを加えた構成
     case standardWithOrthogonalChoices
     /// 標準デッキに斜め選択キングを加えた構成
@@ -42,8 +48,14 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
             return "クラシカル構成"
         case .kingOnly:
             return "王将構成"
+        case .kingPlusKnightOnly:
+            return "王将＋桂馬構成"
+        case .kingAndKnightBasic:
+            return "キング＆桂馬基本構成"
         case .directionChoice:
             return "選択式キング構成"
+        case .standardLight:
+            return "標準ライト構成"
         case .standardWithOrthogonalChoices:
             return "標準＋縦横選択キング構成"
         case .standardWithDiagonalChoices:
@@ -77,8 +89,14 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
             return .classicalChallenge
         case .kingOnly:
             return .kingOnly
+        case .kingPlusKnightOnly:
+            return .kingPlusKnightOnly
+        case .kingAndKnightBasic:
+            return .kingAndKnightBasic
         case .directionChoice:
             return .directionChoice
+        case .standardLight:
+            return .standardLight
         case .standardWithOrthogonalChoices:
             return .standardWithOrthogonalChoices
         case .standardWithDiagonalChoices:


### PR DESCRIPTION
## Summary
- expand chapter 1 campaign definitions to eight stages with updated spawn rules, penalties, and score targets that match the regulations table
- introduce new deck presets for the chapter 1 flow and wire them into the campaign stage definitions
- refresh the campaign library tests to cover the new deck presets and the full first chapter progression

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68df0c0c6ed4832ca187b75047b6eefc