### PR TITLE
Add directional ray cards and update decks

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -75,8 +75,8 @@ struct Deck {
         /// - Note: 直線 2 マスと斜め 2 マスのカードだけ重みを下げ、初心者向けに調整する
         static let standardLight: Configuration = {
             let allowedMoves = MoveCard.standardSet
-            // 長距離カード 8 種を個別に上書きし、重み 1 で出現頻度を抑える
-            let longRangeCards: [MoveCard] = [
+            // 長距離カード（距離 2 系＋レイ型）を個別に上書きし、重み 1 で出現頻度を抑える
+            let longRangeCards: [MoveCard] = MoveCard.directionalRayCards + [
                 .straightUp2,
                 .straightDown2,
                 .straightRight2,
@@ -91,6 +91,20 @@ struct Deck {
                 allowedMoves: allowedMoves,
                 weightProfile: WeightProfile(defaultWeight: 3, overrides: overrides),
                 deckSummaryText: "長距離カード抑制型標準デッキ"
+            )
+        }()
+
+        /// 連続レイ型カードの練習に特化した構成
+        /// - Note: レイ型カードは重み 3、サポート用に上下左右キングを重み 1 で混在させ、盤面調整しやすくする
+        static let directionalRayFocus: Configuration = {
+            let rayCards = MoveCard.directionalRayCards
+            let supportKings: [MoveCard] = [.kingUp, .kingRight, .kingDown, .kingLeft]
+            let allowedMoves = rayCards + supportKings
+            let overrides = Dictionary(uniqueKeysWithValues: rayCards.map { ($0, 3) })
+            return Configuration(
+                allowedMoves: allowedMoves,
+                weightProfile: WeightProfile(defaultWeight: 1, overrides: overrides),
+                deckSummaryText: "連続移動カード集中デッキ"
             )
         }()
 

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -19,6 +19,8 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
     case kingPlusKnightOnly
     /// キング型カードに上下左右の選択肢を加えた構成
     case directionChoice
+    /// レイ型カードを主体とした連続移動構成
+    case directionalRayFocus
     /// 標準デッキに上下左右の選択キングを加えた構成
     case standardWithOrthogonalChoices
     /// 標準デッキに斜め選択キングを加えた構成
@@ -56,6 +58,8 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
             return "キング＋ナイト限定構成"
         case .directionChoice:
             return "選択式キング構成"
+        case .directionalRayFocus:
+            return "連続移動カード構成"
         case .standardWithOrthogonalChoices:
             return "標準＋縦横選択キング構成"
         case .standardWithDiagonalChoices:
@@ -97,6 +101,8 @@ public enum GameDeckPreset: String, CaseIterable, Codable, Identifiable {
             return .kingPlusKnightOnly
         case .directionChoice:
             return .directionChoice
+        case .directionalRayFocus:
+            return .directionalRayFocus
         case .standardWithOrthogonalChoices:
             return .standardWithOrthogonalChoices
         case .standardWithDiagonalChoices:

--- a/Tests/GameTests/CampaignLibraryTests.swift
+++ b/Tests/GameTests/CampaignLibraryTests.swift
@@ -74,6 +74,17 @@ final class CampaignLibraryTests: XCTestCase {
                 ])
             ),
             (.directionChoice, "選択式キング構成", "選択式キングカード入り", [.kingUpOrDown, .kingLeftOrRight]),
+            (
+                .directionalRayFocus,
+                "連続移動カード構成",
+                "連続移動カード集中デッキ",
+                Set(MoveCard.directionalRayCards).union([
+                    .kingUp,
+                    .kingRight,
+                    .kingDown,
+                    .kingLeft
+                ])
+            ),
             (.standardWithOrthogonalChoices, "標準＋縦横選択キング構成", "標準＋上下左右選択キング", Set(MoveCard.standardSet).union([.kingUpOrDown, .kingLeftOrRight])),
             (.standardWithDiagonalChoices, "標準＋斜め選択キング構成", "標準＋斜め選択キング", Set(MoveCard.standardSet).union([
                 .kingUpwardDiagonalChoice,

--- a/Tests/GameTests/GameCoreAvailableMovesTests.swift
+++ b/Tests/GameTests/GameCoreAvailableMovesTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import Game
+
+/// GameCore.availableMoves() がレイ型カードの挙動を正しく解決するか検証するテスト
+final class GameCoreAvailableMovesTests: XCTestCase {
+    /// 盤端と障害物に応じてレイ型カードが停止することを確認する
+    func testDirectionalRayStopsAtBoardEdgeAndObstacle() {
+        // --- 盤端まで進むケースを検証 ---
+        let edgeRegulation = GameMode.Regulation(
+            boardSize: BoardGeometry.standardSize,
+            handSize: 1,
+            nextPreviewCount: 0,
+            allowsStacking: true,
+            deckPreset: .directionalRayFocus,
+            spawnRule: .fixed(GridPoint(x: 2, y: 2)),
+            penalties: GameMode.PenaltySettings(
+                deadlockPenaltyCost: 0,
+                manualRedrawPenaltyCost: 0,
+                manualDiscardPenaltyCost: 0,
+                revisitPenaltyCost: 0
+            )
+        )
+        let edgeMode = GameMode(
+            identifier: .freeCustom,
+            displayName: "レイ端テスト",
+            regulation: edgeRegulation,
+            leaderboardEligible: false
+        )
+        let edgeDeck = Deck.makeTestDeck(cards: [.rayUp], configuration: edgeRegulation.deckPreset.configuration)
+        let edgeCore = GameCore.makeTestInstance(deck: edgeDeck, current: GridPoint(x: 2, y: 2), mode: edgeMode)
+        let rayStack = HandStack(cards: [DealtCard(move: .rayUp)])
+        let edgeMoves = edgeCore.availableMoves(handStacks: [rayStack], current: GridPoint(x: 2, y: 2))
+        XCTAssertEqual(edgeMoves.count, 1, "盤端テストで候補数が 1 件になっていません")
+        if let move = edgeMoves.first {
+            XCTAssertEqual(move.destination, GridPoint(x: 2, y: 4), "盤端到達先が期待値と異なります")
+            XCTAssertEqual(move.path, [GridPoint(x: 2, y: 3), GridPoint(x: 2, y: 4)], "通過マスの記録が不足しています")
+        }
+
+        // --- 障害物で停止するケースを検証 ---
+        let obstaclePoint = GridPoint(x: 2, y: 4)
+        let obstacleRegulation = GameMode.Regulation(
+            boardSize: BoardGeometry.standardSize,
+            handSize: 1,
+            nextPreviewCount: 0,
+            allowsStacking: true,
+            deckPreset: .directionalRayFocus,
+            spawnRule: .fixed(GridPoint(x: 2, y: 2)),
+            penalties: GameMode.PenaltySettings(
+                deadlockPenaltyCost: 0,
+                manualRedrawPenaltyCost: 0,
+                manualDiscardPenaltyCost: 0,
+                revisitPenaltyCost: 0
+            ),
+            impassableTilePoints: [obstaclePoint]
+        )
+        let obstacleMode = GameMode(
+            identifier: .freeCustom,
+            displayName: "レイ障害物テスト",
+            regulation: obstacleRegulation,
+            leaderboardEligible: false
+        )
+        let obstacleDeck = Deck.makeTestDeck(cards: [.rayUp], configuration: obstacleRegulation.deckPreset.configuration)
+        let obstacleCore = GameCore.makeTestInstance(deck: obstacleDeck, current: GridPoint(x: 2, y: 2), mode: obstacleMode)
+        let obstacleMoves = obstacleCore.availableMoves(handStacks: [rayStack], current: GridPoint(x: 2, y: 2))
+        XCTAssertEqual(obstacleMoves.count, 1, "障害物テストで候補数が 1 件になっていません")
+        if let move = obstacleMoves.first {
+            XCTAssertEqual(move.destination, GridPoint(x: 2, y: 3), "障害物直前で停止していません")
+            XCTAssertEqual(move.path, [GridPoint(x: 2, y: 3)], "障害物直前までの経路記録が想定と異なります")
+        }
+    }
+
+    /// レイ型カードの通過マスがすべて踏破扱いになるように記録されているか検証する
+    func testDirectionalRayTraversedPointsIncludeEntireRoute() {
+        let regulation = GameMode.Regulation(
+            boardSize: BoardGeometry.standardSize,
+            handSize: 1,
+            nextPreviewCount: 0,
+            allowsStacking: true,
+            deckPreset: .directionalRayFocus,
+            spawnRule: .fixed(GridPoint(x: 0, y: 0)),
+            penalties: GameMode.PenaltySettings(
+                deadlockPenaltyCost: 0,
+                manualRedrawPenaltyCost: 0,
+                manualDiscardPenaltyCost: 0,
+                revisitPenaltyCost: 0
+            )
+        )
+        let mode = GameMode(
+            identifier: .freeCustom,
+            displayName: "レイ踏破テスト",
+            regulation: regulation,
+            leaderboardEligible: false
+        )
+        let deck = Deck.makeTestDeck(cards: [.rayUpRight], configuration: regulation.deckPreset.configuration)
+        let core = GameCore.makeTestInstance(deck: deck, current: GridPoint(x: 0, y: 0), mode: mode)
+        let stack = HandStack(cards: [DealtCard(move: .rayUpRight)])
+        let moves = core.availableMoves(handStacks: [stack], current: GridPoint(x: 0, y: 0))
+        XCTAssertEqual(moves.count, 1, "踏破テストで候補数が 1 件ではありません")
+        if let move = moves.first {
+            let expectedPath = [
+                GridPoint(x: 1, y: 1),
+                GridPoint(x: 2, y: 2),
+                GridPoint(x: 3, y: 3),
+                GridPoint(x: 4, y: 4)
+            ]
+            XCTAssertEqual(move.path, expectedPath, "通過マスが全経路を表していません")
+        }
+    }
+
+    /// UI 側へ渡す候補数が 1 件に固定され、選択式扱いにならないことを確認する
+    func testDirectionalRayProvidesSingleCandidate() {
+        let regulation = GameMode.Regulation(
+            boardSize: BoardGeometry.standardSize,
+            handSize: 1,
+            nextPreviewCount: 0,
+            allowsStacking: true,
+            deckPreset: .directionalRayFocus,
+            spawnRule: .fixed(GridPoint(x: 2, y: 2)),
+            penalties: GameMode.PenaltySettings(
+                deadlockPenaltyCost: 0,
+                manualRedrawPenaltyCost: 0,
+                manualDiscardPenaltyCost: 0,
+                revisitPenaltyCost: 0
+            )
+        )
+        let mode = GameMode(
+            identifier: .freeCustom,
+            displayName: "レイ候補数テスト",
+            regulation: regulation,
+            leaderboardEligible: false
+        )
+        let deck = Deck.makeTestDeck(cards: [.rayRight], configuration: regulation.deckPreset.configuration)
+        let core = GameCore.makeTestInstance(deck: deck, current: GridPoint(x: 2, y: 2), mode: mode)
+        let stack = HandStack(cards: [DealtCard(move: .rayRight)])
+        let moves = core.availableMoves(handStacks: [stack], current: GridPoint(x: 2, y: 2))
+        XCTAssertEqual(moves.count, 1, "レイ型カードが複数候補を返しています")
+    }
+}


### PR DESCRIPTION
## Summary
- add directional-ray move cards with helper logic that records full traversal while returning only the final destination
- integrate the new cards into standard move sets, deck configurations, and presets including a ray-focused preset
- extend unit coverage for deck expectations and available move resolution with new directional-ray scenarios

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e2f8fc1914832c99adbd6a7aeeb113