### PR TITLE
Annotate campaign helper with MainActor isolation

### DIFF
--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -492,10 +492,12 @@ private struct ChapterProgressSummary {
 ///   - library: 章とステージ定義を含むキャンペーンライブラリ
 ///   - progressStore: ステージ解放状況と獲得スター数を保持する進捗ストア
 /// - Returns: 展開すべき章 ID の集合。該当章が無い場合は最新の解放章、さらに無い場合は先頭章を返す。
+@MainActor
 internal func chapterIDsWithUnlockedUnclearedStages(
     library: CampaignLibrary,
     progressStore: CampaignProgressStore
 ) -> Set<Int> {
+    // メインアクター隔離を明示することで、progressStore の ObservableObject メソッドへ安全にアクセスできるようにする
     // まずは未クリア（スター 0）でありながら解放済みのステージを探索し、同じ章を重複なく収集する
     var unlockedUnclearedChapterIDs = Set<Int>()
     for chapter in library.chapters {


### PR DESCRIPTION
## Summary
- ensure `chapterIDsWithUnlockedUnclearedStages` is annotated with `@MainActor` to guarantee safe access to `CampaignProgressStore`
- document the actor-isolation intent for the helper while keeping existing behavior intact

## Testing
- xcodebuild -scheme MonoKnight -destination 'platform=iOS Simulator,name=iPhone 14' test *(fails: `xcodebuild` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfbb91dab4832ca7a69c9d84736c96