### PR TITLE
Revise warp card visuals and ordering

### DIFF
--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -135,6 +135,26 @@ struct AppTheme: DynamicProperty {
         }
     }
 
+    /// ワープ系カード全体に使う紫系アクセント色
+    var warpCardAccent: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            return Color(red: 0.70, green: 0.55, blue: 0.93)
+        default:
+            return Color(red: 0.56, green: 0.42, blue: 0.86)
+        }
+    }
+
+    /// スーパーワープカード専用の明るいアクセント色
+    var superWarpCardAccent: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            return Color(red: 0.80, green: 0.62, blue: 0.98)
+        default:
+            return Color(red: 0.64, green: 0.48, blue: 0.92)
+        }
+    }
+
     /// 盤面中央セルのハイライト色（手札用）
     var centerHighlightHand: Color {
         switch resolvedColorScheme {


### PR DESCRIPTION
## Summary
- add dedicated purple accents and warp destination markers for fixed and super warp card illustrations
- ensure direction-sorted hands place warp cards after relative cards and always push super warp cards to the far right

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e34ad24240832c91c6ed01101590f8