### PR TITLE
Fix hexagram drawing without SpriteKit fillRule

### DIFF
--- a/Game/GameScene.swift
+++ b/Game/GameScene.swift
@@ -1389,8 +1389,9 @@
                     }
                     starPath.closeSubpath()
                 }
-                // SKShapeNode 側で偶奇塗りつぶしルールを指定し、中央をくり抜いた六芒星を描画する
-                hexagram.fillRule = .evenOdd
+                // CoreGraphics 側のパスに偶奇塗りつぶしを指定し、古い SpriteKit でも同じくり抜き効果を再現する
+                starPath.usesEvenOddFillRule = true
+                // SKShapeNode が保持するパスへ偶奇ルールを適用した形状を渡し、六芒星の中央を透明に保つ
                 hexagram.path = starPath
                 hexagram.lineWidth = max(1.0, tileSize * 0.032)
                 hexagram.position = .zero


### PR DESCRIPTION
## Summary
- ensure the hexagram tile effect uses the CoreGraphics even-odd fill rule on its path
- keep the hollow center rendering working even when SKShapeNode.fillRule is unavailable

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e363bb2544832cbae4cead36f9ac8c