### PR TITLE
Fix rewarded ad closure signature

### DIFF
--- a/Services/RewardedAdController.swift
+++ b/Services/RewardedAdController.swift
@@ -36,7 +36,8 @@ protocol RewardedAdPresentable: AnyObject, FullScreenPresentingAd {
 extension RewardedAd: RewardedAdPresentable {
     func present(from viewController: UIViewController, userDidEarnRewardHandler: @escaping () -> Void) {
         // SDK v11 以降は `present(from:)` が推奨 API
-        present(from: viewController) { _ in
+        // SDK 側のクロージャは引数を受け取らないため、報酬獲得時にハンドラーを呼び出すだけにする
+        present(from: viewController) {
             userDidEarnRewardHandler()
         }
     }


### PR DESCRIPTION
## Summary
- 修正された RewardedAd のラッパーで SDK が要求する引数なしクロージャを使用
- 報酬獲得時にハンドラーのみを呼び出すようコメントで意図を明記

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df7796858c832cbabf0b10c1cda53c