### PR TITLE
Implement multi-step move card visuals

### DIFF
--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -195,6 +195,17 @@ struct AppTheme: DynamicProperty {
         }
     }
 
+    /// 複数マス移動カード専用のアクセントカラー（シアン系）
+    /// - Note: Assets に依存せずコード側で調整し、ライト/ダーク両モードに最適化したトーンを返す
+    var multiStepAccent: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            return Color(red: 0.35, green: 0.85, blue: 0.95)
+        default:
+            return Color(red: 0.0, green: 0.68, blue: 0.86)
+        }
+    }
+
     /// 現在位置マーカーの縁取り色
     var startMarkerStroke: Color {
         switch resolvedColorScheme {


### PR DESCRIPTION
## Summary
- add a public `MoveCardKind` classification and expose unit direction vectors for ray cards
- introduce a cyan accent in the theme and rework `MoveCardIllustrationView` to draw multi-step paths with the new triple-arrow header icon
- update accessibility labels and hints to describe multi-step movement behaviour

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e342edb234832cbca2528630f9e021