### PR TITLE
Adjust choice card weights to emphasize training

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -122,9 +122,11 @@ struct Deck {
         static let standardWithOrthogonalChoices: Configuration = {
             let choiceCards: [MoveCard] = [.kingUpOrDown, .kingLeftOrRight]
             let allowedMoves = MoveCard.standardSet + choiceCards
+            // 選択式カードの初動習得を早めるため、該当カードだけ重みを 2 に引き上げてドロー頻度を上げる
+            let overrides = Dictionary(uniqueKeysWithValues: choiceCards.map { ($0, 2) })
             return Configuration(
                 allowedMoves: allowedMoves,
-                weightProfile: WeightProfile(defaultWeight: 1),
+                weightProfile: WeightProfile(defaultWeight: 1, overrides: overrides),
                 deckSummaryText: "標準＋上下左右選択キング"
             )
         }()
@@ -139,9 +141,11 @@ struct Deck {
                 .kingLeftDiagonalChoice
             ]
             let allowedMoves = MoveCard.standardSet + choiceCards
+            // 斜め選択カードの練習段階では、プレイヤーが積極的に引けるよう重み 2 の上書きを適用する
+            let overrides = Dictionary(uniqueKeysWithValues: choiceCards.map { ($0, 2) })
             return Configuration(
                 allowedMoves: allowedMoves,
-                weightProfile: WeightProfile(defaultWeight: 1),
+                weightProfile: WeightProfile(defaultWeight: 1, overrides: overrides),
                 deckSummaryText: "標準＋斜め選択キング"
             )
         }()
@@ -156,9 +160,11 @@ struct Deck {
                 .knightLeftwardChoice
             ]
             let allowedMoves = MoveCard.standardSet + choiceCards
+            // 桂馬の複方向ジャンプを習得しやすくするため、選択式桂馬カードだけ重み 2 で抽選されるようにする
+            let overrides = Dictionary(uniqueKeysWithValues: choiceCards.map { ($0, 2) })
             return Configuration(
                 allowedMoves: allowedMoves,
-                weightProfile: WeightProfile(defaultWeight: 1),
+                weightProfile: WeightProfile(defaultWeight: 1, overrides: overrides),
                 deckSummaryText: "標準＋桂馬選択カード"
             )
         }()

--- a/Tests/GameTests/DeckTests.swift
+++ b/Tests/GameTests/DeckTests.swift
@@ -55,6 +55,12 @@ final class DeckTests: XCTestCase {
         // MARK: 追加カードが正しく入っているか確認
         let expectedChoices: Set<MoveCard> = [.kingUpOrDown, .kingLeftOrRight]
         XCTAssertTrue(expectedChoices.isSubset(of: allowedMoves), "上下左右選択キングが不足しています")
+        // MARK: 選択式キングの学習を促すため重み 2 で上書きされていることを確認
+        expectedChoices.forEach { choice in
+            XCTAssertEqual(config.weightProfile.weight(for: choice), 2, "縦横選択キングの重みが想定値の 2 ではありません: \(choice)")
+        }
+        // MARK: 既存カードは重み 1 を維持しているか念のためチェック
+        XCTAssertEqual(config.weightProfile.weight(for: .kingUp), 1, "標準カードの重みが 1 から変化しています")
         // MARK: サマリー文言がプレイヤー向け説明と一致しているか検証
         XCTAssertEqual(config.deckSummaryText, "標準＋上下左右選択キング")
     }
@@ -72,6 +78,12 @@ final class DeckTests: XCTestCase {
             .kingLeftDiagonalChoice
         ]
         XCTAssertTrue(expectedChoices.isSubset(of: allowedMoves), "斜め選択キングが不足しています")
