### PR TITLE
Adjust stage 3-8 move requirement to 36 moves

### DIFF
--- a/Game/CampaignStage.swift
+++ b/Game/CampaignStage.swift
@@ -942,7 +942,7 @@ public struct CampaignLibrary {
             unlockRequirement: .stageClear(stage36.id)
         )
 
-        // 3-8: ペナルティ合計 2 以下かつ 34 手以内を同時達成する総合演習。
+        // 3-8: ペナルティ合計 2 以下かつ 36 手以内を同時達成する総合演習。
         let stage38MixedVisit: [GridPoint: Int] = [
             GridPoint(x: 1, y: 1): 2,
             GridPoint(x: 2, y: 2): 3,
@@ -951,7 +951,7 @@ public struct CampaignLibrary {
         let stage38 = CampaignStage(
             id: CampaignStageID(chapter: 3, index: 8),
             title: "総合演習",
-            summary: "2/3/4 回踏みを組み合わせ、ペナルティ合計 2 以下かつ 34 手以内を達成する総仕上げです。",
+            summary: "2/3/4 回踏みを組み合わせ、ペナルティ合計 2 以下かつ 36 手以内を達成する総仕上げです。",
             regulation: GameMode.Regulation(
                 boardSize: 5,
                 handSize: 5,
@@ -962,7 +962,7 @@ public struct CampaignLibrary {
                 penalties: standardPenalties,
                 additionalVisitRequirements: stage38MixedVisit
             ),
-            secondaryObjective: .finishWithPenaltyAtMostAndWithinMoves(maxPenaltyCount: 2, maxMoves: 34),
+            secondaryObjective: .finishWithPenaltyAtMostAndWithinMoves(maxPenaltyCount: 2, maxMoves: 36),
             scoreTarget: 530,
             scoreTargetComparison: .lessThanOrEqual,
             unlockRequirement: .stageClear(stage37.id)

--- a/Tests/GameTests/CampaignLibraryTests.swift
+++ b/Tests/GameTests/CampaignLibraryTests.swift
@@ -511,7 +511,7 @@ final class CampaignLibraryTests: XCTestCase {
                 deck: .standardWithAllChoices,
                 spawn: fixedSpawn5,
                 penalties: standardPenalties,
-                secondary: .finishWithPenaltyAtMostAndWithinMoves(maxPenaltyCount: 2, maxMoves: 34),
+                secondary: .finishWithPenaltyAtMostAndWithinMoves(maxPenaltyCount: 2, maxMoves: 36),
                 scoreTarget: 530,
                 unlock: .stageClear(CampaignStageID(chapter: 3, index: 7)),
                 additional: [GridPoint(x: 1, y: 1): 2, GridPoint(x: 2, y: 2): 3, GridPoint(x: 3, y: 3): 4]


### PR DESCRIPTION
## Summary
- update the stage 3-8 definition to require completion within 36 moves instead of 34
- align the campaign library unit test expectations with the new secondary objective

## Testing
- swift test --filter CampaignLibraryTests

------
https://chatgpt.com/codex/tasks/task_e_68e23f0f8414832cb6291f23bdb7040e