### PR TITLE
Implement penalty-free redraw for shuffle tiles

### DIFF
--- a/Game/GameCore.swift
+++ b/Game/GameCore.swift
@@ -310,9 +310,8 @@ public final class GameCore: ObservableObject {
         rebuildHandAndNext(preferredInsertionIndices: removedIndex.map { [$0] } ?? [])
 
         if requiresHandShuffle {
-            var generator = SystemRandomNumberGenerator()
-            handManager.shuffleForTileEffect(using: &generator)
-            refreshHandStateFromManager()
+            // --- シャッフルマスの効果が発動した場合は、手動ペナルティと同様に手札・NEXT を丸ごと引き直す（ペナルティ加算なし） ---
+            applyTileEffectHandRedraw()
         }
 
         // クリア判定


### PR DESCRIPTION
## Summary
- replace the shuffle tile branch with a penalty-free hand/NEXT rebuild shared helper
- add a dedicated redraw routine for tile effects that mirrors manual redraw flow without increasing penalties
- cover the shuffle tile behaviour with a deterministic test that confirms new cards are dealt and no penalty event is emitted

## Testing
- `swift test` *(fails: GameCoreAvailableMovesTests.testSuperWarpExcludesVisitedAndImpassableTiles already failing on the base branch)*

------
https://chatgpt.com/codex/tasks/task_e_68e3573b691c832c9326536aa298eaf4