### PR TITLE
Add daily leaderboard mappings for new game modes

### DIFF
--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -122,6 +122,8 @@ public struct GameMode: Equatable, Identifiable {
     public enum Identifier: String, CaseIterable {
         case standard5x5
         case classicalChallenge
+        case dailyFixedChallenge   // 日替わり固定シード用モード。Game Center の仮 ID から本番 ID へ差し替える想定
+        case dailyRandomChallenge  // 日替わりランダムシード用モード。将来的に xcconfig で ID を設定予定
         case freeCustom
         case campaignStage
     }
@@ -412,6 +414,10 @@ public struct GameMode: Equatable, Identifiable {
             return "square.grid.3x3.fill"
         case .classicalChallenge:
             return "checkerboard.rectangle"
+        case .dailyFixedChallenge:
+            return "calendar"
+        case .dailyRandomChallenge:
+            return "sparkles"
         case .freeCustom:
             return "slider.horizontal.3"
         case .campaignStage:
@@ -425,6 +431,10 @@ public struct GameMode: Equatable, Identifiable {
         case .standard5x5:
             return .balanced
         case .classicalChallenge:
+            return .advanced
+        case .dailyFixedChallenge:
+            return .balanced
+        case .dailyRandomChallenge:
             return .advanced
         case .freeCustom:
             return .custom
@@ -546,6 +556,12 @@ public struct GameMode: Equatable, Identifiable {
             return standard
         case .classicalChallenge:
             return classicalChallenge
+        case .dailyFixedChallenge:
+            // 日替わり固定シードは現状ビルトイン定義が存在しないため、スタンダード相当をフォールバックとして返す
+            return standard
+        case .dailyRandomChallenge:
+            // 日替わりランダムシードも同様に将来的な実装を想定し、暫定的にスタンダードを返しておく
+            return standard
         case .freeCustom:
             // フリーモードはユーザー設定によって変化するため、デフォルトとしてスタンダード相当を返す
             return standard

--- a/MonoKnightAppTests/MonoKnightAppTests.swift
+++ b/MonoKnightAppTests/MonoKnightAppTests.swift
@@ -127,4 +127,15 @@ struct MonoKnightAppTests {
             #expect(authState.wrappedValue == true)
         }
     }
+
+    /// 日替わりモード用リーダーボード ID のマッピングが期待通りかを検証する
+    /// - Note: GameCenterService 側で xcconfig 差し替えを行う前提のため、仮 ID を固定で確認しておく
+    @MainActor
+    @Test func leaderboardIdentifier_dailyModes_haveExpectedTestIDs() throws {
+        let service = GameCenterService.shared
+        // 日替わり固定シード用リーダーボードの ID を確認
+        #expect(service.leaderboardIdentifier(for: .dailyFixedChallenge) == "test_daily_fixed_v1")
+        // 日替わりランダムシード用リーダーボードの ID を確認
+        #expect(service.leaderboardIdentifier(for: .dailyRandomChallenge) == "test_daily_random_v1")
+    }
 }

--- a/Services/GameCenterService.swift
+++ b/Services/GameCenterService.swift
@@ -33,8 +33,24 @@ private struct GameCenterLeaderboardCatalog {
         supportedModes: [.classicalChallenge]
     )
 
+    /// 日替わり固定シード用リーダーボード
+    /// - Note: 本番用の参照名・ID は xcconfig で差し替えるため、仮値であることをコメントに明記しておく
+    static let dailyFixedTest = Entry(
+        referenceName: "[TEST] Daily Fixed Leaderboard",   // FIXME: 本番ビルドでは xcconfig 経由で正式名称へ差し替える予定
+        leaderboardID: "test_daily_fixed_v1",              // FIXME: 本番ビルドでは xcconfig からリーダーボード ID を注入予定
+        supportedModes: [.dailyFixedChallenge]
+    )
+
+    /// 日替わりランダムシード用リーダーボード
+    /// - Note: こちらもテスト値で運用し、後日 xcconfig へ値を移して差し替えしやすくする
+    static let dailyRandomTest = Entry(
+        referenceName: "[TEST] Daily Random Leaderboard",  // FIXME: 本番ビルドでの正式名称に差し替える（xcconfig 管理予定）
+        leaderboardID: "test_daily_random_v1",             // FIXME: xcconfig による差し替えを前提とした仮 ID
+        supportedModes: [.dailyRandomChallenge]
+    )
+
     /// 定義済みのリーダーボード一覧
-    static let allEntries: [Entry] = [standardTest, classicalChallengeTest]
+    static let allEntries: [Entry] = [standardTest, classicalChallengeTest, dailyFixedTest, dailyRandomTest]
 
     /// 指定したゲームモードに対応するリーダーボードを返す
     /// - Parameter identifier: 判定対象となるゲームモード識別子
@@ -350,6 +366,13 @@ final class GameCenterService: NSObject, GKGameCenterControllerDelegate, GameCen
             }
             root.present(vc, animated: true)
         }
