### PR TITLE
Add dual daily challenge presentation

### DIFF
--- a/Tests/GameTests/DailyChallengeDefinitionTests.swift
+++ b/Tests/GameTests/DailyChallengeDefinitionTests.swift
@@ -23,6 +23,20 @@ final class DailyChallengeDefinitionTests: XCTestCase {
         XCTAssertNotEqual(fixedMode.deckSeed, randomMode.deckSeed, "バリアント間で山札シードが衝突しないようにする")
     }
 
+    /// バリアント統合 API が専用ファクトリと同一結果を返すことを確認
+    func testUnifiedMakeModeMatchesDedicatedFactories() {
+        // 単一シードを利用し、統合 API と従来 API の結果差分がないことを検証する
+        let seed: UInt64 = 0x0BAD_F00D_1234_5678
+
+        let fixedFromUnified = DailyChallengeDefinition.makeMode(for: .fixed, baseSeed: seed)
+        let fixedDirect = DailyChallengeDefinition.makeFixedMode(baseSeed: seed)
+        XCTAssertEqual(fixedFromUnified, fixedDirect, "固定版は統合 API でも従来 API と完全一致する必要があります")
+
+        let randomFromUnified = DailyChallengeDefinition.makeMode(for: .random, baseSeed: seed)
+        let randomDirect = DailyChallengeDefinition.makeRandomMode(baseSeed: seed)
+        XCTAssertEqual(randomFromUnified, randomDirect, "ランダム版も統合 API と従来 API で完全一致する必要があります")
+    }
+
     /// 固定版がキャンペーン 5-8 と同じレギュレーションを持つことを確認
     func testFixedModeMatchesCampaignStage58() {
         let seed: UInt64 = 12345

--- a/Tests/GameUITests/DailyChallengeUITests.swift
+++ b/Tests/GameUITests/DailyChallengeUITests.swift
@@ -16,14 +16,20 @@ final class DailyChallengeUITests: XCTestCase {
         let dailyView = app.otherElements["daily_challenge_view"]
         XCTAssertTrue(dailyView.waitForExistence(timeout: 5), "日替わりチャレンジ画面へ遷移できること")
 
+        let fixedCard = app.otherElements["daily_challenge_stage_card_fixed"]
+        XCTAssertTrue(fixedCard.waitForExistence(timeout: 5), "固定レギュレーション用カードが表示されること")
+
+        let randomCard = app.otherElements["daily_challenge_stage_card_random"]
+        XCTAssertTrue(randomCard.waitForExistence(timeout: 5), "ランダムレギュレーション用カードが表示されること")
+
         let remainingLabel = app.staticTexts["daily_challenge_remaining_label"]
         XCTAssertTrue(remainingLabel.waitForExistence(timeout: 5), "残り挑戦回数ラベルが表示されること")
         XCTAssertTrue(remainingLabel.label.contains("残り 1 回"), "初回は無料挑戦が 1 回残っている想定")
 
-        let startButton = app.buttons["daily_challenge_start_button"]
-        XCTAssertTrue(startButton.waitForExistence(timeout: 5), "挑戦開始ボタンが存在すること")
-        XCTAssertTrue(startButton.isEnabled, "挑戦回数が残っている場合は開始ボタンが有効であること")
-        startButton.tap()
+        let fixedStartButton = app.buttons["daily_challenge_start_button_fixed"]
+        XCTAssertTrue(fixedStartButton.waitForExistence(timeout: 5), "固定モード用の挑戦ボタンが存在すること")
+        XCTAssertTrue(fixedStartButton.isEnabled, "挑戦回数が残っている場合は固定モードの開始ボタンが有効であること")
+        fixedStartButton.tap()
 
         let overlay = app.otherElements["game_preparation_overlay"]
         XCTAssertTrue(overlay.waitForExistence(timeout: 5), "挑戦開始後に準備オーバーレイが表示されること")
@@ -53,6 +59,19 @@ final class DailyChallengeUITests: XCTestCase {
             object: remainingAfterStart
         )
         XCTAssertEqual(XCTWaiter.wait(for: [rewardExpectation, remainingExpectation], timeout: 5), .completed, "広告視聴後に挑戦回数が 1 回ぶん回復し、付与済み回数が更新されること")
+
+        let randomStartButton = app.buttons["daily_challenge_start_button_random"]
+        XCTAssertTrue(randomStartButton.waitForExistence(timeout: 5), "ランダムモード用の挑戦ボタンが存在すること")
+        let startEnabledExpectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "isEnabled == true"),
+            object: randomStartButton
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [startEnabledExpectation], timeout: 5), .completed, "広告視聴後にランダムモードの開始ボタンが有効化されること")
+        randomStartButton.tap()
+
+        XCTAssertTrue(overlay.waitForExistence(timeout: 5), "ランダムモード開始後にも準備オーバーレイが表示されること")
+        XCTAssertTrue(returnButton.waitForExistence(timeout: 5), "ランダム挑戦後も戻るボタンが表示されること")
+        returnButton.tap()
 
         let closeButton = app.buttons["daily_challenge_back_button"]
         XCTAssertTrue(closeButton.waitForExistence(timeout: 3), "日替わり画面へ戻るボタンが表示されること")

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -2072,20 +2072,23 @@ private extension TitleScreenView {
     }
 
     var dailyChallengeTileHeadline: String {
-        let info = dailyChallengeInfo
+        let bundle = dailyChallengeBundle
         let remaining = dailyChallengeAttemptStore.remainingAttempts
-        return "\(info.mode.displayName) ・ 残り \(remaining) 回"
+        let modeNames = bundle.orderedInfos.map { $0.mode.displayName }.joined(separator: " / ")
+        return "\(modeNames) ・ 残り \(remaining) 回"
     }
 
     var dailyChallengeTileDetail: String {
-        let info = dailyChallengeInfo
+        let bundle = dailyChallengeBundle
         let granted = dailyChallengeAttemptStore.rewardedAttemptsGranted
         let maximumRewarded = dailyChallengeAttemptStore.maximumRewardedAttempts
-        return "\(info.regulationPrimaryText) ・ 広告追加 \(granted)/\(maximumRewarded)"
+        let fixedSummary = bundle.fixed.regulationPrimaryText
+        let randomSummary = bundle.random.regulationPrimaryText
+        return "固定: \(fixedSummary) / ランダム: \(randomSummary) ・ 広告追加 \(granted)/\(maximumRewarded)"
     }
 
-    var dailyChallengeInfo: DailyChallengeDefinitionService.ChallengeInfo {
-        dailyChallengeDefinitionService.challengeInfo(for: Date())
+    var dailyChallengeBundle: DailyChallengeDefinitionService.ChallengeBundle {
+        dailyChallengeDefinitionService.challengeBundle(for: Date())
     }
 
     var bestPointsDescription: String {


### PR DESCRIPTION
## Summary
- add a ChallengeBundle API so the daily challenge service returns fixed and random variants together
- refactor the daily challenge view model and view to surface two stage cards with per-variant start and leaderboard actions
- update root tile text and tests to cover the new dual-mode daily challenge flow

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e23daa4048832c8d7de67dfa95cff7