### PR TITLE
Add daily challenge attempt store and rewarded ads

### DIFF
--- a/MonoKnightAppTests/DailyChallengeAttemptStoreTests.swift
+++ b/MonoKnightAppTests/DailyChallengeAttemptStoreTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import MonoKnightApp
+
+@MainActor
+struct DailyChallengeAttemptStoreTests {
+    /// UTC 基準で日付が変わった際に挑戦回数がリセットされることを確認する
+    @Test
+    func resetOccursWhenUtcDateChanges() {
+        let suiteName = "daily_challenge_store_test_reset"
+        let defaults = makeIsolatedDefaults(suiteName: suiteName)
+        defer { clearDefaults(defaults, suiteName: suiteName) }
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let start = calendar.date(from: DateComponents(year: 2024, month: 6, day: 1, hour: 10))!
+        var now = start
+
+        let store = DailyChallengeAttemptStore(userDefaults: defaults, nowProvider: { now })
+        #expect(store.remainingAttempts == 1)
+
+        _ = store.consumeAttempt()
+        #expect(store.remainingAttempts == 0)
+
+        now = calendar.date(byAdding: .day, value: 1, to: start)!
+        store.refreshForCurrentDate()
+        #expect(store.remainingAttempts == 1)
+    }
+
+    /// 無料 1 回 + リワード広告 3 回の計 4 回を超えて消費できないことを検証する
+    @Test
+    func rejectsConsumptionBeyondDailyLimit() {
+        let suiteName = "daily_challenge_store_test_limit"
+        let defaults = makeIsolatedDefaults(suiteName: suiteName)
+        defer { clearDefaults(defaults, suiteName: suiteName) }
+
+        let store = DailyChallengeAttemptStore(userDefaults: defaults)
+        for _ in 0..<3 {
+            #expect(store.grantRewardedAttempt())
+        }
+        #expect(store.remainingAttempts == 4)
+
+        for _ in 0..<4 {
+            #expect(store.consumeAttempt())
+        }
+        #expect(store.remainingAttempts == 0)
+        #expect(store.consumeAttempt() == false)
+    }
+
+    /// リワード広告成功時に残り挑戦回数が増加することを確認する
+    @Test
+    func rewardedGrantRestoresAttemptsAfterConsumption() {
+        let suiteName = "daily_challenge_store_test_reward"
+        let defaults = makeIsolatedDefaults(suiteName: suiteName)
+        defer { clearDefaults(defaults, suiteName: suiteName) }
+
+        let store = DailyChallengeAttemptStore(userDefaults: defaults)
+        _ = store.consumeAttempt()
+        #expect(store.remainingAttempts == 0)
+
+        #expect(store.grantRewardedAttempt())
+        #expect(store.remainingAttempts == 1)
+    }
+
+    // MARK: - ヘルパー
+    private func makeIsolatedDefaults(suiteName: String) -> UserDefaults {
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("UserDefaults suite (\(suiteName)) の生成に失敗しました")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private func clearDefaults(_ defaults: UserDefaults, suiteName: String) {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults.synchronize()
+    }
+}

--- a/MonoKnightAppTests/GameHandSectionViewAccessibilityTests.swift
+++ b/MonoKnightAppTests/GameHandSectionViewAccessibilityTests.swift
@@ -108,6 +108,7 @@ private final class NoopAdsService: AdsServiceProtocol {
     func showInterstitial() {}
     func resetPlayFlag() {}
     func disableAds() {}
+    func showRewardedAd() async -> Bool { true }
     func requestTrackingAuthorization() async {}
     func requestConsentIfNeeded() async {}
     func refreshConsentStatus() async {}

--- a/MonoKnightAppTests/GameViewIntegrationTests.swift
+++ b/MonoKnightAppTests/GameViewIntegrationTests.swift
@@ -761,6 +761,7 @@ private final class AdsServiceSpy: AdsServiceProtocol {
     func showInterstitial() {}
     func resetPlayFlag() {}
     func disableAds() {}
+    func showRewardedAd() async -> Bool { true }
     func requestTrackingAuthorization() async {}
     func requestConsentIfNeeded() async {}
     func refreshConsentStatus() async {}

--- a/MonoKnightAppTests/GameViewModelTests.swift
+++ b/MonoKnightAppTests/GameViewModelTests.swift
@@ -338,6 +338,7 @@ private final class DummyAdsService: AdsServiceProtocol {
     func showInterstitial() {}
     func resetPlayFlag() {}
     func disableAds() {}
+    func showRewardedAd() async -> Bool { true }
     func requestTrackingAuthorization() async {}
     func requestConsentIfNeeded() async {}
     func refreshConsentStatus() async {}
@@ -357,6 +358,7 @@ private final class SpyAdsService: AdsServiceProtocol {
     }
 
     func disableAds() {}
+    func showRewardedAd() async -> Bool { true }
     func requestTrackingAuthorization() async {}
     func requestConsentIfNeeded() async {}
     func refreshConsentStatus() async {}

--- a/Services/DailyChallengeAttemptStore.swift
+++ b/Services/DailyChallengeAttemptStore.swift
@@ -1,0 +1,245 @@
+import Foundation
+import Combine
+import SwiftUI
+import SharedSupport // ログユーティリティを活用するため追加
+
+// MARK: - 日替わりチャレンジ挑戦回数の公開インターフェース
+/// UI 全体から挑戦回数の残量や付与処理を扱えるようにするためのプロトコル
+/// - Note: `ObservableObject` に準拠しているため、SwiftUI の `@EnvironmentObject` としても利用できる
+@MainActor
+protocol DailyChallengeAttemptStoreProtocol: ObservableObject {
+    /// 残り挑戦回数（無料 1 回 + リワード広告による加算分 - 消費済み回数）
+    var remainingAttempts: Int { get }
+    /// その日のリワード広告によって付与済みの回数
+    var rewardedAttemptsGranted: Int { get }
+    /// 1 日あたり付与できるリワード広告ボーナス回数の上限（仕様で 3 回）
+    var maximumRewardedAttempts: Int { get }
+
+    /// UTC 日付の境界を跨いだ場合に状態を初期化する
+    func refreshForCurrentDate()
+    /// 残り挑戦回数を 1 消費し、成功したかを返す
+    @discardableResult
+    func consumeAttempt() -> Bool
+    /// リワード広告視聴が成功した際に 1 回分の挑戦回数を付与する
+    @discardableResult
+    func grantRewardedAttempt() -> Bool
+}
+
+// MARK: - 型消去ラッパー
+/// 具象ストアを `ObservableObject` のまま別タイプへ差し替えられるようにするためのタイプイレース
+@MainActor
+final class AnyDailyChallengeAttemptStore: ObservableObject, DailyChallengeAttemptStoreProtocol {
+    /// 実体となるストアを保持
+    private let base: any DailyChallengeAttemptStoreProtocol
+    /// `objectWillChange` を購読し Published プロパティへ反映するためのストア
+    private var cancellable: AnyCancellable?
+
+    /// 残り挑戦回数を公開（Published で SwiftUI へ伝播）
+    @Published private(set) var remainingAttempts: Int
+    /// 付与済みリワード回数
+    @Published private(set) var rewardedAttemptsGranted: Int
+    /// 仕様で定めた 1 日あたりの付与上限
+    let maximumRewardedAttempts: Int
+
+    init(base: any DailyChallengeAttemptStoreProtocol) {
+        self.base = base
+        self.remainingAttempts = base.remainingAttempts
+        self.rewardedAttemptsGranted = base.rewardedAttemptsGranted
+        self.maximumRewardedAttempts = base.maximumRewardedAttempts
+
+        // objectWillChange を購読して最新値を同期
+        cancellable = base.objectWillChange.sink { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                self.remainingAttempts = base.remainingAttempts
+                self.rewardedAttemptsGranted = base.rewardedAttemptsGranted
+            }
+        }
+    }
+
+    func refreshForCurrentDate() {
+        base.refreshForCurrentDate()
+        synchronizeAfterAsyncChange()
+    }
+
+    @discardableResult
+    func consumeAttempt() -> Bool {
+        let result = base.consumeAttempt()
+        synchronizeAfterAsyncChange()
+        return result
+    }
+
+    @discardableResult
+    func grantRewardedAttempt() -> Bool {
+        let result = base.grantRewardedAttempt()
+        synchronizeAfterAsyncChange()
+        return result
+    }
+
+    /// `base` 側の値が変化した直後にメインアクターで同期する
+    private func synchronizeAfterAsyncChange() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.remainingAttempts = base.remainingAttempts
+            self.rewardedAttemptsGranted = base.rewardedAttemptsGranted
+        }
+    }
+}
+
+// MARK: - 実ストア実装
+/// UserDefaults へ挑戦回数の履歴を保存し、毎日 UTC 基準でリセットするストア
+@MainActor
+final class DailyChallengeAttemptStore: ObservableObject, DailyChallengeAttemptStoreProtocol {
+    /// UserDefaults 保存時のキー
+    /// - Important: バージョンを明記しておくことで将来のスキーマ変更に備える
+    private enum StorageKey {
+        /// 本日の挑戦状況（JSON エンコードした `State` を格納）
+        static let state = "daily_challenge_attempt_state_v1" // JSON で `State` を保存
+    }
+
+    /// 日付キーを生成する際のフォーマット
+    private enum DateFormat {
+        /// `yyyy-MM-dd` 形式で UTC 日付を表現する
+        static let pattern = "yyyy-MM-dd"
+    }
+
+    /// 最大付与可能なリワード広告回数（仕様で 3 回）
+    let maximumRewardedAttempts: Int = 3
+
+    /// UserDefaults 保存用の状態
+    private struct State: Codable {
+        /// UTC 基準の日付キー（例: 2025-05-25）
+        let dateKey: String
+        /// その日に消費した挑戦回数
+        var usedAttempts: Int
+        /// その日にリワード広告で付与済みの回数
+        var rewardedAttemptsGranted: Int
+    }
+
+    /// 現在の状態（更新時に Published プロパティへ反映）
+    private var state: State {
+        didSet { updatePublishedValues(); persistState() }
+    }
+
+    /// 現在の UTC 日付キーを生成するためのフォーマッタ
+    private let dateFormatter: DateFormatter
+    /// 永続化先 UserDefaults（テスト注入のため DI 対応）
+    private let userDefaults: UserDefaults
+    /// 現在日時を取得するクロージャ（テストで任意の日時を差し替える）
+    private let nowProvider: () -> Date
+
+    /// 残り挑戦回数（Published で公開）
+    @Published private(set) var remainingAttempts: Int
+    /// リワード広告による付与済み回数（Published で公開）
+    @Published private(set) var rewardedAttemptsGranted: Int
+
+    init(
+        userDefaults: UserDefaults = .standard,
+        nowProvider: @escaping () -> Date = { Date() }
+    ) {
+        self.userDefaults = userDefaults
+        self.nowProvider = nowProvider
+
+        // UTC（協定世界時）で日付を判定するため、TimeZone(secondsFromGMT: 0) をセットしたカレンダーを採用
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+
+        // `yyyy-MM-dd` 形式で日付キーを生成するフォーマッタを用意
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.timeZone = calendar.timeZone
+        formatter.dateFormat = DateFormat.pattern
+        self.dateFormatter = formatter
+
+        // 起動時に現在日付の状態を復元（存在しない場合は当日分を新規作成）
+        let currentDateKey = formatter.string(from: nowProvider())
+        if let data = userDefaults.data(forKey: StorageKey.state) {
+            do {
+                let decoded = try JSONDecoder().decode(State.self, from: data)
+                if decoded.dateKey == currentDateKey {
+                    state = decoded
+                    debugLog("DailyChallengeAttemptStore: 保存済みの挑戦状況を復元しました (dateKey: \(decoded.dateKey))")
+                } else {
+                    state = State(dateKey: currentDateKey, usedAttempts: 0, rewardedAttemptsGranted: 0)
+                    debugLog("DailyChallengeAttemptStore: 日付が変わっていたため挑戦回数をリセットしました")
+                    persistState()
+                }
+            } catch {
+                state = State(dateKey: currentDateKey, usedAttempts: 0, rewardedAttemptsGranted: 0)
+                debugError(error, message: "DailyChallengeAttemptStore: 復元に失敗したため状態を初期化しました")
+                persistState()
+            }
+        } else {
+            state = State(dateKey: currentDateKey, usedAttempts: 0, rewardedAttemptsGranted: 0)
+            debugLog("DailyChallengeAttemptStore: 保存データが無かったため本日の挑戦状況を新規作成しました")
+            persistState()
+        }
+
+        // Published プロパティへ初期値を反映
+        self.remainingAttempts = Self.computeRemainingAttempts(from: state)
+        self.rewardedAttemptsGranted = state.rewardedAttemptsGranted
+    }
+
+    /// 日付境界を跨いだ場合に状態を初期化する
+    func refreshForCurrentDate() {
+        let currentKey = dateFormatter.string(from: nowProvider())
+        guard state.dateKey != currentKey else { return }
+        state = State(dateKey: currentKey, usedAttempts: 0, rewardedAttemptsGranted: 0)
+        debugLog("DailyChallengeAttemptStore: 新しい日付 (\(currentKey)) が検出されたため挑戦回数をリセットしました")
+    }
+
+    @discardableResult
+    func consumeAttempt() -> Bool {
+        refreshForCurrentDate()
+        let totalAvailable = 1 + state.rewardedAttemptsGranted
+        guard state.usedAttempts < totalAvailable else {
+            debugLog("DailyChallengeAttemptStore: 挑戦回数の上限に達しているため消費できません")
+            return false
+        }
+
+        state.usedAttempts += 1
+        debugLog("DailyChallengeAttemptStore: 挑戦回数を 1 消費しました (used: \(state.usedAttempts)/total: \(totalAvailable))")
+        return true
+    }
+
+    @discardableResult
+    func grantRewardedAttempt() -> Bool {
+        refreshForCurrentDate()
+        guard state.rewardedAttemptsGranted < maximumRewardedAttempts else {
+            debugLog("DailyChallengeAttemptStore: リワード広告による付与上限に達しているため増加できません")
+            return false
+        }
+
+        state.rewardedAttemptsGranted += 1
+        debugLog("DailyChallengeAttemptStore: リワード広告成功により挑戦回数を 1 追加しました (granted: \(state.rewardedAttemptsGranted))")
+        return true
+    }
+
+    // MARK: - 内部処理
+    private func updatePublishedValues() {
+        remainingAttempts = Self.computeRemainingAttempts(from: state)
+        rewardedAttemptsGranted = state.rewardedAttemptsGranted
+    }
+
+    private func persistState() {
+        do {
+            let data = try JSONEncoder().encode(state)
+            userDefaults.set(data, forKey: StorageKey.state)
+            userDefaults.synchronize()
+        } catch {
+            debugError(error, message: "DailyChallengeAttemptStore: 永続化に失敗しました")
+        }
+    }
+
+    private static func computeRemainingAttempts(from state: State) -> Int {
+        let total = 1 + state.rewardedAttemptsGranted
+        return max(0, total - state.usedAttempts)
+    }
+}
+
+private extension TimeZone {
+    /// GMT (UTC±0) の TimeZone を安全に取得するためのヘルパー
+    static var gmt: TimeZone {
+        TimeZone(secondsFromGMT: 0) ?? TimeZone(identifier: "GMT") ?? .current
+    }
+}

--- a/Services/RewardedAdController.swift
+++ b/Services/RewardedAdController.swift
@@ -1,0 +1,232 @@
+import Foundation
+import UIKit
+import GoogleMobileAds
+import SharedSupport // ログユーティリティを利用するため追加
+
+// MARK: - デリゲート定義
+/// リワード広告を表示する際に UI 依存の処理を委譲するためのプロトコル
+@MainActor
+protocol RewardedAdControllerDelegate: AnyObject {
+    /// 表示に利用する最前面の ViewController を提供する
+    func rootViewControllerForPresentation(_ controller: RewardedAdControlling) -> UIViewController?
+}
+
+// MARK: - 管理用インターフェース
+/// リワード広告のロード・表示を統一インターフェースで扱うためのプロトコル
+@MainActor
+protocol RewardedAdControlling: AnyObject, FullScreenContentDelegate, AdsConsentCoordinatorStateDelegate {
+    var delegate: RewardedAdControllerDelegate? { get set }
+
+    /// 初期表示に備えて広告を読み込み、必要ならば再度ロードする
+    func prepareInitialLoad()
+    /// リワード広告を表示し、視聴完了で報酬が得られたかどうかを返す
+    func showRewardedAd() async -> Bool
+    /// 広告機能全体を停止する（IAP による広告除去対応など）
+    func disableAds()
+    /// removeAds フラグ取得用クロージャを登録する
+    func updateRemoveAdsProvider(_ provider: @escaping () -> Bool)
+}
+
+// MARK: - GMA SDK を抽象化する薄いラッパー
+protocol RewardedAdPresentable: AnyObject, FullScreenPresentingAd {
+    var fullScreenContentDelegate: FullScreenContentDelegate? { get set }
+    func present(from viewController: UIViewController, userDidEarnRewardHandler: @escaping () -> Void)
+}
+
+extension RewardedAd: RewardedAdPresentable {
+    func present(from viewController: UIViewController, userDidEarnRewardHandler: @escaping () -> Void) {
+        // SDK v11 以降は `present(from:)` が推奨 API
+        present(from: viewController) { _ in
+            userDidEarnRewardHandler()
+        }
+    }
+}
+
+/// リワード広告の読み込みを切り替え可能にするためのプロトコル
+protocol RewardedAdLoading {
+    func load(adUnitID: String, request: GoogleMobileAds.Request, completion: @escaping (RewardedAdPresentable?, Error?) -> Void)
+}
+
+/// 実機用のデフォルトローダー
+struct DefaultRewardedAdLoader: RewardedAdLoading {
+    func load(adUnitID: String, request: GoogleMobileAds.Request, completion: @escaping (RewardedAdPresentable?, Error?) -> Void) {
+        RewardedAd.load(with: adUnitID, request: request) { ad, error in
+            completion(ad, error)
+        }
+    }
+}
+
+// MARK: - 本体実装
+@MainActor
+final class RewardedAdController: NSObject, RewardedAdControlling {
+    weak var delegate: RewardedAdControllerDelegate?
+
+    private let adUnitID: String
+    private let hasValidAdConfiguration: Bool
+    private var consentState: AdsConsentState
+    private let loader: RewardedAdLoading
+    private var removeAdsProvider: () -> Bool = { false }
+
+    private var rewardedAd: RewardedAdPresentable?
+    private var isLoadingAd: Bool = false
+    private var areAdsDisabled: Bool = false
+    private var pendingContinuation: CheckedContinuation<Bool, Never>?
+    private var didEarnRewardInCurrentPresentation: Bool = false
+
+    init(
+        adUnitID: String,
+        hasValidAdConfiguration: Bool,
+        initialConsentState: AdsConsentState,
+        loader: RewardedAdLoading = DefaultRewardedAdLoader()
+    ) {
+        self.adUnitID = adUnitID
+        self.hasValidAdConfiguration = hasValidAdConfiguration
+        self.consentState = initialConsentState
+        self.loader = loader
+        super.init()
+    }
+
+    deinit {
+        pendingContinuation?.resume(returning: false)
+        pendingContinuation = nil
+    }
+
+    func prepareInitialLoad() {
+        loadIfNeeded()
+    }
+
+    func showRewardedAd() async -> Bool {
+        guard hasValidAdConfiguration else {
+            debugLog("RewardedAdController: Info.plist にリワード広告の設定が不足しているため表示を行いません")
+            return false
+        }
+
+        guard !areAdsDisabled, !removeAdsProvider() else {
+            debugLog("RewardedAdController: 広告が無効化されているためリワード広告を表示しません")
+            return false
+        }
+
+        guard consentState.canRequestAds else {
+            debugLog("RewardedAdController: UMP の状態により広告リクエストが禁止されているため表示できません")
+            return false
+        }
+
+        guard let root = delegate?.rootViewControllerForPresentation(self) else {
+            debugLog("RewardedAdController: 表示に利用できる ViewController が見つからなかったためリトライを予約します")
+            triggerReload()
+            return false
+        }
+
+        guard let rewardedAd else {
+            debugLog("RewardedAdController: リワード広告が未ロードのため表示できません。再読み込みを実行します")
+            triggerReload()
+            return false
+        }
+
+        didEarnRewardInCurrentPresentation = false
+        self.rewardedAd = nil
+        rewardedAd.fullScreenContentDelegate = self
+
+        return await withCheckedContinuation { continuation in
+            pendingContinuation = continuation
+            debugLog("RewardedAdController: リワード広告の表示を開始します")
+            rewardedAd.present(from: root) { [weak self] in
+                self?.didEarnRewardInCurrentPresentation = true
+                debugLog("RewardedAdController: ユーザーが報酬条件を満たしました")
+            }
+        }
+    }
+
+    func disableAds() {
+        guard !areAdsDisabled else { return }
+        areAdsDisabled = true
+        rewardedAd = nil
+        pendingContinuation?.resume(returning: false)
+        pendingContinuation = nil
+        debugLog("RewardedAdController: 広告機能を無効化したため以後のリワード広告読み込みを停止します")
+    }
+
+    func updateRemoveAdsProvider(_ provider: @escaping () -> Bool) {
+        removeAdsProvider = provider
+    }
+
+    func adsConsentCoordinator(_ coordinator: AdsConsentCoordinating, didUpdate state: AdsConsentState, shouldReloadAds: Bool) {
+        consentState = state
+        if shouldReloadAds {
+            rewardedAd = nil
+            loadIfNeeded(force: true)
+            return
+        }
+
+        if state.canRequestAds && rewardedAd == nil && !isLoadingAd {
+            loadIfNeeded()
+        }
+    }
+
+    // MARK: - FullScreenContentDelegate
+    func adWillPresentFullScreenContent(_ ad: FullScreenPresentingAd) {
+        debugLog("RewardedAdController: リワード広告の表示準備が完了しました")
+    }
+
+    func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
+        pendingContinuation?.resume(returning: didEarnRewardInCurrentPresentation)
+        pendingContinuation = nil
+        debugLog("RewardedAdController: リワード広告を閉じたため次の読み込みを開始します")
+        triggerReload()
+    }
+
+    func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        debugError(error, message: "RewardedAdController: リワード広告の表示に失敗しました")
+        pendingContinuation?.resume(returning: false)
+        pendingContinuation = nil
+        triggerReload()
+    }
+
+    // MARK: - 内部処理
+    private func loadIfNeeded(force: Bool = false) {
+        guard hasValidAdConfiguration else { return }
+        guard consentState.canRequestAds else { return }
+        guard !areAdsDisabled else { return }
+        guard !removeAdsProvider() else { return }
+        guard force || rewardedAd == nil else { return }
+        guard !isLoadingAd else { return }
+
+        debugLog("RewardedAdController: リワード広告の読み込みを開始します (NPA: \(consentState.shouldUseNPA))")
+        isLoadingAd = true
+
+        let request = GoogleMobileAds.Request()
+        if consentState.shouldUseNPA {
+            let extras = Extras()
+            extras.additionalParameters = ["npa": "1"]
+            request.register(extras)
+        }
+
+        loader.load(adUnitID: adUnitID, request: request) { [weak self] ad, error in
+            Task { [weak self] in
+                guard let self else { return }
+                await self.handleLoadResult(ad: ad, error: error)
+            }
+        }
+    }
+
+    private func handleLoadResult(ad: RewardedAdPresentable?, error: Error?) async {
+        isLoadingAd = false
+
+        if let error {
+            debugError(error, message: "RewardedAdController: リワード広告の読み込みに失敗しました")
+            return
+        }
+
+        guard !areAdsDisabled, !removeAdsProvider() else { return }
+        rewardedAd = ad
+        debugLog("RewardedAdController: リワード広告の読み込みが完了しました")
+    }
+
+    private func triggerReload() {
+        guard !areAdsDisabled else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            await MainActor.run { self.loadIfNeeded(force: true) }
+        }
+    }
+}

