### PR TITLE
Add chapter star unlock requirement for campaign stages

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -46,6 +46,8 @@ public enum CampaignStageUnlockRequirement: Equatable {
     case always
     /// 合計スター数が指定値以上
     case totalStars(minimum: Int)
+    /// 指定章で獲得したスター数の合計が閾値以上
+    case chapterTotalStars(chapter: Int, minimum: Int)
     /// 指定ステージをクリア済み
     case stageClear(CampaignStageID)
 }
@@ -201,6 +203,11 @@ public struct CampaignStage: Identifiable, Equatable {
             return "最初から解放済み"
         case .totalStars(let minimum):
             return "スターを合計 \(minimum) 個集める"
+        case .chapterTotalStars(_, let minimum) where minimum <= 0:
+            // 閾値が 0 以下の場合は常時解放と等価であるため、利用者へもその旨を伝える
+            return "最初から解放済み"
+        case .chapterTotalStars(let chapter, let minimum):
+            return "第\(chapter)章でスターを合計 \(minimum) 個集める"
         case .stageClear(let requiredID):
             return "ステージ \(requiredID.displayCode) をクリア"
         }
@@ -364,7 +371,8 @@ public struct CampaignLibrary {
             secondaryObjective: .finishWithinSeconds(maxSeconds: 60),
             scoreTarget: 300,
             scoreTargetComparison: .lessThan,
-            unlockRequirement: .totalStars(minimum: 0)
+            // MARK: スタート地点となるため常時解放として整理する
+            unlockRequirement: .always
         )
 
         // 1-2 はキングと桂馬の最小構成で、ペナルティ合計 5 以下を目指す導入ステージ。
@@ -589,7 +597,8 @@ public struct CampaignLibrary {
             secondaryObjective: .finishWithPenaltyAtMost(maxPenaltyCount: 5),
             scoreTarget: 450,
             scoreTargetComparison: .lessThanOrEqual,
-            unlockRequirement: .stageClear(stage18.id)
+            // MARK: 第 2 章開始条件は第 1 章で十分なスターを獲得しているかを基準にする
+            unlockRequirement: .chapterTotalStars(chapter: 1, minimum: 16)
         )
 
         // 2-2: 5×5 盤で対角二度踏みを巡回し、任意スポーンでも 45 手以内へ収める判断力を育てる。
@@ -807,7 +816,8 @@ public struct CampaignLibrary {
             secondaryObjective: .finishWithoutPenalty,
             scoreTarget: 600,
             scoreTargetComparison: .lessThanOrEqual,
-            unlockRequirement: .stageClear(stage28.id)
+            // MARK: 第 3 章も前章のスター総数を指標とし、継続的なチャレンジを促す
+            unlockRequirement: .chapterTotalStars(chapter: 2, minimum: 16)
         )
 
         // 3-2: 5×5 盤へ拡張し、縦横カードで 40 手以内の踏破を目指す。
@@ -1006,7 +1016,8 @@ public struct CampaignLibrary {
             secondaryObjective: .finishWithinMoves(maxMoves: 30),
             scoreTarget: 520,
             scoreTargetComparison: .lessThanOrEqual,
-            unlockRequirement: .stageClear(stage38.id)
+            // MARK: 第 4 章開始条件は前章スター数の蓄積を基準にし、幅広い攻略を促す
+            unlockRequirement: .chapterTotalStars(chapter: 3, minimum: 16)
         )
 
         // 4-2: トグル 3 箇所でペナルティ合計 2 以下に抑える。
@@ -1231,7 +1242,8 @@ public struct CampaignLibrary {
             secondaryObjective: .finishWithinMoves(maxMoves: 30),
             scoreTarget: 500,
             scoreTargetComparison: .lessThanOrEqual,
-            unlockRequirement: .stageClear(stage48.id)
+            // MARK: 最終章は直前の章で十分なスターを獲得したプレイヤーに解放する
+            unlockRequirement: .chapterTotalStars(chapter: 4, minimum: 16)
         )
 
         // 5-2: 障害物を 3 箇所へ増やし、ペナルティ合計 2 以下で安定させる。

