### PR TITLE
Fix hexagram fill rule assignment

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -1389,9 +1389,8 @@
                     }
                     starPath.closeSubpath()
                 }
-                // SpriteKit 側で fillRule プロパティが公開されていない環境でも
-                // 中央をくり抜いた六芒星を描画できるよう、CGPath 側の even-odd ルールを使用する
-                starPath.usesEvenOddFillRule = true
+                // SKShapeNode 側で偶奇塗りつぶしルールを指定し、中央をくり抜いた六芒星を描画する
+                hexagram.fillRule = .evenOdd
                 hexagram.path = starPath
                 hexagram.lineWidth = max(1.0, tileSize * 0.032)
                 hexagram.position = .zero


### PR DESCRIPTION
## Summary
- replace the unsupported CGMutablePath fill rule assignment with the SKShapeNode fillRule property to keep the hexagram cutout rendering correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e36340a7b8832c9d286787cadde717