### PR TITLE
Add accessibility direction phrases for new move cards

### DIFF
--- a/UI/GameHandSectionView.swift
+++ b/UI/GameHandSectionView.swift
@@ -352,6 +352,28 @@ private extension GameHandSectionView {
             return "右下へ 2"
         case .diagonalDownLeft2:
             return "左下へ 2"
+        // レイ型カードは止まるまで進む特性があるため、連続移動であることを強調して伝える
+        case .rayUp:
+            return "上方向へ連続移動"
+        case .rayUpRight:
+            return "右上方向へ連続移動"
+        case .rayRight:
+            return "右方向へ連続移動"
+        case .rayDownRight:
+            return "右下方向へ連続移動"
+        case .rayDown:
+            return "下方向へ連続移動"
+        case .rayDownLeft:
+            return "左下方向へ連続移動"
+        case .rayLeft:
+            return "左方向へ連続移動"
+        case .rayUpLeft:
+            return "左上方向へ連続移動"
+        // ワープ系カードは挙動が特殊なので、対象範囲を明確に読み上げて誤操作を防ぐ
+        case .superWarp:
+            return "未踏マスへ全域ワープ"
+        case .fixedWarp:
+            return "定められた座標へ固定ワープ"
         }
     }
 


### PR DESCRIPTION
## Summary
- add VoiceOver direction phrases for the new ray and warp move cards in `GameHandSectionView`

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e31de3ebe0832c8db5c91679063e4d