### PR TITLE
Refine multi-step card styling and cyan board guides

### DIFF
--- a/Game/GameScenePalette.swift
+++ b/Game/GameScenePalette.swift
@@ -28,6 +28,8 @@ public struct GameScenePalette {
     public let boardKnight: SKColor
     /// ガイド枠の線色
     public let boardGuideHighlight: SKColor
+    /// 複数マス移動カード専用のガイド線色
+    public let boardMultiStepHighlight: SKColor
     /// ワープ効果のアクセントカラー
     public let boardTileEffectWarp: SKColor
     /// 手札シャッフル効果のアクセントカラー
@@ -45,6 +47,7 @@ public struct GameScenePalette {
     ///   - boardTileImpassable: 移動不可マスの塗り色
     ///   - boardKnight: 駒の塗り色
     ///   - boardGuideHighlight: ガイド枠の線色
+    ///   - boardMultiStepHighlight: 複数マス移動ガイドの線色
     public init(
         boardBackground: SKColor,
         boardGridLine: SKColor,
@@ -56,6 +59,7 @@ public struct GameScenePalette {
         boardTileImpassable: SKColor,
         boardKnight: SKColor,
         boardGuideHighlight: SKColor,
+        boardMultiStepHighlight: SKColor,
         boardTileEffectWarp: SKColor,
         boardTileEffectShuffle: SKColor
     ) {
@@ -69,6 +73,7 @@ public struct GameScenePalette {
         self.boardTileImpassable = boardTileImpassable
         self.boardKnight = boardKnight
         self.boardGuideHighlight = boardGuideHighlight
+        self.boardMultiStepHighlight = boardMultiStepHighlight
         self.boardTileEffectWarp = boardTileEffectWarp
         self.boardTileEffectShuffle = boardTileEffectShuffle
     }
@@ -97,6 +102,8 @@ public extension GameScenePalette {
         boardKnight: SKColor(white: 0.1, alpha: 1.0),
         // NOTE: SwiftUI のライトテーマと同じ彩度を抑えたオレンジを採用し、テーマ適用前でも一貫した強調色を維持する
         boardGuideHighlight: SKColor(red: 0.94, green: 0.41, blue: 0.08, alpha: 0.85),
+        // NOTE: 連続移動カードはカード枠と同じシアンを用い、盤面でも一目で識別できるようにする
+        boardMultiStepHighlight: SKColor(red: 0.0, green: 0.68, blue: 0.86, alpha: 0.88),
         // NOTE: ワープ効果は高コントラストなライトブルーを採用し、盤面上で瞬時に目に入るようにする
         boardTileEffectWarp: SKColor(red: 0.36, green: 0.56, blue: 0.98, alpha: 0.95),
         // NOTE: 手札シャッフルはモノトーン基調を維持しつつも差別化できるようニュートラルグレーを活用する
@@ -121,6 +128,8 @@ public extension GameScenePalette {
         boardKnight: SKColor(white: 0.95, alpha: 1.0),
         // NOTE: ダークテーマに合わせて明度を上げたオレンジを用い、背景の暗さに負けない発光感を演出する
         boardGuideHighlight: SKColor(red: 1.0, green: 0.74, blue: 0.38, alpha: 0.9),
+        // NOTE: 連続移動カードのシアンもダークテーマ向けに明度を調整し、背景との差を確保する
+        boardMultiStepHighlight: SKColor(red: 0.35, green: 0.85, blue: 0.95, alpha: 0.92),
         // NOTE: ダークテーマのワープも明度を高めた青系で描画し、夜間でも視認できる発光感を持たせる
         boardTileEffectWarp: SKColor(red: 0.56, green: 0.75, blue: 1.0, alpha: 0.95),
         // NOTE: シャッフルはライトテーマよりも明度を上げ、背景とのコントラストを十分に確保する

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -503,6 +503,19 @@ struct AppTheme: DynamicProperty {
         }
     }
 
+    /// 複数マス移動カード専用のガイド枠色
+    /// - Note: カード枠と同系統のシアンを採用し、盤面とカードで視覚的な関連性を持たせる
+    var boardMultiStepHighlight: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            // ダークテーマでは発光感を出しつつ背景になじむよう、やや高めの透明度を設定する
+            return Color(red: 0.35, green: 0.85, blue: 0.95).opacity(0.92)
+        default:
+            // ライトテーマでは鮮やかさと可読性のバランスを保つため、少しだけ透過させたシアンを用いる
+            return Color(red: 0.0, green: 0.68, blue: 0.86).opacity(0.88)
+        }
+    }
+
     /// ワープ効果を描画する際のアクセントカラー
     var boardTileEffectWarp: Color {
         switch resolvedColorScheme {
@@ -629,6 +642,14 @@ struct AppTheme: DynamicProperty {
         )
     }
 
+    /// SpriteKit 複数マス移動カード用ガイド枠の UIColor 版
+    var uiBoardMultiStepHighlight: UIColor {
+        dynamicUIColor(
+            light: color(for: .light, keyPath: \.boardMultiStepHighlight),
+            dark: color(for: .dark, keyPath: \.boardMultiStepHighlight)
+        )
+    }
+
     /// SpriteKit ワープ効果カラーの UIColor 版
     var uiBoardTileEffectWarp: UIColor {
         dynamicUIColor(
@@ -676,6 +697,9 @@ struct AppTheme: DynamicProperty {
 
     /// SpriteKit の SKColor へ変換したガイドハイライト色
     var skBoardGuideHighlight: SKColor { SKColor(cgColor: uiBoardGuideHighlight.cgColor) }
+
+    /// SpriteKit の SKColor へ変換した複数マス移動カード用ガイド色
+    var skBoardMultiStepHighlight: SKColor { SKColor(cgColor: uiBoardMultiStepHighlight.cgColor) }
 
     /// SpriteKit の SKColor へ変換したワープ効果カラー
     var skBoardTileEffectWarp: SKColor { SKColor(cgColor: uiBoardTileEffectWarp.cgColor) }


### PR DESCRIPTION
## Summary
- apply the cyan accent to multi-step card borders and streamline the illustration layout
- extend the theme and palette with multi-step highlight colors and bucket multi-step destinations separately
- update SpriteKit highlight rendering so cyan frames avoid overlapping existing guide outlines

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e34986ca68832cb98ba84a44644db8