### PR TITLE
Fix rewarded ad adapter paid event handler type

### DIFF
--- a/Services/RewardedAdController.swift
+++ b/Services/RewardedAdController.swift
@@ -55,7 +55,7 @@ final class RewardedAdAdapter: NSObject, RewardedAdPresentable {
     }
 
     /// 広告収益イベントをテストコードからも参照できるよう、SDK 側のハンドラーを委譲する
-    var paidEventHandler: PaidEventHandler? {
+    var paidEventHandler: GADPaidEventHandler? {
         get { rewardedAd.paidEventHandler }
         set { rewardedAd.paidEventHandler = newValue }
     }


### PR DESCRIPTION
## Summary
- update the rewarded ad adapter to rely on the Google Mobile Ads SDK-provided paid event handler type

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68df827f8070832ca4b477e961e79df6