### PR TITLE
Fix multi-step card detection in guide highlights

### DIFF
--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -243,7 +243,7 @@ final class GameBoardBridgeViewModel: ObservableObject {
             guard let representative = moves.first else { continue }
             let destinations = moves.map { $0.destination }
 
-            if representative.card.kind == .multiStep {
+            if representative.card.move.kind == .multiStep {
                 // 連続移動カードは専用のシアン枠で描画するため、別バケットへ振り分ける
                 computedBuckets.multiStepDestinations.formUnion(destinations)
             } else if representative.card.move.movementVectors.count > 1 {


### PR DESCRIPTION
## Summary
- 修正: 連続移動カードのハイライト判定で `DealtCard` が持つ `MoveCard` の種別を参照するように更新

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68e350755384832c8d8d9b0f68809d2d