### PR TITLE
Add super warp card and tighten highlight filtering

### DIFF
--- a/Game/Deck.swift
+++ b/Game/Deck.swift
@@ -161,13 +161,14 @@ struct Deck {
                 .knightDownwardChoice,
                 .knightLeftwardChoice
             ]
-            let allowedMoves = MoveCard.standardSet + choiceCards
+            let specialCards = choiceCards + [.superWarp]
+            let allowedMoves = MoveCard.standardSet + specialCards
             // 選択式カードを積極的に引いてもらうため、単一方向カード（重み 1）の 2 倍となる重み 2 を個別指定する
             let overrides = Dictionary(uniqueKeysWithValues: choiceCards.map { ($0, 2) })
             return Configuration(
                 allowedMoves: allowedMoves,
                 weightProfile: WeightProfile(defaultWeight: 1, overrides: overrides),
-                deckSummaryText: "標準＋全選択カード"
+                deckSummaryText: "標準＋全選択カード＋超ワープ"
             )
         }()
 
@@ -284,12 +285,13 @@ struct Deck {
                 .knightUpwardChoice,
                 .knightRightwardChoice,
                 .knightDownwardChoice,
-                .knightLeftwardChoice
+                .knightLeftwardChoice,
+                .superWarp
             ]
             return Configuration(
                 allowedMoves: moves,
                 weightProfile: WeightProfile(defaultWeight: 1),
-                deckSummaryText: "選択カード総合ミックス"
+                deckSummaryText: "選択カード＋超ワープ総合ミックス"
             )
         }()
     }

