### PR TITLE
Fix rewarded ad presentation API usage

### DIFF
--- a/Services/RewardedAdController.swift
+++ b/Services/RewardedAdController.swift
@@ -64,7 +64,7 @@ final class RewardedAdAdapter: NSObject, RewardedAdPresentable {
     func presentAd(from viewController: UIViewController, userDidEarnRewardHandler: @escaping () -> Void) {
         // SDK が提供する正式な present API を直接叩くことで、ラッパー内での自己再帰を確実に排除する
         rewardedAd.present(
-            fromRootViewController: viewController,
+            from: viewController,
             userDidEarnRewardHandler: {
                 // 報酬獲得時には引数なしクロージャが呼ばれるため、そのままアプリ側のハンドラーを実行する
                 userDidEarnRewardHandler()


### PR DESCRIPTION
## Summary
- update the rewarded ad adapter to use the latest present(from:userDidEarnRewardHandler:) signature

## Testing
- not run (explanatory change only)


------
https://chatgpt.com/codex/tasks/task_e_68df83a50874832cb7177b5fa861aaa6