### PR TITLE
タイル効果の導入と描画対応

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -116,7 +116,8 @@ public final class GameCore: ObservableObject {
             initialVisitedPoints: mode.initialVisitedPoints,
             requiredVisitOverrides: mode.additionalVisitRequirements,
             togglePoints: mode.toggleTilePoints,
-            impassablePoints: mode.impassableTilePoints
+            impassablePoints: mode.impassableTilePoints,
+            tileEffects: mode.tileEffects
         )
         current = mode.initialSpawnPoint ?? BoardGeometry.defaultSpawnPoint(for: mode.boardSize)
         // モードに紐付くシードが指定されている場合はそれを利用し、日替わりチャレンジなどの再現性を確保する
@@ -362,7 +363,8 @@ public final class GameCore: ObservableObject {
             initialVisitedPoints: mode.initialVisitedPoints,
             requiredVisitOverrides: mode.additionalVisitRequirements,
             togglePoints: mode.toggleTilePoints,
-            impassablePoints: mode.impassableTilePoints
+            impassablePoints: mode.impassableTilePoints,
+            tileEffects: mode.tileEffects
         )
         current = mode.initialSpawnPoint
         moveCount = 0
@@ -546,14 +548,16 @@ extension GameCore {
                 initialVisitedPoints: [resolvedCurrent],
                 requiredVisitOverrides: mode.additionalVisitRequirements,
                 togglePoints: mode.toggleTilePoints,
-                impassablePoints: mode.impassableTilePoints
+                impassablePoints: mode.impassableTilePoints,
+                tileEffects: mode.tileEffects
             )
         } else {
             core.board = Board(
                 size: mode.boardSize,
                 requiredVisitOverrides: mode.additionalVisitRequirements,
                 togglePoints: mode.toggleTilePoints,
-                impassablePoints: mode.impassableTilePoints
+                impassablePoints: mode.impassableTilePoints,
+                tileEffects: mode.tileEffects
             )
         }
         core.current = resolvedCurrent

--- a/Game/GameScenePalette.swift
+++ b/Game/GameScenePalette.swift
@@ -28,6 +28,10 @@ public struct GameScenePalette {
     public let boardKnight: SKColor
     /// ガイド枠の線色
     public let boardGuideHighlight: SKColor
+    /// ワープ効果のアクセントカラー
+    public let boardTileEffectWarp: SKColor
+    /// 手札シャッフル効果のアクセントカラー
+    public let boardTileEffectShuffle: SKColor
 
     /// 主要な色をまとめて指定できるイニシャライザ
     /// - Parameters:
@@ -51,7 +55,9 @@ public struct GameScenePalette {
         boardTileToggle: SKColor,
         boardTileImpassable: SKColor,
         boardKnight: SKColor,
-        boardGuideHighlight: SKColor
+        boardGuideHighlight: SKColor,
+        boardTileEffectWarp: SKColor,
+        boardTileEffectShuffle: SKColor
     ) {
         self.boardBackground = boardBackground
         self.boardGridLine = boardGridLine
@@ -63,6 +69,8 @@ public struct GameScenePalette {
         self.boardTileImpassable = boardTileImpassable
         self.boardKnight = boardKnight
         self.boardGuideHighlight = boardGuideHighlight
+        self.boardTileEffectWarp = boardTileEffectWarp
+        self.boardTileEffectShuffle = boardTileEffectShuffle
     }
 }
 
@@ -88,7 +96,11 @@ public extension GameScenePalette {
         boardTileImpassable: SKColor(white: 0.05, alpha: 1.0),
         boardKnight: SKColor(white: 0.1, alpha: 1.0),
         // NOTE: SwiftUI のライトテーマと同じ彩度を抑えたオレンジを採用し、テーマ適用前でも一貫した強調色を維持する
-        boardGuideHighlight: SKColor(red: 0.94, green: 0.41, blue: 0.08, alpha: 0.85)
+        boardGuideHighlight: SKColor(red: 0.94, green: 0.41, blue: 0.08, alpha: 0.85),
+        // NOTE: ワープ効果は高コントラストなライトブルーを採用し、盤面上で瞬時に目に入るようにする
+        boardTileEffectWarp: SKColor(red: 0.36, green: 0.56, blue: 0.98, alpha: 0.95),
+        // NOTE: 手札シャッフルはモノトーン基調を維持しつつも差別化できるようニュートラルグレーを活用する
+        boardTileEffectShuffle: SKColor(white: 0.3, alpha: 0.92)
     )
 
     /// ダークテーマ適用前後でのデバッグ確認用のフォールバック
@@ -108,7 +120,11 @@ public extension GameScenePalette {
         boardTileImpassable: SKColor(white: 0.02, alpha: 1.0),
         boardKnight: SKColor(white: 0.95, alpha: 1.0),
         // NOTE: ダークテーマに合わせて明度を上げたオレンジを用い、背景の暗さに負けない発光感を演出する
-        boardGuideHighlight: SKColor(red: 1.0, green: 0.74, blue: 0.38, alpha: 0.9)
+        boardGuideHighlight: SKColor(red: 1.0, green: 0.74, blue: 0.38, alpha: 0.9),
+        // NOTE: ダークテーマのワープも明度を高めた青系で描画し、夜間でも視認できる発光感を持たせる
+        boardTileEffectWarp: SKColor(red: 0.56, green: 0.75, blue: 1.0, alpha: 0.95),
+        // NOTE: シャッフルはライトテーマよりも明度を上げ、背景とのコントラストを十分に確保する
+        boardTileEffectShuffle: SKColor(white: 0.7, alpha: 0.9)
     )
 }
 #endif

