### PR TITLE
Add debug unlimited mode toggle for daily challenge attempts

### DIFF
--- a/UI/DailyChallengeView.swift
+++ b/UI/DailyChallengeView.swift
@@ -148,6 +148,13 @@ final class DailyChallengeViewModel: ObservableObject {
     func requestRewardedAttempt() async {
         attemptStore.refreshForCurrentDate()
 
+        if attemptStore.isDebugUnlimitedEnabled {
+            // デバッグ無制限モードでは広告視聴が不要であることを明示する
+            alertState = AlertState(title: "デバッグモード", message: "無制限モードが有効なため広告視聴は不要です。")
+            updateAttemptRelatedTexts()
+            return
+        }
+
         guard attemptStore.rewardedAttemptsGranted < attemptStore.maximumRewardedAttempts else {
             alertState = AlertState(title: "追加不可", message: "広告で追加できる回数の上限に達しています。")
             updateAttemptRelatedTexts()
@@ -192,6 +199,15 @@ final class DailyChallengeViewModel: ObservableObject {
 
     /// 残量テキストやボタン有効状態をストアから再計算する
     private func updateAttemptRelatedTexts() {
+        if attemptStore.isDebugUnlimitedEnabled {
+            // 無制限モード時は残量文言とボタン状態を専用表示へ切り替える
+            remainingAttemptsText = "デバッグモード: 無制限"
+            rewardProgressText = "広告視聴は不要です（デバッグモード）"
+            isStartButtonEnabled = true
+            isRewardButtonEnabled = false
+            return
+        }
+
         let remaining = attemptStore.remainingAttempts
         let granted = attemptStore.rewardedAttemptsGranted
         let maximumRewarded = attemptStore.maximumRewardedAttempts

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -400,6 +400,8 @@ fileprivate extension RootView {
                 )
                     // キャンペーン進捗ストアも同じインスタンスを共有し、デバッグ用パスコード入力で即座に反映されるようにする。
                     .environmentObject(campaignProgressStore)
+                    // 日替わりチャレンジの挑戦回数ストアも共有し、設定画面からデバッグ無制限を切り替えられるようにする。
+                    .environmentObject(dailyChallengeAttemptStore)
             }
             // Game Center の再サインインを促すためのアラートを監視する
             .alert(item: stateStore.binding(for: \.gameCenterSignInPrompt)) { prompt in

--- a/UI/SettingsView.swift
+++ b/UI/SettingsView.swift
@@ -24,6 +24,9 @@ struct SettingsView: View {
     // キャンペーンモードの進捗を共有し、デバッグ用パスコード入力で全ステージ解放フラグを更新できるようにする。
     @EnvironmentObject private var campaignProgressStore: CampaignProgressStore
 
+    // 日替わりチャレンジの挑戦回数ストアを共有し、デバッグ無制限モードの切り替えにも対応する。
+    @EnvironmentObject private var dailyChallengeAttemptStore: AnyDailyChallengeAttemptStore
+
     // 購入ボタンを複数回タップできないようにするための進行状況フラグ。
     @State private var isPurchaseInProgress = false
 
@@ -408,6 +411,16 @@ struct SettingsView: View {
                                 .font(.footnote)
                                 .foregroundStyle(.secondary)
                         }
+
+                        if dailyChallengeAttemptStore.isDebugUnlimitedEnabled {
+                            // 日替わりチャレンジの無制限モードが有効であることを通知し、広告視聴が不要な旨を共有する。
+                            Label("デイリーチャレンジは無制限モードです", systemImage: "infinity")
+                                .foregroundStyle(.blue)
+                                .font(.subheadline)
+                            Text("デバッグ検証中は挑戦回数の消費と広告視聴がスキップされます。")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 } header: {
                     Text("デバッグ")
@@ -523,6 +536,8 @@ private extension SettingsView {
         if trimmed == Self.debugUnlockPassword {
             // 正しいパスコード入力時は進捗ストアへ通知して永続化し、アラートで完了を知らせる
             campaignProgressStore.enableDebugUnlock()
+            // デイリーチャレンジの挑戦回数もデバッグモードへ切り替え、検証を効率化する
+            dailyChallengeAttemptStore.enableDebugUnlimited()
             debugUnlockInput = ""
             isDebugUnlockSuccessAlertPresented = true
         } else {


### PR DESCRIPTION
## Summary
- add a persisted debug-unlimited flag to the daily challenge attempt store and its type eraser
- expose debug mode messaging in the daily challenge view and enable the toggle from settings
- cover the new behavior with unit tests for persistence and unlimited consumption

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e038330b64832cb64e628a4193a000