### PR TITLE
Mark daily challenge variant resolver nonisolated

### DIFF
--- a/Services/DailyChallengeDefinitionService.swift
+++ b/Services/DailyChallengeDefinitionService.swift
@@ -118,8 +118,9 @@ final class DailyChallengeDefinitionService: ObservableObject, DailyChallengeDef
         return nextDay
     }
 
+    // 純粋関数のためメインアクター不要
     /// 既定のバリアント決定ロジック（偶数シードは固定、奇数シードはランダム）
-    private static func defaultVariantResolver(_ seed: UInt64) -> DailyChallengeDefinition.Variant {
+    private nonisolated static func defaultVariantResolver(_ seed: UInt64) -> DailyChallengeDefinition.Variant {
         // seed の最下位ビットで偶奇を判定し、シンプルかつ決定論的にバリアントを切り替える
         if seed & 1 == 0 {
             return .fixed


### PR DESCRIPTION
## Summary
- note that the default daily challenge variant resolver is a pure function that does not require the main actor
- mark the resolver as `nonisolated` so it can be called from Swift 6 concurrency contexts without main-actor isolation warnings

## Testing
- `swift build -Xswiftc -swift-version -Xswiftc 6` *(fails due to pre-existing concurrency-safety errors in SharedSupport)*

------
https://chatgpt.com/codex/tasks/task_e_68df78ba175c832c9b56c4b3c349ab49