--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -191,7 +191,8 @@ public final class GameCore: ObservableObject {
         let context = MoveCard.MovePattern.ResolutionContext(
             boardSize: snapshotBoard.size,
             contains: { point in snapshotBoard.contains(point) },
-            isTraversable: { point in snapshotBoard.isTraversable(point) }
+            isTraversable: { point in snapshotBoard.isTraversable(point) },
+            isVisited: { point in snapshotBoard.isVisited(point) }
         )
         let validPaths = card.move.resolvePaths(from: currentPosition, context: context)
         let isStillValid = validPaths.contains { path in
@@ -322,7 +323,8 @@ public final class GameCore: ObservableObject {
         let resolutionContext = MoveCard.MovePattern.ResolutionContext(
             boardSize: activeBoard.size,
             contains: { point in activeBoard.contains(point) },
-            isTraversable: { point in activeBoard.isTraversable(point) }
+            isTraversable: { point in activeBoard.isTraversable(point) },
+            isVisited: { point in activeBoard.isVisited(point) }
         )
 
         // 列挙中に同じ座標へ向かうカードを検出しやすいよう、結果は座標→スタック順でソートする
@@ -641,6 +643,15 @@ extension GameCore {
         self.elapsedSeconds = elapsedSeconds
         self.hasRevisitedTile = hasRevisitedTile
         sessionTimer.overrideFinalizedElapsedSecondsForTesting(elapsedSeconds)
+    }
+
+    /// 指定マスを強制的に踏破済みにするテスト専用メソッド
+    /// - Parameter points: 踏破扱いにしたい座標集合
+    func markVisitedTilesForTesting(_ points: [GridPoint]) {
+        for point in points {
+            guard board.contains(point) else { continue }
+            board.markVisited(point)
+        }
     }
 
     /// テストでクリア時刻を任意指定したい場合に利用する

--- a/MonoKnightAppTests/GameBoardBridgeViewModelHighlightTests.swift
+++ b/MonoKnightAppTests/GameBoardBridgeViewModelHighlightTests.swift
@@ -153,6 +153,28 @@ final class GameBoardBridgeViewModelHighlightTests: XCTestCase {
         )
     }
 
+    /// 強制ハイライトが既踏マスを除外することを検証する
+    func testForcedSelectionHighlightsExcludeVisitedTiles() {
+        let viewModel = makeViewModel()
+        let origin = GridPoint(x: 2, y: 2)
+        let visitedPoint = GridPoint(x: 3, y: 2)
+
+        viewModel.core.markVisitedTilesForTesting([visitedPoint])
+
+        // 右隣（既踏マス）を強制ハイライトに指定するが、実際には除外される想定
+        let movement = MoveVector(dx: 1, dy: 0)
+        viewModel.updateForcedSelectionHighlights([], origin: origin, movementVectors: [movement])
+
+        XCTAssertFalse(
+            viewModel.forcedSelectionHighlightPoints.contains(visitedPoint),
+            "既踏マスが強制ハイライトに含まれています"
+        )
+        XCTAssertTrue(
+            viewModel.forcedSelectionHighlightPoints.isEmpty,
+            "今回のシナリオでは有効マスが存在しないため空集合を維持する想定です"
+        )
+    }
+
     /// テストで使い回す ViewModel を生成するヘルパー
     private func makeViewModel() -> GameBoardBridgeViewModel {
         let core = GameCore(mode: .standard)

--- a/Tests/GameTests/CampaignLibraryTests.swift
+++ b/Tests/GameTests/CampaignLibraryTests.swift
@@ -87,18 +87,24 @@ final class CampaignLibraryTests: XCTestCase {
                 .knightDownwardChoice,
                 .knightLeftwardChoice
             ])),
-            (.standardWithAllChoices, "標準＋全選択カード構成", "標準＋全選択カード", Set(MoveCard.standardSet).union([
-                .kingUpOrDown,
-                .kingLeftOrRight,
-                .kingUpwardDiagonalChoice,
-                .kingRightDiagonalChoice,
-                .kingDownwardDiagonalChoice,
-                .kingLeftDiagonalChoice,
-                .knightUpwardChoice,
-                .knightRightwardChoice,
-                .knightDownwardChoice,
-                .knightLeftwardChoice
-            ])),
+            (
+                .standardWithAllChoices,
+                "標準＋全選択カード構成",
+                "標準＋全選択カード＋超ワープ",
+                Set(MoveCard.standardSet).union([
+                    .kingUpOrDown,
+                    .kingLeftOrRight,
+                    .kingUpwardDiagonalChoice,
+                    .kingRightDiagonalChoice,
+                    .kingDownwardDiagonalChoice,
+                    .kingLeftDiagonalChoice,
+                    .knightUpwardChoice,
+                    .knightRightwardChoice,
+                    .knightDownwardChoice,
+                    .knightLeftwardChoice,
+                    .superWarp
+                ])
+            ),
             (.kingOrthogonalChoiceOnly, "上下左右選択キング構成", "上下左右の選択キング限定", [.kingUpOrDown, .kingLeftOrRight]),
             (.kingDiagonalChoiceOnly, "斜め選択キング構成", "斜め選択キング限定", [
                 .kingUpwardDiagonalChoice,
@@ -112,18 +118,24 @@ final class CampaignLibraryTests: XCTestCase {
                 .knightDownwardChoice,
                 .knightLeftwardChoice
             ]),
-            (.allChoiceMixed, "選択カード総合構成", "選択カード総合ミックス", [
-                .kingUpOrDown,
-                .kingLeftOrRight,
-                .kingUpwardDiagonalChoice,
-                .kingRightDiagonalChoice,
-                .kingDownwardDiagonalChoice,
-                .kingLeftDiagonalChoice,
-                .knightUpwardChoice,
-                .knightRightwardChoice,
-                .knightDownwardChoice,
-                .knightLeftwardChoice
-            ])
+            (
+                .allChoiceMixed,
+                "選択カード総合構成",
+                "選択カード＋超ワープ総合ミックス",
+                Set([
+                    .kingUpOrDown,
+                    .kingLeftOrRight,
+                    .kingUpwardDiagonalChoice,
+                    .kingRightDiagonalChoice,
+                    .kingDownwardDiagonalChoice,
+                    .kingLeftDiagonalChoice,
+                    .knightUpwardChoice,
+                    .knightRightwardChoice,
+                    .knightDownwardChoice,
+                    .knightLeftwardChoice,
+                    .superWarp
+                ])
+            )
         ]
 
         for (preset, expectedName, expectedSummary, expectedMoves) in presets {

--- a/Tests/GameTests/DeckTests.swift
+++ b/Tests/GameTests/DeckTests.swift
@@ -128,13 +128,16 @@ final class DeckTests: XCTestCase {
             .knightLeftwardChoice
         ]
         XCTAssertTrue(expectedChoices.isSubset(of: allowedMoves), "全選択カードが揃っていません")
+        XCTAssertTrue(allowedMoves.contains(.superWarp), "超ワープカードが全選択デッキに含まれていません")
         // MARK: 選択式カードは単一方向カードの 2 倍である重み 2 に引き上げられているか検証
         expectedChoices.forEach { choice in
             XCTAssertEqual(config.weightProfile.weight(for: choice), 2, "全選択カードの重みが想定値 2 と異なります: \(choice)")
         }
+        // MARK: 超ワープは標準カード相当の重みで追加されているか確認
+        XCTAssertEqual(config.weightProfile.weight(for: .superWarp), 1, "超ワープの重みは 1 の想定です")
         // MARK: 既存の単一方向カードは従来どおり重み 1 を維持しているかチェック
         XCTAssertEqual(config.weightProfile.weight(for: .kingUp), 1, "標準カードの重みが 1 から変化しています")
-        XCTAssertEqual(config.deckSummaryText, "標準＋全選択カード")
+        XCTAssertEqual(config.deckSummaryText, "標準＋全選択カード＋超ワープ")
     }
 
     /// MoveCard.allCases にキング型 8 種が含まれているかを検証する
@@ -177,6 +180,7 @@ final class DeckTests: XCTestCase {
         XCTAssertFalse(MoveCard.standardSet.contains(.knightRightwardChoice), "選択式カードがスタンダードセットへ混入しています")
         XCTAssertFalse(MoveCard.standardSet.contains(.knightDownwardChoice), "選択式カードがスタンダードセットへ混入しています")
         XCTAssertFalse(MoveCard.standardSet.contains(.knightLeftwardChoice), "選択式カードがスタンダードセットへ混入しています")
+        XCTAssertFalse(MoveCard.standardSet.contains(.superWarp), "特殊カードの超ワープがスタンダードセットへ混入しています")
     }
 
     /// directionChoice 構成が新カードを含み、重みも設定されていることを検証する
@@ -241,11 +245,12 @@ final class DeckTests: XCTestCase {
             .knightUpwardChoice,
             .knightRightwardChoice,
             .knightDownwardChoice,
-            .knightLeftwardChoice
+            .knightLeftwardChoice,
+            .superWarp
         ]
         XCTAssertEqual(Set(config.allowedMoves), expected, "全選択カード混合デッキの内容が一致していません")
         XCTAssertTrue(expected.allSatisfy { config.weightProfile.weight(for: $0) == 1 }, "混合デッキ内の重みが均等ではありません")
-        XCTAssertEqual(config.deckSummaryText, "選択カード総合ミックス", "サマリーテキストが仕様と異なります")
+        XCTAssertEqual(config.deckSummaryText, "選択カード＋超ワープ総合ミックス", "サマリーテキストが仕様と異なります")
     }
 
     /// クラシカルチャレンジ設定では桂馬カードのみが配られるか検証する

