### PR TITLE
Disable campaign close button on navigation push

### DIFF
--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -13,6 +13,7 @@ struct CampaignStageSelectionView: View {
     /// クローズハンドラ
     let onClose: () -> Void
     /// ナビゲーションバーに閉じるボタンを表示するかどうか
+    /// - NOTE: モーダルシート表示では `true`、NavigationStack のプッシュ遷移では戻るボタンと役割が重複するため `false` を渡す想定
     let showsCloseButton: Bool
     /// ステージ決定時のハンドラ
     let onSelectStage: (CampaignStage) -> Void
@@ -29,7 +30,7 @@ struct CampaignStageSelectionView: View {
     ///   - selectedStageID: すでに選択済みのステージ ID
     ///   - onClose: ビューを閉じるためのコールバック
     ///   - onSelectStage: ステージ選択確定時に呼び出されるコールバック
-    ///   - showsCloseButton: ナビゲーションバーへ「閉じる」ボタンを表示するかどうか
+    ///   - showsCloseButton: ナビゲーションバーへ「閉じる」ボタンを表示するかどうか（モーダルシートでは `true`、NavigationStack 遷移では `false` を想定）
     init(
         campaignLibrary: CampaignLibrary,
         progressStore: CampaignProgressStore,

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -1822,6 +1822,9 @@ fileprivate struct TitleScreenView: View {
                     progressStore: campaignProgressStore,
                     selectedStageID: highlightedCampaignStageID,
                     onClose: { popNavigationStack() },
+                    // NavigationStack の遷移では左上の戻るボタンのみを利用するため、
+                    // 閉じるボタンを無効化して重複導線を排除する
+                    showsCloseButton: false,
                     onSelectStage: { stage in
                         // 選択されたステージを一旦保持し、NavigationStack をリセットした後に開始処理をキューへ積む
                         handleCampaignStageSelection(stage)


### PR DESCRIPTION
## Summary
- hide the campaign close button when presented from the title screen navigation stack
- document the expected use of the `showsCloseButton` flag for sheet vs navigation push contexts

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e04c76ced8832cbe753ee9d256fba4