--- a/MonoKnightAppTests/CampaignProgressStoreTests.swift
+++ b/MonoKnightAppTests/CampaignProgressStoreTests.swift
@@ -93,4 +93,62 @@ final class CampaignProgressStoreTests: XCTestCase {
         XCTAssertTrue(reloadedStore.isDebugUnlockEnabled, "UserDefaults 経由で再読み込みしても全解放状態が保持される必要があります")
         XCTAssertTrue(reloadedStore.isStageUnlocked(lockedStage), "再生成後もステージが解放されたままになる想定です")
     }
+
+    /// 章単位のスター合計が解放条件へ反映されることを検証する
+    func testChapterTotalStarsUnlocksNextChapter() throws {
+        let defaults = try makeIsolatedDefaults()
+        let store = CampaignProgressStore(userDefaults: defaults)
+        let library = CampaignLibrary.shared
+
+        let nextChapterStageID = CampaignStageID(chapter: 2, index: 1)
+        guard let nextChapterStage = library.stage(with: nextChapterStageID) else {
+            XCTFail("第2章のステージ定義が見つかりません")
+            return
+        }
+
+        // MARK: スター 0 の状態では第 2 章の入り口がロックされている想定
+        XCTAssertFalse(store.isStageUnlocked(nextChapterStage), "第1章のスター合計が不足している場合はロックが維持される必要があります")
+
+        // MARK: 第 1 章の 6 ステージ分を順番にクリアし、スター合計を 18 まで伸ばす
+        let stageIDsToClear: [CampaignStageID] = [
+            CampaignStageID(chapter: 1, index: 1),
+            CampaignStageID(chapter: 1, index: 2),
+            CampaignStageID(chapter: 1, index: 3),
+            CampaignStageID(chapter: 1, index: 4),
+            CampaignStageID(chapter: 1, index: 5),
+            CampaignStageID(chapter: 1, index: 6)
+        ]
+        // 3 スター獲得を想定した共通メトリクス（スコアとペナルティを十分小さく保つ）
+        let perfectMetrics = CampaignStageClearMetrics(
+            moveCount: 10,
+            penaltyCount: 0,
+            elapsedSeconds: 50,
+            totalMoveCount: 10,
+            score: 200,
+            hasRevisitedTile: false
+        )
+
+        for stageID in stageIDsToClear.prefix(5) {
+            guard let stage = library.stage(with: stageID) else {
+                XCTFail("ステージ \(stageID.displayCode) の定義が見つかりません")
+                return
+            }
+            _ = store.registerClear(for: stage, metrics: perfectMetrics)
+        }
+
+        // MARK: スター合計 15 の時点では解放条件に届かないことを確認
+        XCTAssertEqual(store.totalStars(inChapter: 1), 15, "5 ステージクリア後のスター合計が想定と異なります")
+        XCTAssertFalse(store.isStageUnlocked(nextChapterStage), "スターが 16 未満の場合はロックが継続する想定です")
+
+        // MARK: 6 ステージ目をクリアして合計 18 に達すると解放される
+        if let finalStage = library.stage(with: stageIDsToClear[5]) {
+            _ = store.registerClear(for: finalStage, metrics: perfectMetrics)
+        } else {
+            XCTFail("ステージ \(stageIDsToClear[5].displayCode) の定義が見つかりません")
+            return
+        }
+
+        XCTAssertEqual(store.totalStars(inChapter: 1), 18, "第1章で獲得したスター数の集計が期待値と異なります")
+        XCTAssertTrue(store.isStageUnlocked(nextChapterStage), "スターが 16 以上になった時点で第 2 章の入口は解放される必要があります")
+    }
 }