+        // MARK: 斜め選択キングだけ重み 2 で抽選されることを検証
+        expectedChoices.forEach { choice in
+            XCTAssertEqual(config.weightProfile.weight(for: choice), 2, "斜め選択キングの重みが想定値の 2 ではありません: \(choice)")
+        }
+        // MARK: 標準カードが従来通り重み 1 のままか確認
+        XCTAssertEqual(config.weightProfile.weight(for: .kingUp), 1, "標準カードの重みが 1 から変化しています")
         XCTAssertEqual(config.deckSummaryText, "標準＋斜め選択キング")
     }
 
@@ -88,6 +100,12 @@ final class DeckTests: XCTestCase {
             .knightLeftwardChoice
         ]
         XCTAssertTrue(expectedChoices.isSubset(of: allowedMoves), "桂馬選択カードが不足しています")
+        // MARK: 桂馬選択カードのみ重み 2 に引き上げられていることを確認
+        expectedChoices.forEach { choice in
+            XCTAssertEqual(config.weightProfile.weight(for: choice), 2, "桂馬選択カードの重みが想定値の 2 ではありません: \(choice)")
+        }
+        // MARK: スタンダードカードの重みは 1 を維持していることを確認
+        XCTAssertEqual(config.weightProfile.weight(for: .knightUp2Right1), 1, "既存桂馬カードの重みが 1 から変化しています")
         XCTAssertEqual(config.deckSummaryText, "標準＋桂馬選択カード")
     }
 

--- a/docs/campaign-stage-regulations.md
+++ b/docs/campaign-stage-regulations.md
@@ -51,12 +51,12 @@ MonoKnight のキャンペーンモードに収録されている各ステージ
 |----------------|-----------|----------------|-----------|
 | `kingOnly` | キング型 8 種のみ | 全カードを均等重み (1) で抽選 | 3×3 初学者訓練 (1-1)。 |
 | `standard` | `MoveCard.standardSet` 24 種 | 全カードを均等重み (1) で抽選 | 4×4〜5×5 の基礎ステージ。 |
-| `standardWithOrthogonalChoices` | 標準 + 上下左右選択キング 2 種 | 全カードを均等重み (1) で抽選 | 3-1 の選択カード導入。 |
-| `standardWithDiagonalChoices` | 標準 + 斜め選択キング 4 種 | 全カードを均等重み (1) で抽選 | 3-2 の角操作練習。 |
-| `standardWithKnightChoices` | 標準 + 桂馬選択 4 種 | 全カードを均等重み (1) で抽選 | 3-3 のジャンプ練習。 |
+| `standardWithOrthogonalChoices` | 標準 + 上下左右選択キング 2 種 | 選択カードのみ重み 2 / その他は 1 | 3-1 の選択カード導入。 |
+| `standardWithDiagonalChoices` | 標準 + 斜め選択キング 4 種 | 選択カードのみ重み 2 / その他は 1 | 3-2 の角操作練習。 |
+| `standardWithKnightChoices` | 標準 + 桂馬選択 4 種 | 選択カードのみ重み 2 / その他は 1 | 3-3 のジャンプ練習。 |
 | `standardWithAllChoices` | 標準 + 全選択カード 10 種 | 全カードを均等重み (1) で抽選 | 3-4・5-1 の総合演習。 |
 
-> **補足:** 現行実装では選択カードに個別重みの上書きは設定していない。調整が必要になった場合は `Deck.Configuration.WeightProfile` の `overrides` を更新する。<!-- コード変更ポイントを明記 -->
+> **補足:** 章 3 の導入をスムーズにするため、各種選択カードは `Deck.Configuration.WeightProfile` の `overrides` で重み 2 に上書きしている。その他カードは従来通り重み 1 を維持する。<!-- コード変更ポイントと調整理由を明記 -->
 
 ## 4. ペナルティ設定一覧
 


### PR DESCRIPTION
## Summary
- raise the weight overrides for choice-enabled standard deck variants so their cards are drawn more often
- document the new weighting approach for campaign presets to keep balance notes in sync
- extend deck configuration tests to assert the updated weights while guarding existing cards

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e21c3b92c8832ca39b60b814f71a64