### PR TITLE
Add controls to disable debug unlock modes

### DIFF
--- a/MonoKnightAppTests/DailyChallengeAttemptStoreTests.swift
+++ b/MonoKnightAppTests/DailyChallengeAttemptStoreTests.swift
@@ -88,6 +88,29 @@ struct DailyChallengeAttemptStoreTests {
         }
     }
 
+    /// 無制限モードを無効化すると通常の残量判定へ戻ることを検証する
+    @Test
+    func debugUnlimitedCanBeDisabled() {
+        let suiteName = "daily_challenge_store_test_disable_debug"
+        let defaults = makeIsolatedDefaults(suiteName: suiteName)
+        defer { clearDefaults(defaults, suiteName: suiteName) }
+
+        let store = DailyChallengeAttemptStore(userDefaults: defaults)
+        store.enableDebugUnlimited()
+        #expect(store.isDebugUnlimitedEnabled)
+
+        // 解除後は残量が減る通常仕様へ戻るため、連続消費でゼロになることを確認する
+        store.disableDebugUnlimited()
+        #expect(store.isDebugUnlimitedEnabled == false)
+        #expect(store.consumeAttempt())
+        #expect(store.remainingAttempts == 0)
+        #expect(store.consumeAttempt() == false)
+
+        // 再生成しても無制限フラグが false のまま維持されることを確認
+        let reloadedStore = DailyChallengeAttemptStore(userDefaults: defaults)
+        #expect(reloadedStore.isDebugUnlimitedEnabled == false)
+    }
+
     // MARK: - ヘルパー
     private func makeIsolatedDefaults(suiteName: String) -> UserDefaults {
         guard let defaults = UserDefaults(suiteName: suiteName) else {

--- a/MonoKnightAppTests/MonoKnightAppTests.swift
+++ b/MonoKnightAppTests/MonoKnightAppTests.swift
@@ -98,11 +98,18 @@ private final class StubDailyChallengeAttemptStore: ObservableObject, DailyChall
     var remainingAttempts: Int
     var rewardedAttemptsGranted: Int
     let maximumRewardedAttempts: Int
+    var isDebugUnlimitedEnabled: Bool
 
-    init(remainingAttempts: Int = 1, rewardedAttemptsGranted: Int = 0, maximumRewardedAttempts: Int = 3) {
+    init(
+        remainingAttempts: Int = 1,
+        rewardedAttemptsGranted: Int = 0,
+        maximumRewardedAttempts: Int = 3,
+        isDebugUnlimitedEnabled: Bool = false
+    ) {
         self.remainingAttempts = remainingAttempts
         self.rewardedAttemptsGranted = rewardedAttemptsGranted
         self.maximumRewardedAttempts = maximumRewardedAttempts
+        self.isDebugUnlimitedEnabled = isDebugUnlimitedEnabled
     }
 
     func refreshForCurrentDate() {}
@@ -112,6 +119,16 @@ private final class StubDailyChallengeAttemptStore: ObservableObject, DailyChall
 
     @discardableResult
     func grantRewardedAttempt() -> Bool { true }
+
+    func enableDebugUnlimited() {
+        // スタブではフラグの状態遷移だけ管理し、UI 連携の検証に利用する
+        isDebugUnlimitedEnabled = true
+    }
+
+    func disableDebugUnlimited() {
+        // 解除時は false へ戻し、再入力テストでも利用できるようにする
+        isDebugUnlimitedEnabled = false
+    }
 }
 
 struct MonoKnightAppTests {

--- a/Services/CampaignProgressStore.swift
+++ b/Services/CampaignProgressStore.swift
@@ -123,6 +123,16 @@ final class CampaignProgressStore: ObservableObject {
         debugLog("CampaignProgressStore: デバッグ用全ステージ解放フラグを有効化しました")
     }
 
+    /// デバッグ用パスコードによる全ステージ解放を無効化する
+    /// - Note: 解除操作時はフラグを false へ戻し、永続化内容も同時に更新する
+    func disableDebugUnlock() {
+        // 既に無効化済みであれば追加処理は不要なので早期リターンする
+        guard isDebugUnlockEnabled else { return }
+        isDebugUnlockEnabled = false
+        userDefaults.set(false, forKey: debugUnlockStorageKey)
+        debugLog("CampaignProgressStore: デバッグ用全ステージ解放フラグを無効化しました")
+    }
+
     /// 進捗データを読み出し
     private func loadProgress() -> [CampaignStageID: CampaignStageProgress] {
         guard let data = userDefaults.data(forKey: storageKey) else { return [:] }

--- a/Services/DailyChallengeAttemptStore.swift
+++ b/Services/DailyChallengeAttemptStore.swift
@@ -28,6 +28,8 @@ protocol DailyChallengeAttemptStoreProtocol: ObservableObject where ObjectWillCh
     func grantRewardedAttempt() -> Bool
     /// デバッグパスコード入力などで無制限モードを有効化する
     func enableDebugUnlimited()
+    /// デバッグ無制限モードを明示的に無効化する
+    func disableDebugUnlimited()
 }
 
 // MARK: - 型消去ラッパー
@@ -102,6 +104,11 @@ final class AnyDailyChallengeAttemptStore: ObservableObject, DailyChallengeAttem
 
     func enableDebugUnlimited() {
         base.enableDebugUnlimited()
+        synchronizeAfterAsyncChange()
+    }
+
+    func disableDebugUnlimited() {
+        base.disableDebugUnlimited()
         synchronizeAfterAsyncChange()
     }
 
@@ -303,6 +310,16 @@ final class DailyChallengeAttemptStore: ObservableObject, DailyChallengeAttemptS
         userDefaults.set(true, forKey: Self.debugUnlimitedStorageKey)
         userDefaults.synchronize()
         debugLog("DailyChallengeAttemptStore: デバッグ無制限モードを有効化しました")
+    }
+
+    /// デバッグ無制限モードを解除し、通常の挑戦回数管理へ戻す
+    func disableDebugUnlimited() {
+        // 無効化操作時にのみ処理を行い、不要な永続化を避ける
+        guard isDebugUnlimitedEnabled else { return }
+        isDebugUnlimitedEnabled = false
+        userDefaults.set(false, forKey: Self.debugUnlimitedStorageKey)
+        userDefaults.synchronize()
+        debugLog("DailyChallengeAttemptStore: デバッグ無制限モードを無効化しました")
     }
 
     // MARK: - 内部処理


### PR DESCRIPTION
## Summary
- add disable flows for the campaign debug unlock flag and daily challenge unlimited flag, persisting the reset to UserDefaults
- extend the settings debug tools with a disable button and updated input handling so re-entry is possible after turning overrides off
- cover the new behaviour in unit tests and align supporting stubs with the expanded protocol

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e2212489c0832c8d76c7bd07d08ace