### PR TITLE
Simplify campaign stage clear unlock description text

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -209,7 +209,8 @@ public struct CampaignStage: Identifiable, Equatable {
         case .chapterTotalStars(let chapter, let minimum):
             return "第\(chapter)章でスターを合計 \(minimum) 個集める"
         case .stageClear(let requiredID):
-            return "ステージ \(requiredID.displayCode) をクリア"
+            // ステージ番号を簡潔に伝えるため、重複した「ステージ」表現は省いている
+            return "\(requiredID.displayCode) をクリア"
         }
     }
 


### PR DESCRIPTION
## Summary
- remove the redundant "ステージ" prefix from stage-clear unlock descriptions so the requirement reads more concisely
- document the simplification intent in code comments for future maintainers

## Testing
- `swift build`


------
https://chatgpt.com/codex/tasks/task_e_68e226e96210832c8e0252135cdafe7f