--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -301,7 +301,9 @@ final class GameBoardBridgeViewModel: ObservableObject {
         // 盤面内かつ移動可能なマスだけを残し、障害物をハイライト対象から除外する
         let validPoints = Set(
             candidatePoints.filter { point in
-                core.board.contains(point) && core.board.isTraversable(point)
+                core.board.contains(point) &&
+                core.board.isTraversable(point) &&
+                !core.board.isVisited(point)
             }
         )
         guard forcedSelectionHighlightPoints != validPoints else { return }

--- a/UI/GameViewModel.swift
+++ b/UI/GameViewModel.swift
@@ -380,12 +380,21 @@ final class GameViewModel: ObservableObject {
             return
         }
 
-        // MoveCard.movementVectors を現在地へ適用し、盤面内の候補座標をハイライトへ変換する
-        boardBridge.updateForcedSelectionHighlights(
-            [],
-            origin: current,
-            movementVectors: card.move.movementVectors
-        )
+        // GameCore.availableMoves() を利用し、障害物・既踏マスを除外した実際の候補のみをハイライトする
+        let resolvedMoves = core.availableMoves().filter { candidate in
+            candidate.stackID == stack.id &&
+            candidate.card.id == card.id &&
+            candidate.card.move == card.move
+        }
+
+        guard !resolvedMoves.isEmpty else {
+            boardBridge.updateForcedSelectionHighlights([])
+            return
+        }
+
+        let destinations = Set(resolvedMoves.map(\.destination))
+        let vectors = resolvedMoves.map(\.moveVector)
+        boardBridge.updateForcedSelectionHighlights(destinations, origin: current, movementVectors: vectors)
     }
 
     /// 表示用の経過時間を再計算する


### PR DESCRIPTION
## Summary
- extend `MoveCard.MovePattern` with a resolution context, dynamic absolute target helper, and the new super warp pattern
- include the super warp card in relevant decks, update game logic to filter visited and impassable tiles, and wire UI highlights to the filtered moves
- add regression tests covering super warp move availability, deck composition, and highlight filtering across core and UI layers

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e2f90d19ec832cab343b2563af5599