### PR TITLE
Fix GameView preparation overlay binding

### DIFF
--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -572,7 +572,8 @@ fileprivate extension RootView {
                     gameCenterService: gameCenterService,
                     adsService: adsService,
                     campaignProgressStore: campaignProgressStore,
-                    isPreparationOverlayVisible: stateStore.binding(for: \.isPreparingGame),
+                    // RootView から引き継いだバインディングなので、$isPreparingGame をそのまま利用して意図を明確にする
+                    isPreparationOverlayVisible: $isPreparingGame,
                     isGameCenterAuthenticated: isAuthenticated,
                     onRequestGameCenterSignIn: onRequestGameCenterSignInPrompt,
                     onRequestReturnToTitle: {


### PR DESCRIPTION
## Summary
- pass the preparation overlay binding from RootView directly to GameView
- document the binding handoff in RootView for clarity

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68df9e6dad18832cb9e18765fd4efd5f