### PR TITLE
ポーズメニューにペナルティ説明を表示

### DIFF
--- a/MonoKnightAppTests/GameViewModelTests.swift
+++ b/MonoKnightAppTests/GameViewModelTests.swift
@@ -39,6 +39,43 @@ final class GameViewModelTests: XCTestCase {
         )
     }
 
+    /// ポーズメニュー用のペナルティ説明がモード設定と一致することを確認
+    func testPauseMenuPenaltyItemsMatchModePenalties() {
+        // 手詰まりと捨て札のみペナルティが発生するモードを用意し、ゼロの場合の表記も同時に検証する。
+        let penalties = GameMode.PenaltySettings(
+            deadlockPenaltyCost: 7,
+            manualRedrawPenaltyCost: 0,
+            manualDiscardPenaltyCost: 4,
+            revisitPenaltyCost: 0
+        )
+        let regulation = GameMode.Regulation(
+            boardSize: 5,
+            handSize: 5,
+            nextPreviewCount: 3,
+            allowsStacking: true,
+            deckPreset: .standard,
+            spawnRule: .fixed(GridPoint(x: 2, y: 2)),
+            penalties: penalties
+        )
+        let mode = GameMode(
+            identifier: .freeCustom,
+            displayName: "テスト用カスタムモード",
+            regulation: regulation
+        )
+        let (viewModel, _) = makeViewModel(mode: mode)
+
+        XCTAssertEqual(
+            viewModel.pauseMenuPenaltyItems,
+            [
+                "手詰まり +7 手",
+                "引き直し ペナルティなし",
+                "捨て札 +4 手",
+                "再訪ペナルティなし"
+            ],
+            "RootView の表記と同じ並び・文言でペナルティ説明が生成される必要があります"
+        )
+    }
+
     /// 捨て札ボタンを押すとモードが開始されることを確認
     func testToggleManualDiscardSelectionActivatesWhenPlayable() {
         let (viewModel, core) = makeViewModel(mode: .standard)

--- a/MonoKnightAppUITests/MonoKnightAppUITests.swift
+++ b/MonoKnightAppUITests/MonoKnightAppUITests.swift
@@ -104,6 +104,39 @@ final class MonoKnightAppUITests: XCTestCase {
     }
 
     @MainActor
+    func testPauseMenuDisplaysPenaltyRows() throws {
+        // ゲーム画面まで遷移した上でポーズメニューを開き、新設されたペナルティ一覧が表示されることを確認する
+        app.launch()
+
+        // スタンダードモードを選択し、ポーズボタンへアクセスできる状態まで進める
+        let standardModeButton = app.buttons["mode_button_standard5x5"]
+        XCTAssertTrue(standardModeButton.waitForExistence(timeout: 5), "スタンダードモードのカードが表示されること")
+        standardModeButton.tap()
+
+        let startButton = app.buttons["start_game_button"]
+        XCTAssertTrue(startButton.waitForExistence(timeout: 5), "ゲーム開始ボタンが表示されること")
+        XCTAssertTrue(startButton.isEnabled, "選択後は開始ボタンが有効になること")
+        startButton.tap()
+
+        // ゲーム画面の要素を待機してからポーズメニューを開く
+        let firstHandSlot = app.otherElements["hand_slot_0"]
+        XCTAssertTrue(firstHandSlot.waitForExistence(timeout: 5), "ゲーム画面で手札スロットが表示されること")
+
+        let pauseButton = app.buttons["pause_menu_button"]
+        XCTAssertTrue(pauseButton.waitForExistence(timeout: 5), "ポーズボタンが表示されること")
+        pauseButton.tap()
+
+        // ペナルティセクションと各行の文言が RootView の案内と一致することを検証する
+        let penaltyHeader = app.staticTexts["ペナルティ"]
+        XCTAssertTrue(penaltyHeader.waitForExistence(timeout: 5), "ポーズメニューにペナルティ見出しが表示されること")
+
+        XCTAssertTrue(app.staticTexts["手詰まり +5 手"].waitForExistence(timeout: 5), "手詰まりペナルティの行が表示されること")
+        XCTAssertTrue(app.staticTexts["引き直し +5 手"].exists, "引き直しペナルティの行が表示されること")
+        XCTAssertTrue(app.staticTexts["捨て札 +1 手"].exists, "捨て札ペナルティの行が表示されること")
+        XCTAssertTrue(app.staticTexts["再訪ペナルティなし"].exists, "再訪ペナルティなしの行が表示されること")
+    }
+
+    @MainActor
     func testCampaignStageSelectionEnablesManualStartAfterPreparation() throws {
         // キャンペーンセレクターからステージを選択し、ローディング解除までの流れを自動検証する
         app.launch()

--- a/UI/GameView.swift
+++ b/UI/GameView.swift
@@ -197,6 +197,7 @@ struct GameView: View {
         .fullScreenCover(isPresented: $viewModel.isPauseMenuPresented) {
             PauseMenuView(
                 campaignSummary: viewModel.campaignPauseSummary,
+                penaltyItems: viewModel.pauseMenuPenaltyItems,
                 onResume: {
                     // フルスクリーンカバーを閉じてプレイへ戻る
                     viewModel.isPauseMenuPresented = false

--- a/UI/GameViewModel.swift
+++ b/UI/GameViewModel.swift
@@ -153,6 +153,16 @@ final class GameViewModel: ObservableObject {
         let progress = campaignProgressStore.progress(for: stage.id)
         return CampaignPauseSummary(stage: stage, progress: progress)
     }
+    /// ポーズメニューで再利用するペナルティ説明文の一覧
+    /// - Important: RootView の事前案内と文言・順序を揃え、体験の一貫性を保つ
+    var pauseMenuPenaltyItems: [String] {
+        [
+            mode.deadlockPenaltyCost > 0 ? "手詰まり +\(mode.deadlockPenaltyCost) 手" : "手詰まり ペナルティなし",
+            mode.manualRedrawPenaltyCost > 0 ? "引き直し +\(mode.manualRedrawPenaltyCost) 手" : "引き直し ペナルティなし",
+            mode.manualDiscardPenaltyCost > 0 ? "捨て札 +\(mode.manualDiscardPenaltyCost) 手" : "捨て札 ペナルティなし",
+            mode.revisitPenaltyCost > 0 ? "再訪 +\(mode.revisitPenaltyCost) 手" : "再訪ペナルティなし"
+        ]
+    }
     /// 現在のゲーム進行状態
     /// - Note: GameView 側でオーバーレイ表示を切り替える際に利用する
     var progress: GameProgress { core.progress }

--- a/UI/PauseMenuView.swift
+++ b/UI/PauseMenuView.swift
@@ -8,6 +8,8 @@ struct PauseMenuView: View {
     private var theme = AppTheme()
     /// キャンペーン進捗のサマリー（キャンペーン以外では nil）
     let campaignSummary: CampaignPauseSummary?
+    /// ポーズメニューに並べるペナルティ説明文の一覧
+    let penaltyItems: [String]
     /// プレイ再開ボタン押下時の処理
     let onResume: () -> Void
     /// リセット確定時の処理
@@ -22,11 +24,13 @@ struct PauseMenuView: View {
     ///   - onConfirmReturnToTitle: タイトル復帰確定時に実行するクロージャ
     init(
         campaignSummary: CampaignPauseSummary? = nil,
+        penaltyItems: [String] = [],
         onResume: @escaping () -> Void,
         onConfirmReset: @escaping () -> Void,
         onConfirmReturnToTitle: @escaping () -> Void
     ) {
         self.campaignSummary = campaignSummary
+        self.penaltyItems = penaltyItems
         self.onResume = onResume
         self.onConfirmReset = onConfirmReset
         self.onConfirmReturnToTitle = onConfirmReturnToTitle
@@ -51,6 +55,17 @@ struct PauseMenuView: View {
             List {
                 if let summary = campaignSummary {
                     campaignProgressSection(for: summary)
+                }
+                // MARK: - ペナルティ一覧
+                if !penaltyItems.isEmpty {
+                    Section {
+                        ForEach(penaltyItems, id: \.self) { item in
+                            Text(item)
+                                .accessibilityLabel(Text("ペナルティ項目: \(item)"))
+                        }
+                    } header: {
+                        Text("ペナルティ")
+                    }
                 }
                 // MARK: - プレイ再開ボタン
                 Section {


### PR DESCRIPTION
## Summary
- GameViewModel にポーズメニュー用のペナルティ説明プロパティを追加し RootView と表記を共通化
- PauseMenuView へペナルティセクションを追加し、GameView から配列を受け取って表示
- 単体テストと UI テストでペナルティ表示を検証

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e2206708dc832cb1e99f111fb428ac