### PR TITLE
固定マップの複数踏破マスを角から退避

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -1179,8 +1179,8 @@ public struct CampaignLibrary {
 
         // 4-8: 34 手以内＆ノーペナルティで締める総合試験。
         let stage48Additional: [GridPoint: Int] = [
-            GridPoint(x: 0, y: 0): 2,
-            GridPoint(x: 4, y: 0): 3,
+            GridPoint(x: 1, y: 0): 2,
+            GridPoint(x: 3, y: 0): 3,
             GridPoint(x: 2, y: 2): 4
         ]
         let stage48Toggles: Set<GridPoint> = [
@@ -1402,8 +1402,8 @@ public struct CampaignLibrary {
             GridPoint(x: 2, y: 4)
         ]
         let stage57Additional: [GridPoint: Int] = [
-            GridPoint(x: 0, y: 0): 2,
-            GridPoint(x: 4, y: 4): 3
+            GridPoint(x: 0, y: 1): 2,
+            GridPoint(x: 4, y: 3): 3
         ]
         let stage57Toggles: Set<GridPoint> = [
             GridPoint(x: 2, y: 2)
@@ -1437,8 +1437,8 @@ public struct CampaignLibrary {
             GridPoint(x: 2, y: 2)
         ]
         let stage58Additional: [GridPoint: Int] = [
-            GridPoint(x: 0, y: 4): 2,
-            GridPoint(x: 4, y: 0): 3,
+            GridPoint(x: 1, y: 4): 2,
+            GridPoint(x: 3, y: 0): 3,
             GridPoint(x: 2, y: 4): 4
         ]
         let stage58Toggles: Set<GridPoint> = [

--- a/Tests/GameTests/CampaignLibraryTests.swift
+++ b/Tests/GameTests/CampaignLibraryTests.swift
@@ -647,7 +647,7 @@ final class CampaignLibraryTests: XCTestCase {
                 secondary: .finishWithoutPenaltyAndWithinMoves(maxMoves: 34),
                 scoreTarget: 450,
                 unlock: .stageClear(CampaignStageID(chapter: 4, index: 7)),
-                additional: [GridPoint(x: 0, y: 0): 2, GridPoint(x: 4, y: 0): 3, GridPoint(x: 2, y: 2): 4],
+                additional: [GridPoint(x: 1, y: 0): 2, GridPoint(x: 3, y: 0): 3, GridPoint(x: 2, y: 2): 4],
                 toggles: [GridPoint(x: 1, y: 1), GridPoint(x: 3, y: 3), GridPoint(x: 2, y: 4)]
             )
         ]
@@ -761,7 +761,7 @@ final class CampaignLibraryTests: XCTestCase {
                 secondary: .finishWithoutPenalty,
                 scoreTarget: 440,
                 unlock: .stageClear(CampaignStageID(chapter: 5, index: 6)),
-                additional: [GridPoint(x: 0, y: 0): 2, GridPoint(x: 4, y: 4): 3],
+                additional: [GridPoint(x: 0, y: 1): 2, GridPoint(x: 4, y: 3): 3],
                 toggles: [GridPoint(x: 2, y: 2)],
                 impassable: [GridPoint(x: 1, y: 1), GridPoint(x: 3, y: 3), GridPoint(x: 2, y: 4)]
             ),
@@ -774,7 +774,7 @@ final class CampaignLibraryTests: XCTestCase {
                 secondary: .finishWithoutPenaltyAndWithinMoves(maxMoves: 34),
                 scoreTarget: 430,
                 unlock: .stageClear(CampaignStageID(chapter: 5, index: 7)),
-                additional: [GridPoint(x: 0, y: 4): 2, GridPoint(x: 4, y: 0): 3, GridPoint(x: 2, y: 4): 4],
+                additional: [GridPoint(x: 1, y: 4): 2, GridPoint(x: 3, y: 0): 3, GridPoint(x: 2, y: 4): 4],
                 toggles: [GridPoint(x: 1, y: 3), GridPoint(x: 3, y: 1)],
                 impassable: [GridPoint(x: 1, y: 1), GridPoint(x: 3, y: 3), GridPoint(x: 2, y: 2)]
             )


### PR DESCRIPTION
## Summary
- キャンペーン第4章・第5章の固定ステージで角に残っていた複数踏破マスを一マス内側へ移動
- レイアウト変更に追従するためキャンペーン定義テストの期待座標を更新

## Testing
- not run (指示によりテスト未実行)


------
https://chatgpt.com/codex/tasks/task_e_68e22c565334832cb66125c95128f86b