### PR TITLE
Introduce MovePattern metadata for move resolution

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -185,8 +185,15 @@ public final class GameCore: ObservableObject {
         let stack = handStacks[resolvedMove.stackIndex]
         guard stack.id == resolvedMove.stackID else { return }
         guard let card = stack.topCard, card.id == resolvedMove.card.id, card.move == resolvedMove.card.move else { return }
-        // 候補ベクトルが現在のカードに含まれているか検証し、不正な入力を排除する
-        guard card.move.movementVectors.contains(resolvedMove.moveVector) else { return }
+        // MovePattern から算出した経路が現時点でも有効かを検証し、不正な入力を排除する
+        let snapshotBoard = board
+        let context = MoveCard.MovePattern.ResolutionContext(
+            boardSize: snapshotBoard.size,
+            contains: { point in snapshotBoard.contains(point) },
+            isTraversable: { point in snapshotBoard.isTraversable(point) }
+        )
+        let validPaths = card.move.resolvePaths(from: currentPosition, context: context)
+        guard validPaths.contains(resolvedMove.path) else { return }
 
         let computedDestination = currentPosition.offset(dx: resolvedMove.moveVector.dx, dy: resolvedMove.moveVector.dy)
         // ResolvedCardMove が古い現在地から算出された場合は破棄する（UI との同期ズレ対策）
@@ -270,6 +277,11 @@ public final class GameCore: ObservableObject {
 
         // 盤面境界を参照するためローカル変数として保持しておく
         let activeBoard = board
+        let resolutionContext = MoveCard.MovePattern.ResolutionContext(
+            boardSize: activeBoard.size,
+            contains: { point in activeBoard.contains(point) },
+            isTraversable: { point in activeBoard.isTraversable(point) }
+        )
 
         // 列挙中に同じ座標へ向かうカードを検出しやすいよう、結果は座標→スタック順でソートする
         var resolved: [ResolvedCardMove] = []
@@ -279,19 +291,14 @@ public final class GameCore: ObservableObject {
             // トップカードが存在しなければスキップ
             guard let topCard = stack.topCard else { continue }
 
-            // MoveCard.movementVectors が保持する全候補を展開し、1 ベクトルずつ ResolvedCardMove に変換する
-            for vector in topCard.move.movementVectors {
-                let destination = origin.offset(dx: vector.dx, dy: vector.dy)
-                // 盤面外および移動不可マスは候補から除外し、障害物との衝突を防止する
-                guard activeBoard.contains(destination), activeBoard.isTraversable(destination) else { continue }
-
+            // MoveCard の MovePattern から盤面状況に応じた経路を算出する
+            for path in topCard.move.resolvePaths(from: origin, context: resolutionContext) {
                 resolved.append(
                     ResolvedCardMove(
                         stackID: stack.id,
                         stackIndex: index,
                         card: topCard,
-                        moveVector: vector,
-                        destination: destination
+                        path: path
                     )
                 )
             }
@@ -456,8 +463,7 @@ extension GameCore: GameCoreProtocol {
             stackID: resolved.stackID,
             stackIndex: resolved.stackIndex,
             topCard: resolved.card,
-            destination: resolved.destination,
-            moveVector: resolved.moveVector
+            path: resolved.path
         )
     }
 }

--- a/Game/HandStack.swift
+++ b/Game/HandStack.swift
@@ -35,6 +35,12 @@ public struct HandStack: Identifiable, Equatable {
     /// - Note: 今後同じ移動候補を持つ別カードが増えてもスタックを共用できるよう、MoveCard の列挙値ではなくベクトル列を比較基準とする
     public var representativeVectors: [MoveVector]? { representativeMove?.movementVectors }
 
+    /// 最新カードが持つ移動パターン ID を返す
+    /// - Note: MovePattern.Identity を比較すれば移動候補が同一かどうかを簡潔に判断できる
+    public var representativePatternIdentity: MoveCard.MovePattern.Identity? {
+        representativeMove?.movePattern.identity
+    }
+
     /// 同じ種類のカードを積み増しする
     /// - Parameter card: 追加したい `DealtCard`
     public mutating func append(_ card: DealtCard) {

--- a/Game/Models.swift
+++ b/Game/Models.swift
@@ -348,10 +348,12 @@ public struct BoardTapPlayRequest: Identifiable, Equatable {
     public let stackIndex: Int
     /// アニメーション用に参照するスタック先頭のカード
     public let topCard: DealtCard
-    /// リクエスト生成時に確定した移動先座標
-    public let destination: GridPoint
-    /// リクエスト生成時に選択された移動ベクトル
-    public let moveVector: MoveVector
+    /// リクエスト生成時に確定した移動経路
+    public let path: MoveCard.MovePattern.Path
+    /// 既存コード互換用に移動先座標を公開する計算プロパティ
+    public var destination: GridPoint { path.destination }
+    /// 既存コード互換用に移動ベクトルを公開する計算プロパティ
+    public var moveVector: MoveVector { path.vector }
 
     /// 公開イニシャライザ
     /// - Parameters:
@@ -359,22 +361,19 @@ public struct BoardTapPlayRequest: Identifiable, Equatable {
     ///   - stackID: 対象スタックの識別子
     ///   - stackIndex: 手札スロット内での位置
     ///   - topCard: 要求時点での先頭カード
-    ///   - destination: 選択された移動先座標
-    ///   - moveVector: 実際に適用する移動ベクトル
+    ///   - path: 選択された移動経路
     public init(
         id: UUID = UUID(),
         stackID: UUID,
         stackIndex: Int,
         topCard: DealtCard,
-        destination: GridPoint,
-        moveVector: MoveVector
+        path: MoveCard.MovePattern.Path
     ) {
         self.id = id
         self.stackID = stackID
         self.stackIndex = stackIndex
         self.topCard = topCard
-        self.destination = destination
-        self.moveVector = moveVector
+        self.path = path
     }
 
     /// ResolvedCardMove への変換を簡潔に行うための補助プロパティ
@@ -384,8 +383,7 @@ public struct BoardTapPlayRequest: Identifiable, Equatable {
             stackID: stackID,
             stackIndex: stackIndex,
             card: topCard,
-            moveVector: moveVector,
-            destination: destination
+            path: path
         )
     }
 

--- a/Game/ResolvedCardMove.swift
+++ b/Game/ResolvedCardMove.swift
@@ -9,33 +9,34 @@ public struct ResolvedCardMove: Hashable {
     public let stackIndex: Int
     /// 実際に使用可能なカード（`DealtCard`）
     public let card: DealtCard
-    /// 移動量をベクトルとして表現した値
-    public let moveVector: MoveVector
-    /// カード適用後に到達する座標
-    public let destination: GridPoint
+    /// 移動経路の詳細
+    public let path: MoveCard.MovePattern.Path
 
     /// カード種別を直接参照したいケース向けのヘルパー
     public var moveCard: MoveCard { card.move }
+    /// 移動量をベクトルとして取得するヘルパー
+    public var moveVector: MoveVector { path.vector }
+    /// 最終到達地点を返すヘルパー
+    public var destination: GridPoint { path.destination }
+    /// 通過マス一覧（目的地を含む）
+    public var traversedPoints: [GridPoint] { path.traversedPoints }
 
     /// 公開イニシャライザ
     /// - Parameters:
     ///   - stackID: スタックを識別する UUID
     ///   - stackIndex: `handStacks` 内での位置
     ///   - card: 使用対象の `DealtCard`
-    ///   - moveVector: カードが持つ移動ベクトル
-    ///   - destination: カード適用後の座標
+    ///   - path: MovePattern から解決した移動経路
     public init(
         stackID: UUID,
         stackIndex: Int,
         card: DealtCard,
-        moveVector: MoveVector,
-        destination: GridPoint
+        path: MoveCard.MovePattern.Path
     ) {
         self.stackID = stackID
         self.stackIndex = stackIndex
         self.card = card
-        self.moveVector = moveVector
-        self.destination = destination
+        self.path = path
     }
 
     /// `Hashable` 準拠用の実装
@@ -45,8 +46,7 @@ public struct ResolvedCardMove: Hashable {
         hasher.combine(stackIndex)
         hasher.combine(card.id)
         hasher.combine(card.move)
-        hasher.combine(moveVector)
-        hasher.combine(destination)
+        hasher.combine(path)
     }
 
     /// `Equatable` 準拠用の比較演算子
@@ -59,8 +59,7 @@ public struct ResolvedCardMove: Hashable {
         lhs.stackIndex == rhs.stackIndex &&
         lhs.card.id == rhs.card.id &&
         lhs.card.move == rhs.card.move &&
-        lhs.moveVector == rhs.moveVector &&
-        lhs.destination == rhs.destination
+        lhs.path == rhs.path
     }
 }
 

--- a/Tests/GameTests/GameCoreTests.swift
+++ b/Tests/GameTests/GameCoreTests.swift
@@ -548,8 +548,8 @@ final class GameCoreTests: XCTestCase {
             [.kingUp, .kingRight, .straightUp2, .kingLeft, .knightUp1Right2],
             "空きスロットに新カードが補充されていません"
         )
-        let kingRightVectors = MoveCard.kingRight.movementVectors
-        if let rightStack = core.handStacks.first(where: { $0.representativeVectors == kingRightVectors }) {
+        let kingRightIdentity = MoveCard.kingRight.movePattern.identity
+        if let rightStack = core.handStacks.first(where: { $0.representativePatternIdentity == kingRightIdentity }) {
             XCTAssertEqual(rightStack.count, 2, "重なったカード枚数が想定と異なります")
         } else {
             XCTFail("キング右のスタックが見つかりません")
@@ -597,10 +597,10 @@ final class GameCoreTests: XCTestCase {
         XCTAssertFalse(core.isAwaitingManualDiscardSelection)
         XCTAssertEqual(core.penaltyCount, initialPenalty + core.mode.manualDiscardPenaltyCost)
         XCTAssertEqual(core.handStacks.count, 5)
-        let kingRightVectors = MoveCard.kingRight.movementVectors
-        let straightUpVectors = MoveCard.straightUp2.movementVectors
-        XCTAssertFalse(core.handStacks.contains(where: { $0.representativeVectors == kingRightVectors }))
-        XCTAssertTrue(core.handStacks.contains(where: { $0.representativeVectors == straightUpVectors }))
+        let kingRightIdentity = MoveCard.kingRight.movePattern.identity
+        let straightUpIdentity = MoveCard.straightUp2.movePattern.identity
+        XCTAssertFalse(core.handStacks.contains(where: { $0.representativePatternIdentity == kingRightIdentity }))
+        XCTAssertTrue(core.handStacks.contains(where: { $0.representativePatternIdentity == straightUpIdentity }))
         XCTAssertEqual(
             core.nextCards.map { $0.move },
             [.diagonalUpRight2, .kingUpRight, .straightDown2]

--- a/Tests/GameTests/HandManagerTests.swift
+++ b/Tests/GameTests/HandManagerTests.swift
@@ -38,12 +38,12 @@ final class HandManagerTests: XCTestCase {
 
         for scenario in scenarios {
             var deck = Deck.makeTestDeck(cards: scenario.preset, configuration: scenario.configuration)
-            let uniqueCount = deck.uniqueMoveSignatureCount()
+            let uniqueCount = deck.uniqueMoveIdentityCount()
 
             let handManager = HandManager(handSize: 5, nextPreviewCount: 0, allowsCardStacking: true)
             handManager.refillHandStacks(using: &deck)
 
-            // ユニークシグネチャ数と手札上限の小さい方までしかスタックが作られないことを確認する
+            // ユニークパターン数と手札上限の小さい方までしかスタックが作られないことを確認する
             XCTAssertEqual(
                 handManager.handStacks.count,
                 min(5, uniqueCount),
@@ -62,7 +62,7 @@ final class HandManagerTests: XCTestCase {
             .kingLeftOrRight
         ]
         var deck = Deck.makeTestDeck(cards: preset, configuration: .kingOrthogonalChoiceOnly)
-        let uniqueCount = deck.uniqueMoveSignatureCount()
+        let uniqueCount = deck.uniqueMoveIdentityCount()
 
         let handManager = HandManager(handSize: 5, nextPreviewCount: 0, allowsCardStacking: true)
         handManager.refillHandStacks(using: &deck, preferredInsertionIndices: [0, 1, 2])

--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -341,8 +341,7 @@ final class GameBoardBridgeViewModel: ObservableObject {
                 stackID: resolvedMove.stackID,
                 stackIndex: fallbackIndex,
                 card: resolvedMove.card,
-                moveVector: resolvedMove.moveVector,
-                destination: resolvedMove.destination
+                path: resolvedMove.path
             )
             debugLog(
                 "スタック位置を補正: 元index=\(resolvedMove.stackIndex) 新index=\(fallbackIndex) stackID=\(resolvedMove.stackID)"

--- a/docs/refactoring-guidelines.md
+++ b/docs/refactoring-guidelines.md
@@ -52,11 +52,11 @@
 ## 3. 優先すべきリファクタリング領域
 1. **ゲームコアロジック (`Game` パッケージ)**
    - `GameModuleInterfaces` を経由した依存注入が整備されたため、今後は `HandManager` や `Deck` の再利用性を高める。
-   - 2024-05 リファクタリング: 移動量を `MoveVector` へ集約し、`MoveCard.movementVectors` / `primaryVector` を通じて参照する。
-     - 旧実装で `dx` / `dy` を直接参照している箇所は、`primaryVector.dx` / `.dy` へ置き換える。
-     - 同一挙動カードの比較は `MoveVector` 配列をキーにする。`HandStack.representativeVectors` や `Deck.Configuration.allowedMoveSignatures` を活用する。
-     - 複数候補カードを導入する場合は `movementVectors` の配列を増やし、UI は `ResolvedCardMove` の拡張で候補選択ロジックを追加する。
-     - テストは `MoveCard` の代表ベクトルが期待通りであることを明示的に検証し、回帰検知の指標とする。
+  - 2024-05 リファクタリング: 移動量を `MovePattern` で抽象化し、`MoveCard.movePattern` / `primaryVector` を通じて参照する。
+    - 旧実装で `dx` / `dy` を直接参照している箇所は、`primaryVector.dx` / `.dy` へ置き換える。
+    - 同一挙動カードの比較は `MovePattern.Identity` をキーにする。`HandStack.representativePatternIdentity` や `Deck.Configuration.allowedMoveIdentities` を活用する。
+    - 複数候補カードを導入する場合は `MovePattern` による経路解決を利用し、UI は `ResolvedCardMove` の `path` を通じて候補選択ロジックを追加する。
+    - テストは `MoveCard` の移動パターンと代表ベクトルが期待通りであることを明示的に検証し、回帰検知の指標とする。
    - モードごとのペナルティ・手札整理ロジックを `GameMode` のパラメータに一本化し、盤面追加時にも破綻しないようテストを拡充する。
      `GameCore+Penalty.swift` など機能別ファイルの役割をドキュメントへ反映しておく。
 2. **UI レイヤー (`UI/` ディレクトリ)**


### PR DESCRIPTION
## Summary
- introduce the MovePattern abstraction so cards expose reusable identities and board-aware path resolution
- update deck, hand management, and game core logic to rely on MovePattern identity/path data when stacking, sorting, and generating move candidates
- refresh game logic tests and documentation to exercise the new APIs and retire direct movementVectors comparisons

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e2e6513e28832c962aedcf177ccae9