### PR TITLE
Adjust hand card background contrast in light mode

### DIFF
--- a/UI/MoveCardIllustrationView.swift
+++ b/UI/MoveCardIllustrationView.swift
@@ -447,12 +447,15 @@ struct HandStackCardView<Content: View>: View {
                     ForEach(0..<backgroundLayerCount, id: \.self) { index in
                         let offset = CGFloat(index + 1) * 4
                         RoundedRectangle(cornerRadius: 8)
-                            .fill(theme.cardBackgroundHand.opacity(0.55))
+                            // 手札カードが白基調になったため、半透明で重ねても階層が認識できるように濃度を上げる
+                            .fill(theme.cardBackgroundHand.opacity(0.72))
                             .overlay(
                                 RoundedRectangle(cornerRadius: 8)
-                                    .stroke(theme.cardBorderHand.opacity(0.35), lineWidth: 1)
+                                    // 枠線も白背景に埋もれないよう、わずかに濃いトーンへ調整する
+                                    .stroke(theme.cardBorderHand.opacity(0.45), lineWidth: 1)
                             )
-                            .shadow(color: theme.cardBorderHand.opacity(0.18), radius: 4, x: 0, y: 2)
+                            // 影はダークモードでも違和感が出ないよう控えめに保ちつつ、カードの重なりを伝える
+                            .shadow(color: theme.cardBorderHand.opacity(0.22), radius: 4, x: 0, y: 2)
                             .offset(x: offset, y: offset)
                             .accessibilityHidden(true)
                     }

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -101,7 +101,8 @@ struct AppTheme: DynamicProperty {
         case .dark:
             return Color.white.opacity(0.08)
         default:
-            return Color.black.opacity(0.05)
+            // ライトモードでは NEXT カードとの差を強調するため、明度の高いホワイト基調を採用する
+            return Color.white
         }
     }
 


### PR DESCRIPTION
## Summary
- brighten the light-mode hand card background to improve contrast with the NEXT queue
- tweak hand stack background layers to keep depth cues with the new white base

## Testing
- Not run (simulator access required)

------
https://chatgpt.com/codex/tasks/task_e_68e3574848b0832c99c0bb63ae4d9748