### PR TITLE
Track daily challenge attempts per variant

### DIFF
--- a/MonoKnightAppTests/DailyChallengeAttemptStoreTests.swift
+++ b/MonoKnightAppTests/DailyChallengeAttemptStoreTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import Game
 @testable import MonoKnightApp
 
 @MainActor
@@ -17,14 +18,17 @@ struct DailyChallengeAttemptStoreTests {
         var now = start
 
         let store = DailyChallengeAttemptStore(userDefaults: defaults, nowProvider: { now })
-        #expect(store.remainingAttempts == 1)
+        #expect(store.remainingAttempts(for: .fixed) == 1)
+        #expect(store.remainingAttempts(for: .random) == 1)
 
-        _ = store.consumeAttempt()
-        #expect(store.remainingAttempts == 0)
+        _ = store.consumeAttempt(for: .fixed)
+        #expect(store.remainingAttempts(for: .fixed) == 0)
+        #expect(store.remainingAttempts(for: .random) == 1)
 
         now = calendar.date(byAdding: .day, value: 1, to: start)!
         store.refreshForCurrentDate()
-        #expect(store.remainingAttempts == 1)
+        #expect(store.remainingAttempts(for: .fixed) == 1)
+        #expect(store.remainingAttempts(for: .random) == 1)
     }
 
     /// 無料 1 回 + リワード広告 3 回の計 4 回を超えて消費できないことを検証する
@@ -36,15 +40,17 @@ struct DailyChallengeAttemptStoreTests {
 
         let store = DailyChallengeAttemptStore(userDefaults: defaults)
         for _ in 0..<3 {
-            #expect(store.grantRewardedAttempt())
+            #expect(store.grantRewardedAttempt(for: .fixed))
         }
-        #expect(store.remainingAttempts == 4)
+        #expect(store.remainingAttempts(for: .fixed) == 4)
 
         for _ in 0..<4 {
-            #expect(store.consumeAttempt())
+            #expect(store.consumeAttempt(for: .fixed))
         }
-        #expect(store.remainingAttempts == 0)
-        #expect(store.consumeAttempt() == false)
+        #expect(store.remainingAttempts(for: .fixed) == 0)
+        #expect(store.consumeAttempt(for: .fixed) == false)
+        // ランダム側は未操作のため初期値を維持する
+        #expect(store.remainingAttempts(for: .random) == 1)
     }
 
     /// リワード広告成功時に残り挑戦回数が増加することを確認する
@@ -55,11 +61,11 @@ struct DailyChallengeAttemptStoreTests {
         defer { clearDefaults(defaults, suiteName: suiteName) }
 
         let store = DailyChallengeAttemptStore(userDefaults: defaults)
-        _ = store.consumeAttempt()
-        #expect(store.remainingAttempts == 0)
+        _ = store.consumeAttempt(for: .random)
+        #expect(store.remainingAttempts(for: .random) == 0)
 
-        #expect(store.grantRewardedAttempt())
-        #expect(store.remainingAttempts == 1)
+        #expect(store.grantRewardedAttempt(for: .random))
+        #expect(store.remainingAttempts(for: .random) == 1)
     }
 
     /// デバッグ無制限モードが永続化され、挑戦回数を消費しても減らないことを検証する
@@ -80,11 +86,11 @@ struct DailyChallengeAttemptStoreTests {
         let restoredStore = DailyChallengeAttemptStore(userDefaults: defaults, nowProvider: { now })
         #expect(restoredStore.isDebugUnlimitedEnabled == true)
 
-        let initialRemaining = restoredStore.remainingAttempts
+        let initialRemaining = restoredStore.remainingAttempts(for: .fixed)
         // 複数回消費しても残量が変化しない（上限スキップ）ことを確かめる
         for _ in 0..<5 {
-            #expect(restoredStore.consumeAttempt())
-            #expect(restoredStore.remainingAttempts == initialRemaining)
+            #expect(restoredStore.consumeAttempt(for: .fixed))
+            #expect(restoredStore.remainingAttempts(for: .fixed) == initialRemaining)
         }
     }
 
@@ -102,13 +108,34 @@ struct DailyChallengeAttemptStoreTests {
         // 解除後は残量が減る通常仕様へ戻るため、連続消費でゼロになることを確認する
         store.disableDebugUnlimited()
         #expect(store.isDebugUnlimitedEnabled == false)
-        #expect(store.consumeAttempt())
-        #expect(store.remainingAttempts == 0)
-        #expect(store.consumeAttempt() == false)
+        #expect(store.consumeAttempt(for: .fixed))
+        #expect(store.remainingAttempts(for: .fixed) == 0)
+        #expect(store.consumeAttempt(for: .fixed) == false)
 
         // 再生成しても無制限フラグが false のまま維持されることを確認
         let reloadedStore = DailyChallengeAttemptStore(userDefaults: defaults)
         #expect(reloadedStore.isDebugUnlimitedEnabled == false)
+    }
+
+    /// 固定版とランダム版で挑戦回数が独立していることを確認する
+    @Test
+    func variantStatesAreIndependent() {
+        let suiteName = "daily_challenge_store_variant_independent"
+        let defaults = makeIsolatedDefaults(suiteName: suiteName)
+        defer { clearDefaults(defaults, suiteName: suiteName) }
+
+        let store = DailyChallengeAttemptStore(userDefaults: defaults)
+
+        // 固定版だけを操作
+        #expect(store.consumeAttempt(for: .fixed))
+        #expect(store.remainingAttempts(for: .fixed) == 0)
+        #expect(store.remainingAttempts(for: .random) == 1)
+
+        // ランダム版で広告を 2 回付与し、固定版に影響しないことを確認
+        #expect(store.grantRewardedAttempt(for: .random))
+        #expect(store.grantRewardedAttempt(for: .random))
+        #expect(store.remainingAttempts(for: .random) == 3)
+        #expect(store.remainingAttempts(for: .fixed) == 0)
     }
 
     // MARK: - ヘルパー

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -2073,13 +2073,13 @@ private extension TitleScreenView {
 
     var dailyChallengeTileHeadline: String {
         let info = dailyChallengeInfo
-        let remaining = dailyChallengeAttemptStore.remainingAttempts
+        let remaining = dailyChallengeAttemptStore.remainingAttempts(for: info.variant)
         return "\(info.mode.displayName) ・ 残り \(remaining) 回"
     }
 
     var dailyChallengeTileDetail: String {
         let info = dailyChallengeInfo
-        let granted = dailyChallengeAttemptStore.rewardedAttemptsGranted
+        let granted = dailyChallengeAttemptStore.rewardedAttemptsGranted(for: info.variant)
         let maximumRewarded = dailyChallengeAttemptStore.maximumRewardedAttempts
         return "\(info.regulationPrimaryText) ・ 広告追加 \(granted)/\(maximumRewarded)"
     }


### PR DESCRIPTION
## Summary
- split daily challenge attempt state by variant and update the protocol/type erasure to operate with variant parameters
- adjust the daily challenge view model and root view to display and consume attempts per variant with clearer copy
- expand daily challenge attempt store unit tests to cover variant-specific resets, consumption, and reward grants

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e23dad1590832c8b8766164e7de561