### PR TITLE
Adjust locked campaign stage overlay font size

### DIFF
--- a/UI/CampaignStageSelectionView.swift
+++ b/UI/CampaignStageSelectionView.swift
@@ -428,7 +428,8 @@ private struct CampaignStageGridItemView<StarContent: View>: View {
                             .font(.system(size: 20, weight: .bold, design: .rounded))
                         // 解放条件をカード上で明示し、次の目標をその場で確認できるようにする
                         Text(stage.unlockDescription)
-                            .font(.system(size: 13, weight: .medium, design: .rounded))
+                            // フォントサイズを 1pt 下げ、カード内の改行頻度を抑制しつつ視認性を確保する
+                            .font(.system(size: 12, weight: .medium, design: .rounded))
                             .foregroundColor(theme.textPrimary.opacity(0.9))
                             .multilineTextAlignment(.center)
                             .lineLimit(3)


### PR DESCRIPTION
## Summary
- reduce the locked stage overlay description font size to limit line wrapping while keeping readability

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e226efbdb8832c988eab6b96fc6f3f