--- a/Services/CampaignProgressStore.swift
+++ b/Services/CampaignProgressStore.swift
@@ -55,9 +55,24 @@ final class CampaignProgressStore: ObservableObject {
             return true
         case .totalStars(let minimum):
             return totalStars >= minimum
+        case .chapterTotalStars(let chapter, let minimum):
+            // MARK: 章単位のスター数を合計し、条件を満たしているか評価する
+            return minimum <= 0 || totalStars(inChapter: chapter) >= minimum
         case .stageClear(let requiredID):
             let earned = progressMap[requiredID]?.earnedStars ?? 0
             return earned > 0
+        }
+    }
+
+    /// 指定章で獲得済みのスター数を合算する
+    /// - Parameter chapter: 集計対象の章番号
+    /// - Returns: 対象章で得たスター数の合計
+    func totalStars(inChapter chapter: Int) -> Int {
+        // MARK: progressMap はステージ ID をキーに保持しているため、章番号が一致するもののみ抽出して加算する
+        progressMap.reduce(into: 0) { partialResult, element in
+            if element.key.chapter == chapter {
+                partialResult += element.value.earnedStars
+            }
         }
     }
 

--- a/Tests/GameTests/CampaignLibraryTests.swift
+++ b/Tests/GameTests/CampaignLibraryTests.swift
@@ -184,7 +184,7 @@ final class CampaignLibraryTests: XCTestCase {
                 penalties: GameMode.PenaltySettings(deadlockPenaltyCost: 2, manualRedrawPenaltyCost: 2, manualDiscardPenaltyCost: 1, revisitPenaltyCost: 1),
                 secondary: .finishWithinSeconds(maxSeconds: 60),
                 scoreTarget: 300,
-                unlock: .totalStars(minimum: 0)
+                unlock: .always
             ),
             2: (
                 title: "ナイト初見",
@@ -308,7 +308,7 @@ final class CampaignLibraryTests: XCTestCase {
                 penalties: penalties,
                 secondary: .finishWithPenaltyAtMost(maxPenaltyCount: 5),
                 scoreTarget: 620,
-                unlock: .stageClear(CampaignStageID(chapter: 1, index: 8)),
+                unlock: .chapterTotalStars(chapter: 1, minimum: 16),
                 additional: [GridPoint(x: 1, y: 1): 2, GridPoint(x: 2, y: 2): 2]
             ),
             2: StageExpectation(
@@ -441,7 +441,7 @@ final class CampaignLibraryTests: XCTestCase {
                 penalties: noPenalty,
                 secondary: .finishWithoutPenalty,
                 scoreTarget: 600,
-                unlock: .stageClear(CampaignStageID(chapter: 2, index: 8))
+                unlock: .chapterTotalStars(chapter: 2, minimum: 16)
             ),
             2: StageExpectation(
                 title: "縦横基礎",
@@ -560,7 +560,7 @@ final class CampaignLibraryTests: XCTestCase {
                 penalties: penalties,
                 secondary: .finishWithinMoves(maxMoves: 30),
                 scoreTarget: 520,
-                unlock: .stageClear(CampaignStageID(chapter: 3, index: 8)),
+                unlock: .chapterTotalStars(chapter: 3, minimum: 16),
                 toggles: [GridPoint(x: 1, y: 1), GridPoint(x: 3, y: 3)]
             ),
             2: StageExpectation(
@@ -689,7 +689,7 @@ final class CampaignLibraryTests: XCTestCase {
                 penalties: penalties,
                 secondary: .finishWithinMoves(maxMoves: 30),
                 scoreTarget: 500,
-                unlock: .stageClear(CampaignStageID(chapter: 4, index: 8)),
+                unlock: .chapterTotalStars(chapter: 4, minimum: 16),
                 impassable: [GridPoint(x: 1, y: 1), GridPoint(x: 3, y: 3)]
             ),
             2: StageExpectation(


### PR DESCRIPTION
## Summary
- add a chapter-wide star threshold unlock requirement for campaign stages
- wire campaign stages to the new requirement, including first stages of chapters 2–5
- update campaign progress logic and tests to cover the new unlocking behavior

## Testing
- swift test *(fails: CampaignLibraryTests contains existing expectation mismatches unrelated to the new unlock logic)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb77e1d80832c800df0806ff02462