+    }
+
+    /// 指定モードに対応するリーダーボード ID を取得するユーティリティ
+    /// - Note: MonoKnightAppTests からマッピング検証を行う目的で公開しておき、
+    ///         将来 xcconfig 経由で値を差し替えた際にもテストを更新しやすくする
+    func leaderboardIdentifier(for modeIdentifier: GameMode.Identifier) -> String? {
+        GameCenterLeaderboardCatalog.entry(for: modeIdentifier)?.leaderboardID
     }
 
     // MARK: - 表示用ヘルパー

--- a/docs/game-center-leaderboards.md
+++ b/docs/game-center-leaderboards.md
@@ -11,6 +11,8 @@ MonoKnight で利用する Game Center リーダーボードの参照名と Lead
 | --- | --- | --- | --- | --- |
 | スタンダードモード (5x5) | テスト | `[TEST] Standard Leaderboard` | `test_standard_moves_v1` | スタンダードモードのプレイ結果を送信。正式版では本番 ID へ差し替える。 |
 | クラシカルチャレンジ | テスト | `[TEST] Classical Challenge Leaderboard` | `test_classical_moves_v1` | クラシカルチャレンジ専用の桂馬デッキ向けランキング。正式リリース時に本番 ID へ切り替え予定。 |
+| 日替わり固定シード | テスト | `[TEST] Daily Fixed Leaderboard` <!-- FIXME: 本番移行時は xcconfig から正式名称を注入する --> | `test_daily_fixed_v1` <!-- FIXME: xcconfig により本番 ID へ差し替える予定 --> | スタンダード設定の固定シードを日替わりで共有するモード向け。デイリー切り替え時はリセット不要想定。 |
+| 日替わりランダムシード | テスト | `[TEST] Daily Random Leaderboard` <!-- FIXME: xcconfig で本番用リファレンス名を設定予定 --> | `test_daily_random_v1` <!-- FIXME: xcconfig から本番 ID を注入予定 --> | 日替わりで乱数シードを配信するモード。正式運用で集計期間の検証が必要。 |
 
 ### 運用メモ
 
@@ -20,3 +22,5 @@ MonoKnight で利用する Game Center リーダーボードの参照名と Lead
   にエントリを追加し、必要に応じて `GameView` / `ResultView` の送信ロジックを拡張する。
 - テスト用リーダーボードから正式名称へ切り替える際は、旧 ID の送信状況を `resetSubmittedFlag(for:)` でリセットし、
   ユーザーの再送信を促すことを推奨する。
+- デイリーモードは日本時間 0:00 を基準に切り替え予定。日付は `YYYY-MM-DD` 形式の文字列で共有し、固定シードは共通配信、ランダムシードは各端末が共通シードから派生生成する想定。
+- 日替わりリーダーボードは本番運用でのリセットを行わず、日付に応じたスコアが積み上がる前提。必要に応じて App Store Connect 側の期間限定イベント機能を検討する。


### PR DESCRIPTION
## Summary
- add daily fixed/random identifiers to `GameMode` with placeholder handling until the daily modes are finalized
- register daily fixed/random leaderboards in `GameCenterService` and expose a helper for mapping verification
- document daily leaderboard operations and cover the new mapping with a unit test in `MonoKnightAppTests`

## Testing
- Not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68df6daa22c8832c9cc0fc901c0fa670