--- a/Services/ServiceInterfaces.swift
+++ b/Services/ServiceInterfaces.swift
@@ -33,6 +33,8 @@ protocol AdsServiceProtocol: AnyObject {
     func resetPlayFlag()
     /// 広告読み込みを完全に停止する（IAP 購入時などに利用）。
     func disableAds()
+    /// リワード広告を表示し、視聴完了で報酬が得られたかを返す。
+    func showRewardedAd() async -> Bool
     /// ATT（アプリトラッキング許可）をリクエストする。
     func requestTrackingAuthorization() async
     /// UMP（ユーザー同意）を必要に応じて提示する。

--- a/Services/ServiceMocks.swift
+++ b/Services/ServiceMocks.swift
@@ -29,6 +29,10 @@ final class MockGameCenterService: GameCenterServiceProtocol {
 final class MockAdsService: AdsServiceProtocol {
     /// 無効化フラグ。IAP などで広告を停止したケースを再現
     private var isDisabled = false
+    /// リワード広告の結果を切り替えるためのフラグ
+    var rewardedAdShouldSucceed: Bool = true
+    /// リワード広告 API が呼ばれた回数をテストで検証できるようにする
+    private(set) var showRewardedAdCallCount: Int = 0
 
     /// ダミー広告を全画面で表示する
     func showInterstitial() {
@@ -46,6 +50,12 @@ final class MockAdsService: AdsServiceProtocol {
 
     /// 広告読み込み停止も不要なので空実装
     func disableAds() { isDisabled = true }
+
+    /// リワード広告の表示を模倣し、事前に設定したフラグに従って成否を返す
+    func showRewardedAd() async -> Bool {
+        showRewardedAdCallCount += 1
+        return rewardedAdShouldSucceed
+    }
 
     /// ATT 許可ダイアログは表示しないダミー実装
     func requestTrackingAuthorization() async {}


### PR DESCRIPTION
## Summary
- add a user defaults backed daily challenge attempt store with type-erased wrapper for injection
- extend ads service with rewarded-ad management, including a new controller and protocol updates
- wire the attempt store into the app/root view and cover reset, limit, and reward growth cases with new tests

## Testing
- not run (CI only)

------
https://chatgpt.com/codex/tasks/task_e_68df6da96824832caf99da6c54361b1c