### PR TITLE
Retain penalty amount for automatic free redraw announcements

### DIFF
--- a/MonoKnightAppTests/GameViewIntegrationTests.swift
+++ b/MonoKnightAppTests/GameViewIntegrationTests.swift
@@ -110,14 +110,14 @@ final class GameViewIntegrationTests: XCTestCase {
 
         let secondEvent = receivedEvents[1]
         XCTAssertEqual(secondEvent.trigger, .automaticFreeRedraw, "2 回目のイベントが無料再抽選扱いになっていません")
-        XCTAssertEqual(secondEvent.penaltyAmount, 0, "無料再抽選でもペナルティ量が残っています")
+        XCTAssertEqual(secondEvent.penaltyAmount, firstEvent.penaltyAmount, "無料再抽選時に直前の加算手数が維持されていません")
 
         // 文字列生成も確認するため、アクセシビリティラベルを取得して文言を検証
         let firstBannerController = UIHostingController(rootView: PenaltyBannerView(event: firstEvent))
         XCTAssertTrue(firstBannerController.view.accessibilityLabel?.contains("+\(firstEvent.penaltyAmount)") ?? false, "初回イベントで加算手数が表記されていません")
 
         let secondBannerController = UIHostingController(rootView: PenaltyBannerView(event: secondEvent))
-        XCTAssertTrue(secondBannerController.view.accessibilityLabel?.contains("ペナルティなし") ?? false, "無料再抽選時のペナルティなし表記が欠落しています")
+        XCTAssertTrue(secondBannerController.view.accessibilityLabel?.contains("+\(secondEvent.penaltyAmount)") ?? false, "無料再抽選時のアクセシビリティ案内へ直前の手数が含まれていません")
 
         // テスト終了時に購読を破棄してメモリリークを防ぐ
         cancellables.forEach { $0.cancel() }

--- a/UI/PenaltyBannerView.swift
+++ b/UI/PenaltyBannerView.swift
@@ -76,19 +76,14 @@ private extension PenaltyBannerView {
     var primaryMessage: String {
         switch event.trigger {
         case .automaticDeadlock:
-            if event.penaltyAmount > 0 {
-                return "手詰まり → 手札スロットを引き直し (+\(event.penaltyAmount))"
-            } else {
-                return "手詰まり → ペナルティなしで引き直し"
-            }
+            // 自動検出時は加算手数を必ず表示し、0 の場合でも状態確認しやすくする
+            return "手詰まり → 手札スロットを引き直し (+\(event.penaltyAmount))"
         case .manualRedraw:
-            if event.penaltyAmount > 0 {
-                return "手動ペナルティ → 手札を再抽選 (+\(event.penaltyAmount))"
-            } else {
-                return "手動ペナルティ → 手札を再抽選 (ペナルティなし)"
-            }
+            // 手動ペナルティも同様に加算量を明示して、視認性を揃える
+            return "手動ペナルティ → 手札を再抽選 (+\(event.penaltyAmount))"
         case .automaticFreeRedraw:
-            return "連続手詰まり → 無料で手札を再抽選"
+            // 連続手詰まりでは直前のペナルティ手数を強調し、無料表現を避ける
+            return "連続手詰まり → 直前のペナルティ +\(event.penaltyAmount)"
         }
     }
 
@@ -96,19 +91,14 @@ private extension PenaltyBannerView {
     var secondaryMessage: String {
         switch event.trigger {
         case .automaticDeadlock:
-            if event.penaltyAmount > 0 {
-                return "使えるカードが無かったため、手数が \(event.penaltyAmount) 増加しました"
-            } else {
-                return "使えるカードが無かったため、今回はペナルティが発生しません"
-            }
+            // 自動検出では加算結果を数値で伝えて、盤面状況を振り返りやすくする
+            return "使えるカードが無かったため、手数が \(event.penaltyAmount) 増加しました"
         case .manualRedraw:
-            if event.penaltyAmount > 0 {
-                return "プレイヤー操作により手札を入れ替え、手数が \(event.penaltyAmount) 増加しました"
-            } else {
-                return "プレイヤー操作により手札を入れ替えましたが、手数の増加はありません"
-            }
+            // プレイヤー操作由来の加算量も同様に数値で案内する
+            return "プレイヤー操作により手札を入れ替え、手数が \(event.penaltyAmount) 増加しました"
         case .automaticFreeRedraw:
-            return "手詰まりが連続したため、追加手数なしで自動的に手札を入れ替えました"
+            // 無料表現の代わりに、直前に加算された手数を再確認できる補足へ置き換える
+            return "手詰まりが連続したため、直前に加算された手数は \(event.penaltyAmount) です"
         }
     }
 


### PR DESCRIPTION
## Summary
- propagate the previously paid penalty amount through automatic free redraw handling so UI and accessibility receive the correct value
- update the banner and VoiceOver messaging to announce the numeric penalty even on automatic free redraws
- refresh the GameView integration test to expect the carried-over penalty amount and verify the accessibility label includes it

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e2df48a58c832c93b091536ed45717