--- a/Tests/GameTests/BoardImpassableTileTests.swift
+++ b/Tests/GameTests/BoardImpassableTileTests.swift
@@ -61,4 +61,17 @@ final class BoardImpassableTileTests: XCTestCase {
         board.markVisited(traversablePoint)
         XCTAssertTrue(board.isVisited(traversablePoint), "移動可能マスの踏破処理が働いていません")
     }
+
+    /// 障害物にタイル効果を指定しても無視されることを確認する
+    func testTileEffectsIgnoredForImpassableTiles() {
+        let impassablePoint = GridPoint(x: 0, y: 0)
+        let board = Board(
+            size: 3,
+            impassablePoints: Set([impassablePoint]),
+            tileEffects: [impassablePoint: .shuffleHand]
+        )
+
+        XCTAssertNil(board.effect(at: impassablePoint), "障害物には効果が付与されない想定")
+        XCTAssertNil(board.state(at: impassablePoint)?.effect, "TileState へも効果が伝搬していないか確認")
+    }
 }

--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -89,7 +89,8 @@ final class GameBoardBridgeViewModel: ObservableObject {
             initialVisitedPoints: mode.initialVisitedPoints,
             requiredVisitOverrides: mode.additionalVisitRequirements,
             togglePoints: mode.toggleTilePoints,
-            impassablePoints: mode.impassableTilePoints
+            impassablePoints: mode.impassableTilePoints,
+            tileEffects: mode.tileEffects
         )
         preparedScene.scaleMode = .resizeFill
         preparedScene.gameCore = core
@@ -156,7 +157,9 @@ final class GameBoardBridgeViewModel: ObservableObject {
             // NOTE: 移動不可マスは専用トーンで塗り潰し、SpriteKit 側でも障害物が即座に伝わるようにする
             boardTileImpassable: appTheme.skBoardTileImpassable,
             boardKnight: appTheme.skBoardKnight,
-            boardGuideHighlight: appTheme.skBoardGuideHighlight
+            boardGuideHighlight: appTheme.skBoardGuideHighlight,
+            boardTileEffectWarp: appTheme.skBoardTileEffectWarp,
+            boardTileEffectShuffle: appTheme.skBoardTileEffectShuffle
         )
         scene.applyTheme(palette)
     }

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -492,6 +492,26 @@ struct AppTheme: DynamicProperty {
         }
     }
 
+    /// ワープ効果を描画する際のアクセントカラー
+    var boardTileEffectWarp: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            return Color(red: 0.56, green: 0.75, blue: 1.0).opacity(0.95)
+        default:
+            return Color(red: 0.36, green: 0.56, blue: 0.98).opacity(0.95)
+        }
+    }
+
+    /// 手札シャッフル効果を描画する際のニュートラルカラー
+    var boardTileEffectShuffle: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            return Color.white.opacity(0.9)
+        default:
+            return Color(red: 0.3, green: 0.3, blue: 0.3).opacity(0.92)
+        }
+    }
+
     #if canImport(UIKit)
     /// 指定したライト/ダークそれぞれの Color から動的 UIColor を生成するユーティリティ
     private func dynamicUIColor(light: Color, dark: Color) -> UIColor {
@@ -597,6 +617,22 @@ struct AppTheme: DynamicProperty {
             dark: color(for: .dark, keyPath: \.boardGuideHighlight)
         )
     }
+
+    /// SpriteKit ワープ効果カラーの UIColor 版
+    var uiBoardTileEffectWarp: UIColor {
+        dynamicUIColor(
+            light: color(for: .light, keyPath: \.boardTileEffectWarp),
+            dark: color(for: .dark, keyPath: \.boardTileEffectWarp)
+        )
+    }
+
+    /// SpriteKit シャッフル効果カラーの UIColor 版
+    var uiBoardTileEffectShuffle: UIColor {
+        dynamicUIColor(
+            light: color(for: .light, keyPath: \.boardTileEffectShuffle),
+            dark: color(for: .dark, keyPath: \.boardTileEffectShuffle)
+        )
+    }
     #endif
 
     #if canImport(SpriteKit) && canImport(UIKit)
@@ -629,5 +665,11 @@ struct AppTheme: DynamicProperty {
 
     /// SpriteKit の SKColor へ変換したガイドハイライト色
     var skBoardGuideHighlight: SKColor { SKColor(cgColor: uiBoardGuideHighlight.cgColor) }
+
+    /// SpriteKit の SKColor へ変換したワープ効果カラー
+    var skBoardTileEffectWarp: SKColor { SKColor(cgColor: uiBoardTileEffectWarp.cgColor) }
+
+    /// SpriteKit の SKColor へ変換したシャッフル効果カラー
+    var skBoardTileEffectShuffle: SKColor { SKColor(cgColor: uiBoardTileEffectShuffle.cgColor) }
     #endif
 }


### PR DESCRIPTION
## Summary
- add a TileEffect model and extend Board initialization to register warp and shuffle metadata safely
- flow tile effects through GameMode, GameCore, and the SpriteKit scene so decorated tiles render consistently with theme colors
- expand theme palettes and tests to cover tile-effect scenarios without regressing existing board behavior

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e2e63faeb0832cbd3d22bbfa2e9493