### PR TITLE
Split daily challenge attempts by variant

### DIFF
--- a/MonoKnightAppTests/DailyChallengeAttemptStoreTests.swift
+++ b/MonoKnightAppTests/DailyChallengeAttemptStoreTests.swift
@@ -17,17 +17,20 @@ struct DailyChallengeAttemptStoreTests {
         var now = start
 
         let store = DailyChallengeAttemptStore(userDefaults: defaults, nowProvider: { now })
-        #expect(store.remainingAttempts == 1)
+        #expect(store.remainingAttempts(for: .fixed) == 1)
+        #expect(store.remainingAttempts(for: .random) == 1)
 
-        _ = store.consumeAttempt()
-        #expect(store.remainingAttempts == 0)
+        _ = store.consumeAttempt(for: .fixed)
+        #expect(store.remainingAttempts(for: .fixed) == 0)
+        #expect(store.remainingAttempts(for: .random) == 1)
 
         now = calendar.date(byAdding: .day, value: 1, to: start)!
         store.refreshForCurrentDate()
-        #expect(store.remainingAttempts == 1)
+        #expect(store.remainingAttempts(for: .fixed) == 1)
+        #expect(store.remainingAttempts(for: .random) == 1)
     }
 
-    /// 無料 1 回 + リワード広告 3 回の計 4 回を超えて消費できないことを検証する
+    /// 無料 1 回 + リワード広告 3 回の計 4 回を超えて消費できないことを検証する（固定バリアント）
     @Test
     func rejectsConsumptionBeyondDailyLimit() {
         let suiteName = "daily_challenge_store_test_limit"
@@ -36,15 +39,18 @@ struct DailyChallengeAttemptStoreTests {
 
         let store = DailyChallengeAttemptStore(userDefaults: defaults)
         for _ in 0..<3 {
-            #expect(store.grantRewardedAttempt())
+            #expect(store.grantRewardedAttempt(for: .fixed))
         }
-        #expect(store.remainingAttempts == 4)
+        #expect(store.remainingAttempts(for: .fixed) == 4)
+        #expect(store.remainingAttempts(for: .random) == 1)
 
         for _ in 0..<4 {
-            #expect(store.consumeAttempt())
+            #expect(store.consumeAttempt(for: .fixed))
         }
-        #expect(store.remainingAttempts == 0)
-        #expect(store.consumeAttempt() == false)
+        #expect(store.remainingAttempts(for: .fixed) == 0)
+        #expect(store.consumeAttempt(for: .fixed) == false)
+        // ランダム側は全く影響を受けないことを確認する
+        #expect(store.remainingAttempts(for: .random) == 1)
     }
 
     /// リワード広告成功時に残り挑戦回数が増加することを確認する
@@ -55,11 +61,31 @@ struct DailyChallengeAttemptStoreTests {
         defer { clearDefaults(defaults, suiteName: suiteName) }
 
         let store = DailyChallengeAttemptStore(userDefaults: defaults)
-        _ = store.consumeAttempt()
-        #expect(store.remainingAttempts == 0)
+        _ = store.consumeAttempt(for: .random)
+        #expect(store.remainingAttempts(for: .random) == 0)
+        #expect(store.remainingAttempts(for: .fixed) == 1)
 
-        #expect(store.grantRewardedAttempt())
-        #expect(store.remainingAttempts == 1)
+        #expect(store.grantRewardedAttempt(for: .random))
+        #expect(store.remainingAttempts(for: .random) == 1)
+        #expect(store.remainingAttempts(for: .fixed) == 1)
+    }
+
+    /// 固定・ランダムの状態が独立していることを検証する
+    @Test
+    func variantStatesAreIndependent() {
+        let suiteName = "daily_challenge_store_test_variant_independence"
+        let defaults = makeIsolatedDefaults(suiteName: suiteName)
+        defer { clearDefaults(defaults, suiteName: suiteName) }
+
+        let store = DailyChallengeAttemptStore(userDefaults: defaults)
+        _ = store.consumeAttempt(for: .fixed)
+        #expect(store.remainingAttempts(for: .fixed) == 0)
+        #expect(store.remainingAttempts(for: .random) == 1)
+
+        // ランダム側の広告付与が固定側へ影響しないことをチェック
+        #expect(store.grantRewardedAttempt(for: .random))
+        #expect(store.rewardedAttemptsGranted(for: .random) == 1)
+        #expect(store.rewardedAttemptsGranted(for: .fixed) == 0)
     }
 
     /// デバッグ無制限モードが永続化され、挑戦回数を消費しても減らないことを検証する
@@ -80,11 +106,14 @@ struct DailyChallengeAttemptStoreTests {
         let restoredStore = DailyChallengeAttemptStore(userDefaults: defaults, nowProvider: { now })
         #expect(restoredStore.isDebugUnlimitedEnabled == true)
 
-        let initialRemaining = restoredStore.remainingAttempts
+        let initialFixed = restoredStore.remainingAttempts(for: .fixed)
+        let initialRandom = restoredStore.remainingAttempts(for: .random)
         // 複数回消費しても残量が変化しない（上限スキップ）ことを確かめる
         for _ in 0..<5 {
-            #expect(restoredStore.consumeAttempt())
-            #expect(restoredStore.remainingAttempts == initialRemaining)
+            #expect(restoredStore.consumeAttempt(for: .fixed))
+            #expect(restoredStore.consumeAttempt(for: .random))
+            #expect(restoredStore.remainingAttempts(for: .fixed) == initialFixed)
+            #expect(restoredStore.remainingAttempts(for: .random) == initialRandom)
         }
     }
 
@@ -102,9 +131,11 @@ struct DailyChallengeAttemptStoreTests {
         // 解除後は残量が減る通常仕様へ戻るため、連続消費でゼロになることを確認する
         store.disableDebugUnlimited()
         #expect(store.isDebugUnlimitedEnabled == false)
-        #expect(store.consumeAttempt())
-        #expect(store.remainingAttempts == 0)
-        #expect(store.consumeAttempt() == false)
+        #expect(store.consumeAttempt(for: .fixed))
+        #expect(store.remainingAttempts(for: .fixed) == 0)
+        #expect(store.consumeAttempt(for: .fixed) == false)
+        // ランダム側は未消費のため 1 回残っている
+        #expect(store.remainingAttempts(for: .random) == 1)
 
         // 再生成しても無制限フラグが false のまま維持されることを確認
         let reloadedStore = DailyChallengeAttemptStore(userDefaults: defaults)

--- a/MonoKnightAppTests/MonoKnightAppTests.swift
+++ b/MonoKnightAppTests/MonoKnightAppTests.swift
@@ -95,30 +95,72 @@ private final class StubAdsService: AdsServiceProtocol {
 /// 日替わりチャレンジ回数ストアのスタブ
 @MainActor
 private final class StubDailyChallengeAttemptStore: ObservableObject, DailyChallengeAttemptStoreProtocol {
-    var remainingAttempts: Int
-    var rewardedAttemptsGranted: Int
+    var fixedRemainingAttempts: Int
+    var randomRemainingAttempts: Int
+    var fixedRewardedAttemptsGranted: Int
+    var randomRewardedAttemptsGranted: Int
     let maximumRewardedAttempts: Int
     var isDebugUnlimitedEnabled: Bool
 
     init(
-        remainingAttempts: Int = 1,
-        rewardedAttemptsGranted: Int = 0,
+        fixedRemainingAttempts: Int = 1,
+        randomRemainingAttempts: Int = 1,
+        fixedRewardedAttemptsGranted: Int = 0,
+        randomRewardedAttemptsGranted: Int = 0,
         maximumRewardedAttempts: Int = 3,
         isDebugUnlimitedEnabled: Bool = false
     ) {
-        self.remainingAttempts = remainingAttempts
-        self.rewardedAttemptsGranted = rewardedAttemptsGranted
+        self.fixedRemainingAttempts = fixedRemainingAttempts
+        self.randomRemainingAttempts = randomRemainingAttempts
+        self.fixedRewardedAttemptsGranted = fixedRewardedAttemptsGranted
+        self.randomRewardedAttemptsGranted = randomRewardedAttemptsGranted
         self.maximumRewardedAttempts = maximumRewardedAttempts
         self.isDebugUnlimitedEnabled = isDebugUnlimitedEnabled
+    }
+
+    func remainingAttempts(for variant: DailyChallengeDefinition.Variant) -> Int {
+        switch variant {
+        case .fixed:
+            return fixedRemainingAttempts
+        case .random:
+            return randomRemainingAttempts
+        }
+    }
+
+    func rewardedAttemptsGranted(for variant: DailyChallengeDefinition.Variant) -> Int {
+        switch variant {
+        case .fixed:
+            return fixedRewardedAttemptsGranted
+        case .random:
+            return randomRewardedAttemptsGranted
+        }
     }
 
     func refreshForCurrentDate() {}
 
     @discardableResult
-    func consumeAttempt() -> Bool { true }
+    func consumeAttempt(for variant: DailyChallengeDefinition.Variant) -> Bool {
+        switch variant {
+        case .fixed:
+            fixedRemainingAttempts = max(0, fixedRemainingAttempts - 1)
+        case .random:
+            randomRemainingAttempts = max(0, randomRemainingAttempts - 1)
+        }
+        return true
+    }
 
     @discardableResult
-    func grantRewardedAttempt() -> Bool { true }
+    func grantRewardedAttempt(for variant: DailyChallengeDefinition.Variant) -> Bool {
+        switch variant {
+        case .fixed:
+            fixedRewardedAttemptsGranted += 1
+            fixedRemainingAttempts += 1
+        case .random:
+            randomRewardedAttemptsGranted += 1
+            randomRemainingAttempts += 1
+        }
+        return true
+    }
 
     func enableDebugUnlimited() {
         // スタブではフラグの状態遷移だけ管理し、UI 連携の検証に利用する

--- a/Services/DailyChallengeAttemptStore.swift
+++ b/Services/DailyChallengeAttemptStore.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import SwiftUI
+import Game
 import SharedSupport // ログユーティリティを活用するため追加
 
 // MARK: - 日替わりチャレンジ挑戦回数の公開インターフェース
@@ -9,10 +10,12 @@ import SharedSupport // ログユーティリティを活用するため追加
 @MainActor
 /// - Note: `ObservableObjectPublisher` を明示することで `objectWillChange` を型消去経由でも購読可能にする
 protocol DailyChallengeAttemptStoreProtocol: ObservableObject where ObjectWillChangePublisher == ObservableObjectPublisher {
-    /// 残り挑戦回数（無料 1 回 + リワード広告による加算分 - 消費済み回数）
-    var remainingAttempts: Int { get }
-    /// その日のリワード広告によって付与済みの回数
-    var rewardedAttemptsGranted: Int { get }
+    /// 残り挑戦回数（無料 1 回 + リワード広告による加算分 - 消費済み回数）をバリアント単位で参照する
+    /// - Parameter variant: 固定ステージかランダムステージか
+    func remainingAttempts(for variant: DailyChallengeDefinition.Variant) -> Int
+    /// その日にリワード広告によって付与済みの回数をバリアント単位で参照する
+    /// - Parameter variant: 固定ステージかランダムステージか
+    func rewardedAttemptsGranted(for variant: DailyChallengeDefinition.Variant) -> Int
     /// 1 日あたり付与できるリワード広告ボーナス回数の上限（仕様で 3 回）
     var maximumRewardedAttempts: Int { get }
     /// デバッグ用の無制限フラグが有効かどうか
@@ -22,10 +25,10 @@ protocol DailyChallengeAttemptStoreProtocol: ObservableObject where ObjectWillCh
     func refreshForCurrentDate()
     /// 残り挑戦回数を 1 消費し、成功したかを返す
     @discardableResult
-    func consumeAttempt() -> Bool
+    func consumeAttempt(for variant: DailyChallengeDefinition.Variant) -> Bool
     /// リワード広告視聴が成功した際に 1 回分の挑戦回数を付与する
     @discardableResult
-    func grantRewardedAttempt() -> Bool
+    func grantRewardedAttempt(for variant: DailyChallengeDefinition.Variant) -> Bool
     /// デバッグパスコード入力などで無制限モードを有効化する
     func enableDebugUnlimited()
     /// デバッグ無制限モードを明示的に無効化する
@@ -36,105 +39,63 @@ protocol DailyChallengeAttemptStoreProtocol: ObservableObject where ObjectWillCh
 /// 具象ストアを `ObservableObject` のまま別タイプへ差し替えられるようにするためのタイプイレース
 @MainActor
 final class AnyDailyChallengeAttemptStore: ObservableObject, DailyChallengeAttemptStoreProtocol {
-    /// 実体となるストアを保持
+    /// 自身の `objectWillChange` を明示的に保持し、型消去後も購読しやすくする
+    let objectWillChange = ObservableObjectPublisher()
+    /// 実体となるストアを保持し、全メソッドを委譲する
     private let base: any DailyChallengeAttemptStoreProtocol
-    /// `objectWillChange` を購読し Published プロパティへ反映するためのストア
+    /// ストアの変更通知を横取りして上位へ再送するためのキャンセラ
     private var cancellable: AnyCancellable?
-
-    /// 残り挑戦回数を公開（Published で SwiftUI へ伝播）
-    @Published private(set) var remainingAttempts: Int
-    /// 付与済みリワード回数
-    @Published private(set) var rewardedAttemptsGranted: Int
-    /// 仕様で定めた 1 日あたりの付与上限
-    let maximumRewardedAttempts: Int
-    /// デバッグ無制限モードの有効/無効
-    @Published private(set) var isDebugUnlimitedEnabled: Bool
 
     init(base: any DailyChallengeAttemptStoreProtocol) {
         self.base = base
-        self.remainingAttempts = base.remainingAttempts
-        self.rewardedAttemptsGranted = base.rewardedAttemptsGranted
-        self.maximumRewardedAttempts = base.maximumRewardedAttempts
-        self.isDebugUnlimitedEnabled = base.isDebugUnlimitedEnabled
 
-        // objectWillChange を購読して最新値を同期
+        // ベースストアが発行した変更通知をそのまま転送し、SwiftUI 側で再描画されるようにする
         cancellable = base.objectWillChange.sink { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
-                // base から取得した最新値をローカル変数へ退避して比較を行う
-                let latestRemainingAttempts = base.remainingAttempts
-                if self.remainingAttempts != latestRemainingAttempts {
-                    // 差分がある場合のみ Published プロパティを更新する
-                    self.remainingAttempts = latestRemainingAttempts
-                }
-
-                let latestRewardedAttempts = base.rewardedAttemptsGranted
-                if self.rewardedAttemptsGranted != latestRewardedAttempts {
-                    // 付与済み回数も差分が存在するときのみ更新を行い再描画ループを防止する
-                    self.rewardedAttemptsGranted = latestRewardedAttempts
-                }
-
-                let latestDebugFlag = base.isDebugUnlimitedEnabled
-                if self.isDebugUnlimitedEnabled != latestDebugFlag {
-                    // デバッグ無制限モードの状態が変化した場合のみ Published を更新する
-                    self.isDebugUnlimitedEnabled = latestDebugFlag
-                }
+                self.objectWillChange.send()
             }
         }
+    }
+
+    // MARK: - Protocol forwarding（メソッドはすべて委譲）
+
+    func remainingAttempts(for variant: DailyChallengeDefinition.Variant) -> Int {
+        base.remainingAttempts(for: variant)
+    }
+
+    func rewardedAttemptsGranted(for variant: DailyChallengeDefinition.Variant) -> Int {
+        base.rewardedAttemptsGranted(for: variant)
+    }
+
+    var maximumRewardedAttempts: Int {
+        base.maximumRewardedAttempts
+    }
+
+    var isDebugUnlimitedEnabled: Bool {
+        base.isDebugUnlimitedEnabled
     }
 
     func refreshForCurrentDate() {
         base.refreshForCurrentDate()
-        synchronizeAfterAsyncChange()
     }
 
     @discardableResult
-    func consumeAttempt() -> Bool {
-        let result = base.consumeAttempt()
-        synchronizeAfterAsyncChange()
-        return result
+    func consumeAttempt(for variant: DailyChallengeDefinition.Variant) -> Bool {
+        base.consumeAttempt(for: variant)
     }
 
     @discardableResult
-    func grantRewardedAttempt() -> Bool {
-        let result = base.grantRewardedAttempt()
-        synchronizeAfterAsyncChange()
-        return result
+    func grantRewardedAttempt(for variant: DailyChallengeDefinition.Variant) -> Bool {
+        base.grantRewardedAttempt(for: variant)
     }
 
     func enableDebugUnlimited() {
         base.enableDebugUnlimited()
-        synchronizeAfterAsyncChange()
     }
 
     func disableDebugUnlimited() {
         base.disableDebugUnlimited()
-        synchronizeAfterAsyncChange()
-    }
-
-    /// `base` 側の値が変化した直後にメインアクターで同期する
-    private func synchronizeAfterAsyncChange() {
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            // base 側の状態をローカル変数へ取得し、差分が存在する場合のみ代入を実施する
-            let latestRemainingAttempts = base.remainingAttempts
-            if self.remainingAttempts != latestRemainingAttempts {
-                // 差分が無い場合は代入をスキップして不要な objectWillChange 通知を抑制する
-                self.remainingAttempts = latestRemainingAttempts
-            }
-
-            let latestRewardedAttempts = base.rewardedAttemptsGranted
-            if self.rewardedAttemptsGranted != latestRewardedAttempts {
-                // 差分があるケースのみ更新して無限再描画やログ増加を防ぐ
-                self.rewardedAttemptsGranted = latestRewardedAttempts
-            }
-
-            let latestDebugFlag = base.isDebugUnlimitedEnabled
-            if self.isDebugUnlimitedEnabled != latestDebugFlag {
-                // デバッグフラグの変更も同期し、設定画面からの切り替えを即時反映する
-                self.isDebugUnlimitedEnabled = latestDebugFlag
-            }
-        }
     }
 }
 
@@ -146,7 +107,7 @@ final class DailyChallengeAttemptStore: ObservableObject, DailyChallengeAttemptS
     /// - Important: バージョンを明記しておくことで将来のスキーマ変更に備える
     private enum StorageKey {
         /// 本日の挑戦状況（JSON エンコードした `State` を格納）
-        static let state = "daily_challenge_attempt_state_v1" // JSON で `State` を保存
+        static let state = "daily_challenge_attempt_state_v2" // JSON で `State` を保存
     }
 
     /// デバッグ無制限モードの保存に利用するキー
@@ -163,12 +124,101 @@ final class DailyChallengeAttemptStore: ObservableObject, DailyChallengeAttemptS
 
     /// UserDefaults 保存用の状態
     private struct State: Codable {
+        /// バリアントごとの保存キー
+        enum VariantKey: String, Codable, CaseIterable {
+            case fixed
+            case random
+
+            /// `DailyChallengeDefinition.Variant` から保存用キーへ変換する
+            /// - Parameter variant: 固定/ランダムいずれかのバリアント
+            init(variant: DailyChallengeDefinition.Variant) {
+                switch variant {
+                case .fixed:
+                    self = .fixed
+                case .random:
+                    self = .random
+                }
+            }
+
+            /// 保存用キーから `DailyChallengeDefinition.Variant` へ戻す
+            var variant: DailyChallengeDefinition.Variant {
+                switch self {
+                case .fixed:
+                    return .fixed
+                case .random:
+                    return .random
+                }
+            }
+
+            /// ログ出力時に利用する日本語ラベル
+            var debugLabel: String {
+                switch self {
+                case .fixed:
+                    return "固定"
+                case .random:
+                    return "ランダム"
+                }
+            }
+        }
+
+        /// バリアント単位の挑戦状況
+        struct VariantAttempts: Codable {
+            /// 消費済み挑戦回数
+            var usedAttempts: Int
+            /// リワード広告で付与済みの回数
+            var rewardedAttemptsGranted: Int
+
+            init(usedAttempts: Int = 0, rewardedAttemptsGranted: Int = 0) {
+                self.usedAttempts = usedAttempts
+                self.rewardedAttemptsGranted = rewardedAttemptsGranted
+            }
+        }
+
         /// UTC 基準の日付キー（例: 2025-05-25）
         let dateKey: String
-        /// その日に消費した挑戦回数
-        var usedAttempts: Int
-        /// その日にリワード広告で付与済みの回数
-        var rewardedAttemptsGranted: Int
+        /// バリアントごとの挑戦状況
+        var variants: [VariantKey: VariantAttempts]
+
+        init(dateKey: String, variants: [VariantKey: VariantAttempts] = [:]) {
+            self.dateKey = dateKey
+            self.variants = variants
+            normalizeVariants()
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            dateKey = try container.decode(String.self, forKey: .dateKey)
+            variants = try container.decodeIfPresent([VariantKey: VariantAttempts].self, forKey: .variants) ?? [:]
+            normalizeVariants()
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(dateKey, forKey: .dateKey)
+            try container.encode(variants, forKey: .variants)
+        }
+
+        /// 必要な全バリアント分の状態が揃っているか確認し、不足していれば 0 初期値で補完する
+        mutating func normalizeVariants() {
+            for key in VariantKey.allCases where variants[key] == nil {
+                variants[key] = VariantAttempts()
+            }
+        }
+
+        /// 指定バリアントの状態を取得する（存在しない場合はゼロ初期値を返す）
+        func variantState(for key: VariantKey) -> VariantAttempts {
+            variants[key] ?? VariantAttempts()
+        }
+
+        /// 指定バリアントの状態を更新する
+        mutating func updateVariantState(_ value: VariantAttempts, for key: VariantKey) {
+            variants[key] = value
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case dateKey
+            case variants
+        }
     }
 
     /// 現在の状態（更新時に `updatePublishedValues()` を手動で呼び出す）
@@ -181,10 +231,10 @@ final class DailyChallengeAttemptStore: ObservableObject, DailyChallengeAttemptS
     /// 現在日時を取得するクロージャ（テストで任意の日時を差し替える）
     private let nowProvider: () -> Date
 
-    /// 残り挑戦回数（Published で公開）
-    @Published private(set) var remainingAttempts: Int
-    /// リワード広告による付与済み回数（Published で公開）
-    @Published private(set) var rewardedAttemptsGranted: Int
+    /// 残り挑戦回数をバリアント別に公開するディクショナリ
+    @Published private(set) var remainingAttemptsByVariant: [State.VariantKey: Int]
+    /// リワード広告による付与済み回数をバリアント別に公開するディクショナリ
+    @Published private(set) var rewardedAttemptsGrantedByVariant: [State.VariantKey: Int]
     /// デバッグ無制限モードが有効かどうか
     @Published private(set) var isDebugUnlimitedEnabled: Bool
 
@@ -218,26 +268,27 @@ final class DailyChallengeAttemptStore: ObservableObject, DailyChallengeAttemptS
                     initialState = decoded
                     debugLog("DailyChallengeAttemptStore: 保存済みの挑戦状況を復元しました (dateKey: \(decoded.dateKey))")
                 } else {
-                    initialState = State(dateKey: currentDateKey, usedAttempts: 0, rewardedAttemptsGranted: 0)
+                    initialState = State(dateKey: currentDateKey)
                     shouldPersistInitialState = true
                     debugLog("DailyChallengeAttemptStore: 日付が変わっていたため挑戦回数をリセットしました")
                 }
             } catch {
-                initialState = State(dateKey: currentDateKey, usedAttempts: 0, rewardedAttemptsGranted: 0)
+                initialState = State(dateKey: currentDateKey)
                 shouldPersistInitialState = true
                 debugError(error, message: "DailyChallengeAttemptStore: 復元に失敗したため状態を初期化しました")
             }
         } else {
-            initialState = State(dateKey: currentDateKey, usedAttempts: 0, rewardedAttemptsGranted: 0)
+            initialState = State(dateKey: currentDateKey)
             shouldPersistInitialState = true
             debugLog("DailyChallengeAttemptStore: 保存データが無かったため本日の挑戦状況を新規作成しました")
         }
 
-        // 格納プロパティの初期化順序を明示的に統一（state → remainingAttempts → rewardedAttemptsGranted）
+        // Published プロパティの初期値は空ディクショナリとしておき、直後に `updatePublishedValues()` で埋める
         self.state = initialState
-        self.remainingAttempts = Self.computeRemainingAttempts(from: initialState)
-        self.rewardedAttemptsGranted = initialState.rewardedAttemptsGranted
+        self.remainingAttemptsByVariant = [:]
+        self.rewardedAttemptsGrantedByVariant = [:]
         self.isDebugUnlimitedEnabled = userDefaults.bool(forKey: Self.debugUnlimitedStorageKey)
+        updatePublishedValues()
 
         if shouldPersistInitialState {
             // 初期状態作成・更新が発生したケースのみ永続化を行う
@@ -245,61 +296,79 @@ final class DailyChallengeAttemptStore: ObservableObject, DailyChallengeAttemptS
         }
     }
 
+    /// 指定バリアントの残量を返す
+    func remainingAttempts(for variant: DailyChallengeDefinition.Variant) -> Int {
+        let key = State.VariantKey(variant: variant)
+        return remainingAttemptsByVariant[key] ?? Self.computeRemainingAttempts(from: state.variantState(for: key))
+    }
+
+    /// 指定バリアントの広告付与済み回数を返す
+    func rewardedAttemptsGranted(for variant: DailyChallengeDefinition.Variant) -> Int {
+        let key = State.VariantKey(variant: variant)
+        return rewardedAttemptsGrantedByVariant[key] ?? state.variantState(for: key).rewardedAttemptsGranted
+    }
+
     /// 日付境界を跨いだ場合に状態を初期化する
     func refreshForCurrentDate() {
         let currentKey = dateFormatter.string(from: nowProvider())
         guard state.dateKey != currentKey else { return }
-        state = State(dateKey: currentKey, usedAttempts: 0, rewardedAttemptsGranted: 0)
-        debugLog("DailyChallengeAttemptStore: 新しい日付 (\(currentKey)) が検出されたため挑戦回数をリセットしました")
+        state = State(dateKey: currentKey)
+        debugLog("DailyChallengeAttemptStore: 新しい日付 (\(currentKey)) が検出されたため固定/ランダムの挑戦回数をリセットしました")
         // リセット後は Published プロパティと永続化内容を手動で同期させる
         updatePublishedValues()
         persistState()
     }
 
     @discardableResult
-    func consumeAttempt() -> Bool {
+    func consumeAttempt(for variant: DailyChallengeDefinition.Variant) -> Bool {
         refreshForCurrentDate()
 
         if isDebugUnlimitedEnabled {
             // デバッグ無制限モードでは消費上限を撤廃し、状態更新を行わずに成功扱いとする
-            debugLog("DailyChallengeAttemptStore: デバッグ無制限モードのため挑戦回数消費をスキップしました")
+            debugLog("DailyChallengeAttemptStore: デバッグ無制限モードのため \(State.VariantKey(variant: variant).debugLabel) の挑戦回数消費をスキップしました")
             return true
         }
 
-        let totalAvailable = 1 + state.rewardedAttemptsGranted
-        guard state.usedAttempts < totalAvailable else {
-            debugLog("DailyChallengeAttemptStore: 挑戦回数の上限に達しているため消費できません")
+        let key = State.VariantKey(variant: variant)
+        var variantState = state.variantState(for: key)
+        let totalAvailable = 1 + variantState.rewardedAttemptsGranted
+        guard variantState.usedAttempts < totalAvailable else {
+            debugLog("DailyChallengeAttemptStore: \(key.debugLabel) の挑戦回数が上限に達しているため消費できません")
             return false
         }
 
-        state.usedAttempts += 1
+        variantState.usedAttempts += 1
+        state.updateVariantState(variantState, for: key)
         // 消費結果を UI とストレージへ即座に反映させる
         updatePublishedValues()
         persistState()
-        debugLog("DailyChallengeAttemptStore: 挑戦回数を 1 消費しました (used: \(state.usedAttempts)/total: \(totalAvailable))")
+        debugLog("DailyChallengeAttemptStore: \(key.debugLabel) の挑戦回数を 1 消費しました (used: \(variantState.usedAttempts)/total: \(totalAvailable))")
         return true
     }
 
     @discardableResult
-    func grantRewardedAttempt() -> Bool {
+    func grantRewardedAttempt(for variant: DailyChallengeDefinition.Variant) -> Bool {
         refreshForCurrentDate()
 
         if isDebugUnlimitedEnabled {
             // デバッグ無制限モード時は広告視聴による加算が不要なため、常に成功を返す
-            debugLog("DailyChallengeAttemptStore: デバッグ無制限モードのため広告付与をスキップしました")
+            debugLog("DailyChallengeAttemptStore: デバッグ無制限モードのため \(State.VariantKey(variant: variant).debugLabel) への広告付与をスキップしました")
             return true
         }
 
-        guard state.rewardedAttemptsGranted < maximumRewardedAttempts else {
-            debugLog("DailyChallengeAttemptStore: リワード広告による付与上限に達しているため増加できません")
+        let key = State.VariantKey(variant: variant)
+        var variantState = state.variantState(for: key)
+        guard variantState.rewardedAttemptsGranted < maximumRewardedAttempts else {
+            debugLog("DailyChallengeAttemptStore: \(key.debugLabel) の広告付与が上限に達しているため増加できません")
             return false
         }
 
-        state.rewardedAttemptsGranted += 1
+        variantState.rewardedAttemptsGranted += 1
+        state.updateVariantState(variantState, for: key)
         // 付与後も同様に Published プロパティと永続化内容を整合させる
         updatePublishedValues()
         persistState()
-        debugLog("DailyChallengeAttemptStore: リワード広告成功により挑戦回数を 1 追加しました (granted: \(state.rewardedAttemptsGranted))")
+        debugLog("DailyChallengeAttemptStore: \(key.debugLabel) へ広告成功により挑戦回数を 1 追加しました (granted: \(variantState.rewardedAttemptsGranted))")
         return true
     }
 
@@ -324,8 +393,15 @@ final class DailyChallengeAttemptStore: ObservableObject, DailyChallengeAttemptS
 
     // MARK: - 内部処理
     private func updatePublishedValues() {
-        remainingAttempts = Self.computeRemainingAttempts(from: state)
-        rewardedAttemptsGranted = state.rewardedAttemptsGranted
+        var remaining: [State.VariantKey: Int] = [:]
+        var rewarded: [State.VariantKey: Int] = [:]
+        for key in State.VariantKey.allCases {
+            let variantState = state.variantState(for: key)
+            remaining[key] = Self.computeRemainingAttempts(from: variantState)
+            rewarded[key] = variantState.rewardedAttemptsGranted
+        }
+        remainingAttemptsByVariant = remaining
+        rewardedAttemptsGrantedByVariant = rewarded
     }
 
     private func persistState() {
@@ -338,7 +414,7 @@ final class DailyChallengeAttemptStore: ObservableObject, DailyChallengeAttemptS
         }
     }
 
-    private static func computeRemainingAttempts(from state: State) -> Int {
+    private static func computeRemainingAttempts(from state: State.VariantAttempts) -> Int {
         let total = 1 + state.rewardedAttemptsGranted
         return max(0, total - state.usedAttempts)
     }

--- a/UI/DailyChallengeView.swift
+++ b/UI/DailyChallengeView.swift
@@ -15,6 +15,65 @@ final class DailyChallengeViewModel: ObservableObject {
         let message: String
     }
 
+    /// バリアント単位での挑戦状況を UI へ提供するステータス
+    struct VariantAttemptStatus: Identifiable {
+        let variant: DailyChallengeDefinition.Variant
+        let variantDisplayName: String
+        let remaining: Int
+        let totalMaximum: Int
+        let rewardedGranted: Int
+        let maximumRewarded: Int
+        let isDebugUnlimited: Bool
+        let isRequestingReward: Bool
+
+        var id: String { identifierSuffix }
+
+        var identifierSuffix: String {
+            Self.identifier(for: variant)
+        }
+
+        /// バリアントごとの識別子を生成する
+        /// - Parameter variant: 固定/ランダムの別
+        /// - Returns: ビューの識別子として利用する文字列
+        static func identifier(for variant: DailyChallengeDefinition.Variant) -> String {
+            switch variant {
+            case .fixed:
+                return "fixed"
+            case .random:
+                return "random"
+            }
+        }
+
+        /// 残量を説明するテキスト
+        var remainingText: String {
+            if isDebugUnlimited {
+                return "\(variantDisplayName): デバッグモード（無制限）"
+            } else {
+                return "\(variantDisplayName): 残り \(remaining) 回 / 最大 \(totalMaximum) 回"
+            }
+        }
+
+        /// 広告付与進捗を説明するテキスト
+        var rewardProgressText: String {
+            if isDebugUnlimited {
+                return "広告視聴は不要です（デバッグモード）"
+            } else {
+                return "広告追加 \(rewardedGranted) / \(maximumRewarded)"
+            }
+        }
+
+        /// 挑戦ボタンを有効化できるか
+        var isStartButtonEnabled: Bool {
+            isDebugUnlimited || remaining > 0
+        }
+
+        /// 広告ボタンを有効化できるか
+        var isRewardButtonEnabled: Bool {
+            guard !isDebugUnlimited else { return false }
+            return rewardedGranted < maximumRewarded && !isRequestingReward
+        }
+    }
+
     /// 挑戦回数ストア（挑戦消費や広告付与を司る）
     private let attemptStore: AnyDailyChallengeAttemptStore
     /// 日替わりモードの定義サービス
@@ -31,23 +90,19 @@ final class DailyChallengeViewModel: ObservableObject {
     private let resetFormatter: DateFormatter
     /// `attemptStore.objectWillChange` を購読して状態同期するためのキャンセラ
     private var cancellable: AnyCancellable?
+    /// 広告リクエスト中のバリアント。`nil` であればリクエストは発生していない。
+    private var requestingVariant: DailyChallengeDefinition.Variant?
 
     /// 現在表示しているチャレンジ情報バンドル
     @Published private(set) var challengeBundle: DailyChallengeDefinitionService.ChallengeBundle
     /// 「2025年5月26日 (月)」のような日付表示用テキスト
     @Published private(set) var challengeDateText: String
-    /// 「残り 1 回 / 最大 4 回」のような残量テキスト
-    @Published private(set) var remainingAttemptsText: String
-    /// 「広告追加済み: 0 / 3」のようなリワード進捗テキスト
-    @Published private(set) var rewardProgressText: String
     /// 「リセット: 05/27(火) 09:00」のようなリセット案内テキスト
     @Published private(set) var resetTimeText: String
-    /// 挑戦開始ボタンを有効化してよいか
-    @Published private(set) var isStartButtonEnabled: Bool
-    /// リワード広告ボタンを有効化してよいか
-    @Published private(set) var isRewardButtonEnabled: Bool
-    /// リワード広告処理中かどうか（進捗インジケータ表示に利用）
-    @Published private(set) var isRequestingReward: Bool
+    /// バリアントごとの挑戦状況まとめ
+    @Published private(set) var variantAttemptStatuses: [VariantAttemptStatus]
+    /// 広告進捗表示用メッセージ（nil の場合は非表示）
+    @Published private(set) var rewardProgressMessage: String?
     /// ユーザーへ提示するアラート
     @Published var alertState: AlertState?
 
@@ -92,11 +147,9 @@ final class DailyChallengeViewModel: ObservableObject {
         self.challengeBundle = bundle
         self.challengeDateText = Self.makeDateText(for: bundle.date, formatter: dateFormatter)
         self.resetTimeText = Self.makeResetText(bundle: bundle, formatter: resetFormatter, service: definitionService)
-        self.remainingAttemptsText = ""
-        self.rewardProgressText = ""
-        self.isStartButtonEnabled = false
-        self.isRewardButtonEnabled = false
-        self.isRequestingReward = false
+        self.variantAttemptStatuses = []
+        self.rewardProgressMessage = nil
+        self.requestingVariant = nil
 
         // 初期状態でストアの日付を同期し、翌日跨ぎに備える
         attemptStore.refreshForCurrentDate()
@@ -129,8 +182,9 @@ final class DailyChallengeViewModel: ObservableObject {
     /// - Parameter variant: 固定版かランダム版か
     func startChallengeIfPossible(for variant: DailyChallengeDefinition.Variant) -> GameMode? {
         attemptStore.refreshForCurrentDate()
-        guard attemptStore.consumeAttempt() else {
-            alertState = AlertState(title: "挑戦できません", message: "本日の挑戦回数を使い切りました。")
+        guard attemptStore.consumeAttempt(for: variant) else {
+            let variantName = challengeBundle.info(for: variant).variantDisplayName
+            alertState = AlertState(title: "挑戦できません", message: "\(variantName)の挑戦回数を使い切りました。")
             updateAttemptRelatedTexts()
             return nil
         }
@@ -138,39 +192,41 @@ final class DailyChallengeViewModel: ObservableObject {
         return challengeBundle.info(for: variant).mode
     }
 
-    /// リワード広告視聴をリクエストし、成功時に挑戦回数を追加する
-    func requestRewardedAttempt() async {
+    /// リワード広告視聴をリクエストし、成功時に指定バリアントの挑戦回数を追加する
+    /// - Parameter variant: 広告付与対象となるバリアント
+    func requestRewardedAttempt(for variant: DailyChallengeDefinition.Variant) async {
         attemptStore.refreshForCurrentDate()
 
         if attemptStore.isDebugUnlimitedEnabled {
-            // デバッグ無制限モードでは広告視聴が不要であることを明示する
-            alertState = AlertState(title: "デバッグモード", message: "無制限モードが有効なため広告視聴は不要です。")
+            let variantName = challengeBundle.info(for: variant).variantDisplayName
+            alertState = AlertState(title: "デバッグモード", message: "\(variantName)では無制限モードが有効なため広告視聴は不要です。")
             updateAttemptRelatedTexts()
             return
         }
 
-        guard attemptStore.rewardedAttemptsGranted < attemptStore.maximumRewardedAttempts else {
-            alertState = AlertState(title: "追加不可", message: "広告で追加できる回数の上限に達しています。")
+        let granted = attemptStore.rewardedAttemptsGranted(for: variant)
+        if granted >= attemptStore.maximumRewardedAttempts {
+            let variantName = challengeBundle.info(for: variant).variantDisplayName
+            alertState = AlertState(title: "追加不可", message: "\(variantName)では広告で追加できる回数の上限に達しています。")
             updateAttemptRelatedTexts()
             return
         }
 
-        guard !isRequestingReward else { return }
-        isRequestingReward = true
+        guard requestingVariant == nil else { return }
+        requestingVariant = variant
         updateAttemptRelatedTexts()
 
         let success = await adsService.showRewardedAd()
         if success {
-            let granted = attemptStore.grantRewardedAttempt()
-            if !granted {
+            let grantedSuccess = attemptStore.grantRewardedAttempt(for: variant)
+            if !grantedSuccess {
                 alertState = AlertState(title: "付与できません", message: "内部状態が更新できなかったため、挑戦回数は増加しませんでした。")
             }
         } else {
             alertState = AlertState(title: "広告を確認してください", message: "広告視聴が完了しなかったため挑戦回数は追加されませんでした。")
         }
 
-        updateAttemptRelatedTexts()
-        isRequestingReward = false
+        requestingVariant = nil
         updateAttemptRelatedTexts()
     }
 
@@ -186,28 +242,34 @@ final class DailyChallengeViewModel: ObservableObject {
         challengeBundle = latestBundle
         challengeDateText = Self.makeDateText(for: latestBundle.date, formatter: dateFormatter)
         resetTimeText = Self.makeResetText(bundle: latestBundle, formatter: resetFormatter, service: definitionService)
+        updateAttemptRelatedTexts()
     }
 
     /// 残量テキストやボタン有効状態をストアから再計算する
     private func updateAttemptRelatedTexts() {
-        if attemptStore.isDebugUnlimitedEnabled {
-            // 無制限モード時は残量文言とボタン状態を専用表示へ切り替える
-            remainingAttemptsText = "デバッグモード: 無制限"
-            rewardProgressText = "広告視聴は不要です（デバッグモード）"
-            isStartButtonEnabled = true
-            isRewardButtonEnabled = false
-            return
+        let isUnlimited = attemptStore.isDebugUnlimitedEnabled
+        let maximumRewarded = attemptStore.maximumRewardedAttempts
+        let totalMaximum = 1 + maximumRewarded
+
+        variantAttemptStatuses = challengeBundle.orderedInfos.map { info in
+            VariantAttemptStatus(
+                variant: info.variant,
+                variantDisplayName: info.variantDisplayName,
+                remaining: attemptStore.remainingAttempts(for: info.variant),
+                totalMaximum: totalMaximum,
+                rewardedGranted: attemptStore.rewardedAttemptsGranted(for: info.variant),
+                maximumRewarded: maximumRewarded,
+                isDebugUnlimited: isUnlimited,
+                isRequestingReward: requestingVariant == info.variant
+            )
         }
 
-        let remaining = attemptStore.remainingAttempts
-        let granted = attemptStore.rewardedAttemptsGranted
-        let maximumRewarded = attemptStore.maximumRewardedAttempts
-        let totalMax = 1 + maximumRewarded
-
-        remainingAttemptsText = "残り \(remaining) 回 / 最大 \(totalMax) 回"
-        rewardProgressText = "広告追加済み: \(granted) / \(maximumRewarded)"
-        isStartButtonEnabled = remaining > 0
-        isRewardButtonEnabled = granted < maximumRewarded && !isRequestingReward
+        if let requestingVariant {
+            let variantName = challengeBundle.info(for: requestingVariant).variantDisplayName
+            rewardProgressMessage = "\(variantName)向けの広告を確認しています…"
+        } else {
+            rewardProgressMessage = nil
+        }
     }
 
     /// 日付表示テキストを生成する
@@ -228,6 +290,14 @@ final class DailyChallengeViewModel: ObservableObject {
     /// ステージ情報を順序付き配列で取得するヘルパー
     var orderedStageInfos: [DailyChallengeDefinitionService.ChallengeInfo] {
         challengeBundle.orderedInfos
+    }
+
+    /// 指定バリアントに対応するステータスを検索する
+    /// - Parameter variant: 固定/ランダムの別
+    /// - Returns: ビュー描画に必要な挑戦状況。該当しない場合は `nil`。
+    func status(for variant: DailyChallengeDefinition.Variant) -> VariantAttemptStatus? {
+        let identifier = VariantAttemptStatus.identifier(for: variant)
+        return variantAttemptStatuses.first { $0.identifierSuffix == identifier }
     }
 }
 
@@ -263,7 +333,6 @@ struct DailyChallengeView: View {
                 headerSection
                 stageCardsSection
                 attemptsSection
-                rewardButtonSection
             }
             .padding(.horizontal, 24)
             .padding(.vertical, 32)
@@ -293,8 +362,8 @@ struct DailyChallengeView: View {
             Alert(title: Text(state.title), message: Text(state.message), dismissButton: .default(Text("OK")))
         }
         .overlay(alignment: .center) {
-            if viewModel.isRequestingReward {
-                ProgressView("広告を確認しています…")
+            if let message = viewModel.rewardProgressMessage {
+                ProgressView(message)
                     .progressViewStyle(.circular)
                     .padding(24)
                     .background(
@@ -343,7 +412,9 @@ struct DailyChallengeView: View {
     /// 単一ステージのカード表示
     /// - Parameter info: 対応するチャレンジ情報
     private func stageCard(for info: DailyChallengeDefinitionService.ChallengeInfo) -> some View {
-        VStack(alignment: .leading, spacing: 16) {
+        let status = viewModel.status(for: info.variant)
+
+        return VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 6) {
                 Text(info.variantDisplayName)
                     .font(.system(size: 15, weight: .semibold, design: .rounded))
@@ -361,6 +432,19 @@ struct DailyChallengeView: View {
                     .font(.system(size: 13, weight: .regular, design: .rounded))
                     .foregroundColor(theme.textSecondary.opacity(0.9))
                     .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let status {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(status.remainingText)
+                        .font(.system(size: 14, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.textPrimary)
+
+                    Text(status.rewardProgressText)
+                        .font(.system(size: 13, weight: .regular, design: .rounded))
+                        .foregroundColor(theme.textSecondary)
+                }
+                .accessibilityIdentifier("daily_challenge_status_\(status.identifierSuffix)")
             }
 
             HStack(spacing: 12) {
@@ -395,12 +479,34 @@ struct DailyChallengeView: View {
                         .frame(maxWidth: .infinity)
                         .background(
                             RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .fill(viewModel.isStartButtonEnabled ? theme.accentPrimary : theme.accentPrimary.opacity(0.45))
+                                .fill((status?.isStartButtonEnabled ?? false) ? theme.accentPrimary : theme.accentPrimary.opacity(0.45))
                         )
                 }
                 .buttonStyle(.plain)
-                .disabled(!viewModel.isStartButtonEnabled)
+                .disabled(!(status?.isStartButtonEnabled ?? false))
                 .accessibilityIdentifier("daily_challenge_start_button_\(info.identifierSuffix)")
+            }
+
+            if let status {
+                Button {
+                    Task { await viewModel.requestRewardedAttempt(for: info.variant) }
+                } label: {
+                    HStack {
+                        Image(systemName: "gift.fill")
+                        Text("広告を視聴して回数を追加")
+                    }
+                    .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    .foregroundColor(Color.white.opacity(status.isRewardButtonEnabled ? 1 : 0.65))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(theme.accentPrimary.opacity(status.isRewardButtonEnabled ? 0.85 : 0.45))
+                    )
+                }
+                .buttonStyle(.plain)
+                .disabled(!status.isRewardButtonEnabled)
+                .accessibilityIdentifier("daily_challenge_reward_button_\(status.identifierSuffix)")
             }
         }
         .padding(20)
@@ -421,15 +527,18 @@ struct DailyChallengeView: View {
     /// 挑戦回数とリセット時刻の表示
     private var attemptsSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text(viewModel.remainingAttemptsText)
-                .font(.system(size: 16, weight: .semibold, design: .rounded))
-                .foregroundColor(theme.textPrimary)
-                .accessibilityIdentifier("daily_challenge_remaining_label")
+            ForEach(viewModel.variantAttemptStatuses) { status in
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(status.remainingText)
+                        .font(.system(size: 15, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.textPrimary)
 
-            Text(viewModel.rewardProgressText)
-                .font(.system(size: 14, weight: .regular, design: .rounded))
-                .foregroundColor(theme.textSecondary)
-                .accessibilityIdentifier("daily_challenge_reward_status")
+                    Text(status.rewardProgressText)
+                        .font(.system(size: 13, weight: .regular, design: .rounded))
+                        .foregroundColor(theme.textSecondary)
+                }
+                .accessibilityIdentifier("daily_challenge_summary_\(status.identifierSuffix)")
+            }
 
             Text(viewModel.resetTimeText)
                 .font(.system(size: 13, weight: .regular, design: .rounded))
@@ -448,28 +557,6 @@ struct DailyChallengeView: View {
         )
     }
 
-    /// 広告視聴による挑戦回数追加ボタン
-    private var rewardButtonSection: some View {
-        Button {
-            Task { await viewModel.requestRewardedAttempt() }
-        } label: {
-            HStack {
-                Image(systemName: "gift.fill")
-                Text("広告を視聴して回数を追加")
-            }
-            .font(.system(size: 15, weight: .semibold, design: .rounded))
-            .foregroundColor(Color.white.opacity(viewModel.isRewardButtonEnabled ? 1 : 0.6))
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 14)
-            .background(
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .fill(theme.accentPrimary.opacity(viewModel.isRewardButtonEnabled ? 0.85 : 0.45))
-            )
-        }
-        .buttonStyle(.plain)
-        .disabled(!viewModel.isRewardButtonEnabled)
-        .accessibilityIdentifier("daily_challenge_reward_button")
-    }
 }
 
 #Preview {

--- a/UI/RootView.swift
+++ b/UI/RootView.swift
@@ -2073,18 +2073,20 @@ private extension TitleScreenView {
 
     var dailyChallengeTileHeadline: String {
         let bundle = dailyChallengeBundle
-        let remaining = dailyChallengeAttemptStore.remainingAttempts
+        let fixedRemaining = dailyChallengeAttemptStore.remainingAttempts(for: .fixed)
+        let randomRemaining = dailyChallengeAttemptStore.remainingAttempts(for: .random)
         let modeNames = bundle.orderedInfos.map { $0.mode.displayName }.joined(separator: " / ")
-        return "\(modeNames) ・ 残り \(remaining) 回"
+        return "\(modeNames) ・ 固定 残り \(fixedRemaining) 回 / ランダム 残り \(randomRemaining) 回"
     }
 
     var dailyChallengeTileDetail: String {
         let bundle = dailyChallengeBundle
-        let granted = dailyChallengeAttemptStore.rewardedAttemptsGranted
+        let fixedGranted = dailyChallengeAttemptStore.rewardedAttemptsGranted(for: .fixed)
+        let randomGranted = dailyChallengeAttemptStore.rewardedAttemptsGranted(for: .random)
         let maximumRewarded = dailyChallengeAttemptStore.maximumRewardedAttempts
         let fixedSummary = bundle.fixed.regulationPrimaryText
         let randomSummary = bundle.random.regulationPrimaryText
-        return "固定: \(fixedSummary) / ランダム: \(randomSummary) ・ 広告追加 \(granted)/\(maximumRewarded)"
+        return "固定: \(fixedSummary) / ランダム: \(randomSummary) ・ 広告追加 固定 \(fixedGranted)/\(maximumRewarded) ・ ランダム \(randomGranted)/\(maximumRewarded)"
     }
 
     var dailyChallengeBundle: DailyChallengeDefinitionService.ChallengeBundle {


### PR DESCRIPTION
## Summary
- split daily challenge attempt storage into variant-specific counters and expose variant-aware APIs
- update the daily challenge UI to show independent remaining counts and reward buttons per variant
- extend test coverage to verify variant-specific reset, consumption, and reward flows

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e23fd97794832cbbd69ab8fd270653