### PR TITLE
Boost choice card appearance in standardWithAllChoices deck

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -185,9 +185,11 @@ struct Deck {
                 .knightLeftwardChoice
             ]
             let allowedMoves = MoveCard.standardSet + choiceCards
+            // 選択式カードを積極的に引いてもらうため、単一方向カード（重み 1）の 2 倍となる重み 2 を個別指定する
+            let overrides = Dictionary(uniqueKeysWithValues: choiceCards.map { ($0, 2) })
             return Configuration(
                 allowedMoves: allowedMoves,
-                weightProfile: WeightProfile(defaultWeight: 1),
+                weightProfile: WeightProfile(defaultWeight: 1, overrides: overrides),
                 deckSummaryText: "標準＋全選択カード"
             )
         }()

--- a/Tests/GameTests/DeckTests.swift
+++ b/Tests/GameTests/DeckTests.swift
@@ -128,6 +128,12 @@ final class DeckTests: XCTestCase {
             .knightLeftwardChoice
         ]
         XCTAssertTrue(expectedChoices.isSubset(of: allowedMoves), "全選択カードが揃っていません")
+        // MARK: 選択式カードは単一方向カードの 2 倍である重み 2 に引き上げられているか検証
+        expectedChoices.forEach { choice in
+            XCTAssertEqual(config.weightProfile.weight(for: choice), 2, "全選択カードの重みが想定値 2 と異なります: \(choice)")
+        }
+        // MARK: 既存の単一方向カードは従来どおり重み 1 を維持しているかチェック
+        XCTAssertEqual(config.weightProfile.weight(for: .kingUp), 1, "標準カードの重みが 1 から変化しています")
         XCTAssertEqual(config.deckSummaryText, "標準＋全選択カード")
     }
 


### PR DESCRIPTION
## Summary
- double the draw weight of choice cards in the `standardWithAllChoices` deck configuration to increase their appearance rate
- extend the deck configuration unit test to verify the new weight distribution for choice and single-direction cards

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e22fbafb44832c9765107dc08f7d06