### PR TITLE
Remove unused noPenalty constants from campaign library tests

### DIFF
--- a/Tests/GameTests/CampaignLibraryTests.swift
+++ b/Tests/GameTests/CampaignLibraryTests.swift
@@ -430,7 +430,6 @@ final class CampaignLibraryTests: XCTestCase {
         let fixedSpawn5 = GameMode.SpawnRule.fixed(BoardGeometry.defaultSpawnPoint(for: 5))
         let chooseAny = GameMode.SpawnRule.chooseAnyAfterPreview
         let standardPenalties = GameMode.PenaltySettings(deadlockPenaltyCost: 3, manualRedrawPenaltyCost: 2, manualDiscardPenaltyCost: 1, revisitPenaltyCost: 0)
-        let noPenalty = GameMode.PenaltySettings(deadlockPenaltyCost: 0, manualRedrawPenaltyCost: 0, manualDiscardPenaltyCost: 1, revisitPenaltyCost: 0)
 
         let expectations: [Int: StageExpectation] = [
             1: StageExpectation(
@@ -549,7 +548,6 @@ final class CampaignLibraryTests: XCTestCase {
         let fixedSpawn5 = GameMode.SpawnRule.fixed(BoardGeometry.defaultSpawnPoint(for: 5))
         let chooseAny = GameMode.SpawnRule.chooseAnyAfterPreview
         let penalties = GameMode.PenaltySettings(deadlockPenaltyCost: 3, manualRedrawPenaltyCost: 2, manualDiscardPenaltyCost: 1, revisitPenaltyCost: 0)
-        let noPenalty = GameMode.PenaltySettings(deadlockPenaltyCost: 0, manualRedrawPenaltyCost: 0, manualDiscardPenaltyCost: 1, revisitPenaltyCost: 0)
 
         let expectations: [Int: StageExpectation] = [
             1: StageExpectation(
@@ -678,7 +676,6 @@ final class CampaignLibraryTests: XCTestCase {
         let fixedSpawn5 = GameMode.SpawnRule.fixed(BoardGeometry.defaultSpawnPoint(for: 5))
         let chooseAny = GameMode.SpawnRule.chooseAnyAfterPreview
         let penalties = GameMode.PenaltySettings(deadlockPenaltyCost: 3, manualRedrawPenaltyCost: 2, manualDiscardPenaltyCost: 1, revisitPenaltyCost: 0)
-        let noPenalty = GameMode.PenaltySettings(deadlockPenaltyCost: 0, manualRedrawPenaltyCost: 0, manualDiscardPenaltyCost: 1, revisitPenaltyCost: 0)
 
         let expectations: [Int: StageExpectation] = [
             1: StageExpectation(


### PR DESCRIPTION
## Summary
- remove unused penalty settings constants from chapter 3-5 campaign tests to silence warnings

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e23d240e40832ca355ecbb50445af3