### PR TITLE
Implement per-card fixed warp destinations and purple warp guides

### DIFF
--- a/Game/DealtCard.swift
+++ b/Game/DealtCard.swift
@@ -8,13 +8,17 @@ public struct DealtCard: Identifiable, Equatable {
     public let id: UUID
     /// これまでのロジックが扱っていた移動カード本体
     public let move: MoveCard
+    /// 固定ワープカード専用の目的地（それ以外のカードでは nil）
+    /// - Note: カードごとに固有のワープ先を持たせるためのメタデータを保持し、GameCore からも参照できるようにする
+    public let fixedWarpDestination: GridPoint?
 
     /// 新しいカードを生成する
     /// - Parameters:
     ///   - id: 既存カードからラップし直す場合に利用する識別子（省略時は新規採番）
     ///   - move: 実際の移動ロジックを担う `MoveCard`
-    public init(id: UUID = UUID(), move: MoveCard) {
+    public init(id: UUID = UUID(), move: MoveCard, fixedWarpDestination: GridPoint? = nil) {
         self.id = id
         self.move = move
+        self.fixedWarpDestination = fixedWarpDestination
     }
 }

--- a/Game/GameMode.swift
+++ b/Game/GameMode.swift
@@ -810,6 +810,11 @@ public struct GameMode: Equatable, Identifiable {
     public var tileEffectOverrides: [GridPoint: TileEffect] { regulation.tileEffectOverrides }
     /// 固定ワープカード用の目的地辞書
     public var fixedWarpCardTargets: [MoveCard: [GridPoint]] { regulation.fixedWarpCardTargets }
+    /// 固定ワープカードが利用する目的地集合（Deck で順番に割り当てる）
+    /// - Note: `.fixedWarp` キーに対応する座標リストのみを公開し、カード配布時のメタデータとして活用する
+    public var fixedWarpDestinationPool: [GridPoint] {
+        regulation.fixedWarpCardTargets[.fixedWarp] ?? []
+    }
 
     /// 盤面へ適用するタイル効果を合成して返す
     /// - Important: ワープ定義は自動的に `TileEffect.warp` へ展開し、個別指定された効果より優先度は低い（手動指定があればそちらを採用）

--- a/Game/GameScenePalette.swift
+++ b/Game/GameScenePalette.swift
@@ -30,6 +30,8 @@ public struct GameScenePalette {
     public let boardGuideHighlight: SKColor
     /// 複数マス移動カード専用のガイド線色
     public let boardMultiStepHighlight: SKColor
+    /// ワープカード専用のガイド線色
+    public let boardWarpHighlight: SKColor
     /// ワープ効果の基準アクセントカラー
     public let boardTileEffectWarp: SKColor
     /// ワープペアごとに使い分けるアクセントカラー配列
@@ -63,6 +65,7 @@ public struct GameScenePalette {
         boardKnight: SKColor,
         boardGuideHighlight: SKColor,
         boardMultiStepHighlight: SKColor,
+        boardWarpHighlight: SKColor,
         boardTileEffectWarp: SKColor,
         boardTileEffectShuffle: SKColor,
         warpPairAccentColors: [SKColor]
@@ -78,6 +81,7 @@ public struct GameScenePalette {
         self.boardKnight = boardKnight
         self.boardGuideHighlight = boardGuideHighlight
         self.boardMultiStepHighlight = boardMultiStepHighlight
+        self.boardWarpHighlight = boardWarpHighlight
         self.boardTileEffectWarp = boardTileEffectWarp
         self.boardTileEffectShuffle = boardTileEffectShuffle
         self.warpPairAccentColors = warpPairAccentColors
@@ -109,6 +113,8 @@ public extension GameScenePalette {
         boardGuideHighlight: SKColor(red: 0.94, green: 0.41, blue: 0.08, alpha: 0.85),
         // NOTE: 連続移動カードはカード枠と同じシアンを用い、盤面でも一目で識別できるようにする
         boardMultiStepHighlight: SKColor(red: 0.0, green: 0.68, blue: 0.86, alpha: 0.88),
+        // NOTE: ワープカードのガイド枠はカード枠と統一した紫を採用し、カテゴリー差を明確にする
+        boardWarpHighlight: SKColor(red: 0.56, green: 0.42, blue: 0.86, alpha: 0.9),
         // NOTE: ワープ効果は高コントラストなライトブルーを採用し、盤面上で瞬時に目に入るようにする
         boardTileEffectWarp: SKColor(red: 0.36, green: 0.56, blue: 0.98, alpha: 0.95),
         // NOTE: 手札シャッフルはモノトーン基調を維持しつつも差別化できるようニュートラルグレーを活用する
@@ -144,6 +150,8 @@ public extension GameScenePalette {
         boardGuideHighlight: SKColor(red: 1.0, green: 0.74, blue: 0.38, alpha: 0.9),
         // NOTE: 連続移動カードのシアンもダークテーマ向けに明度を調整し、背景との差を確保する
         boardMultiStepHighlight: SKColor(red: 0.35, green: 0.85, blue: 0.95, alpha: 0.92),
+        // NOTE: ダークテーマのワープ枠も明度を上げた紫で描画し、暗所でも識別しやすくする
+        boardWarpHighlight: SKColor(red: 0.70, green: 0.55, blue: 0.93, alpha: 0.92),
         // NOTE: ダークテーマのワープも明度を高めた青系で描画し、夜間でも視認できる発光感を持たせる
         boardTileEffectWarp: SKColor(red: 0.56, green: 0.75, blue: 1.0, alpha: 0.95),
         // NOTE: シャッフルはライトテーマよりも明度を上げ、背景とのコントラストを十分に確保する

--- a/MonoKnightAppTests/GameBoardBridgeViewModelHighlightTests.swift
+++ b/MonoKnightAppTests/GameBoardBridgeViewModelHighlightTests.swift
@@ -110,6 +110,26 @@ final class GameBoardBridgeViewModelHighlightTests: XCTestCase {
         XCTAssertNil(viewModel.pendingGuideCurrent, "ガイド復元後は pending 現在地を解放する必要があります")
     }
 
+    /// ワープカードが専用の紫ガイド集合へ分類されることを検証する
+    func testRefreshGuideHighlightsSeparatesWarpCandidates() {
+        let viewModel = makeViewModel()
+        let origin = GridPoint(x: 2, y: 2)
+        let warpDestination = GridPoint(x: 2, y: 3)
+
+        let warpStack = HandStack(cards: [DealtCard(move: .fixedWarp, fixedWarpDestination: warpDestination)])
+
+        viewModel.refreshGuideHighlights(
+            handOverride: [warpStack],
+            currentOverride: origin,
+            progressOverride: .playing
+        )
+
+        let buckets = viewModel.guideHighlightBuckets
+        XCTAssertTrue(buckets.warpDestinations.contains(warpDestination), "ワープ専用集合に目的地が含まれていません")
+        XCTAssertTrue(buckets.singleVectorDestinations.isEmpty, "ワープカードが単一候補集合へ混入しています")
+        XCTAssertTrue(buckets.multipleVectorDestinations.isEmpty, "ワープカードが複数候補集合へ混入しています")
+    }
+
     /// 強制ハイライトが障害物マスを除外することを検証する
     func testForcedSelectionHighlightsExcludeImpassableTiles() {
         // --- 移動不可マスを含むモードを構築し、ViewModel に適用 ---

--- a/UI/Theme/AppTheme.swift
+++ b/UI/Theme/AppTheme.swift
@@ -537,6 +537,17 @@ struct AppTheme: DynamicProperty {
         }
     }
 
+    /// ワープカード専用のガイド枠色
+    /// - Note: カード枠と同系統の紫を採用し、カード種類との視覚的一貫性を維持する
+    var boardWarpHighlight: Color {
+        switch resolvedColorScheme {
+        case .dark:
+            return Color(red: 0.70, green: 0.55, blue: 0.93).opacity(0.92)
+        default:
+            return Color(red: 0.56, green: 0.42, blue: 0.86).opacity(0.9)
+        }
+    }
+
     /// ワープ効果を描画する際のアクセントカラー
     var boardTileEffectWarp: Color {
         switch resolvedColorScheme {
@@ -671,6 +682,14 @@ struct AppTheme: DynamicProperty {
         )
     }
 
+    /// SpriteKit ワープカード用ガイド枠の UIColor 版
+    var uiBoardWarpHighlight: UIColor {
+        dynamicUIColor(
+            light: color(for: .light, keyPath: \.boardWarpHighlight),
+            dark: color(for: .dark, keyPath: \.boardWarpHighlight)
+        )
+    }
+
     /// SpriteKit ワープ効果カラーの UIColor 版
     var uiBoardTileEffectWarp: UIColor {
         dynamicUIColor(
@@ -746,6 +765,8 @@ struct AppTheme: DynamicProperty {
 
     /// SpriteKit の SKColor へ変換した複数マス移動カード用ガイド色
     var skBoardMultiStepHighlight: SKColor { SKColor(cgColor: uiBoardMultiStepHighlight.cgColor) }
+    /// SpriteKit の SKColor へ変換したワープガイド色
+    var skBoardWarpHighlight: SKColor { SKColor(cgColor: uiBoardWarpHighlight.cgColor) }
 
     /// SpriteKit の SKColor へ変換したワープ効果カラー
     var skBoardTileEffectWarp: SKColor { SKColor(cgColor: uiBoardTileEffectWarp.cgColor) }


### PR DESCRIPTION
## Summary
- attach each fixed warp card with its own destination metadata and rotate assignments when drawing
- update GameCore and view logic to only allow warps to their card-specific destination and surface warp highlights separately
- align theme/palette and SpriteKit guide rendering/tests to use the new purple warp styling

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e370b88148832c9ab0ce2596f9bed1