### PR TITLE
Handle preparation overlay timer pausing in GameViewModel

### DIFF
--- a/UI/GameView+Observers.swift
+++ b/UI/GameView+Observers.swift
@@ -36,7 +36,8 @@ extension GameView {
                     colorScheme: colorScheme,
                     guideModeEnabled: guideModeEnabled,
                     hapticsEnabled: hapticsEnabled,
-                    handOrderingStrategy: resolveHandOrderingStrategy()
+                    handOrderingStrategy: resolveHandOrderingStrategy(),
+                    isPreparationOverlayVisible: isPreparationOverlayVisible
                 )
             }
             // ライト/ダーク切り替えが発生した場合も SpriteKit 側へ反映
@@ -70,6 +71,12 @@ extension GameView {
             // 経過時間を 1 秒ごとに再計算し、リアルタイム表示へ反映
             .onReceive(viewModel.elapsedTimer) { _ in
                 viewModel.updateDisplayedElapsedTime()
+            }
+            // ゲーム準備オーバーレイの表示状態を監視し、タイマー制御へ即座に反映する
+            .onChange(of: isPreparationOverlayVisible, initial: true) { _, isVisible in
+                // initial: true を指定して初期表示時点の状態も ViewModel へ伝播し、
+                // RootView との間で pause/resume の呼び出し漏れが生じないようにする
+                viewModel.handlePreparationOverlayChange(isVisible: isVisible)
             }
             // カードが盤面へ移動中は UI 全体を操作不可とし、状態の齟齬を防ぐ
             .disabled(boardBridge.animatingCard != nil)

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -572,6 +572,7 @@ fileprivate extension RootView {
                     gameCenterService: gameCenterService,
                     adsService: adsService,
                     campaignProgressStore: campaignProgressStore,
+                    isPreparationOverlayVisible: stateStore.binding(for: \.isPreparingGame),
                     isGameCenterAuthenticated: isAuthenticated,
                     onRequestGameCenterSignIn: onRequestGameCenterSignInPrompt,
                     onRequestReturnToTitle: {


### PR DESCRIPTION
## Summary
- pass the preparation overlay binding from `RootView` into `GameView`
- watch the overlay visibility in `GameView` and propagate it so the view model pauses/resumes the campaign timer safely
- add a dedicated unit test ensuring the timer does not advance while the preparation overlay is visible

## Testing
- Not run (local environment lacks iOS tooling)


------
https://chatgpt.com/codex/tasks/task_e_68df7fadd234832c84fa2ecaebd77403