### PR TITLE
Adjust daily challenge back navigation

### DIFF
--- a/Tests/GameUITests/DailyChallengeUITests.swift
+++ b/Tests/GameUITests/DailyChallengeUITests.swift
@@ -54,8 +54,8 @@ final class DailyChallengeUITests: XCTestCase {
         )
         XCTAssertEqual(XCTWaiter.wait(for: [rewardExpectation, remainingExpectation], timeout: 5), .completed, "広告視聴後に挑戦回数が 1 回ぶん回復し、付与済み回数が更新されること")
 
-        let closeButton = app.buttons["daily_challenge_close_button"]
-        XCTAssertTrue(closeButton.waitForExistence(timeout: 3), "日替わり画面を閉じるボタンが表示されること")
+        let closeButton = app.buttons["daily_challenge_back_button"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 3), "日替わり画面へ戻るボタンが表示されること")
         closeButton.tap()
     }
 }

--- a/UI/DailyChallengeView.swift
+++ b/UI/DailyChallengeView.swift
@@ -281,10 +281,18 @@ struct DailyChallengeView: View {
         .background(theme.backgroundPrimary.ignoresSafeArea())
         .navigationTitle("デイリーチャレンジ")
         .navigationBarTitleDisplayMode(.inline)
+        // システム標準の戻る矢印は非表示にし、専用の戻るボタンへ誘導する
+        .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                Button("閉じる") { onDismiss() }
-                    .accessibilityIdentifier("daily_challenge_close_button")
+                Button {
+                    // 戻る操作を親ビューへ伝達し、タイトル画面へ戻る
+                    onDismiss()
+                } label: {
+                    Label("戻る", systemImage: "chevron.backward")
+                        .font(.system(size: 15, weight: .medium, design: .rounded))
+                }
+                .accessibilityIdentifier("daily_challenge_back_button")
             }
         }
         .onAppear {


### PR DESCRIPTION
## Summary
- hide the system back arrow on the daily challenge view and provide the unified back button style used elsewhere
- update the daily challenge UI test to look for the new back button identifier

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e03e59f5b0832c96d40314cb770192