### PR TITLE
Update warp card illustration to highlight assigned destination

### DIFF
--- a/UI/GameCardAnimationOverlay.swift
+++ b/UI/GameCardAnimationOverlay.swift
@@ -43,7 +43,10 @@ private extension GameCardAnimationOverlay {
                 in: boardFrame
             )
 
-            MoveCardIllustrationView(card: animatingCard.move)
+            MoveCardIllustrationView(
+                card: animatingCard.move,
+                fixedWarpDestination: animatingCard.fixedWarpDestination // アニメーション中も固定ワープ先に合わせたカード絵柄を維持する
+            )
                 // 盤面オーバーレイ側は matchedGeometryEffect のターゲット役に固定し、
                 // 手札側のビューと同時に isSource: true になる事態を避けて警告を抑止する
                 .matchedGeometryEffect(

--- a/UI/GameHandSectionView.swift
+++ b/UI/GameHandSectionView.swift
@@ -76,7 +76,11 @@ private extension GameHandSectionView {
             HStack(spacing: 12) {
                 ForEach(Array(core.nextCards.enumerated()), id: \.element.id) { index, dealtCard in
                     ZStack {
-                        MoveCardIllustrationView(card: dealtCard.move, mode: .next)
+                        MoveCardIllustrationView(
+                            card: dealtCard.move,
+                            mode: .next,
+                            fixedWarpDestination: dealtCard.fixedWarpDestination // 固定ワープは目的地を渡して紫マーカーを正しい位置へ描く
+                        )
                             .opacity(boardBridge.hiddenCardIDs.contains(dealtCard.id) ? 0.0 : 1.0)
                             .matchedGeometryEffect(id: dealtCard.id, in: cardAnimationNamespace)
                             .anchorPreference(key: CardPositionPreferenceKey.self, value: .bounds) { [dealtCard.id: $0] }
@@ -157,7 +161,10 @@ private extension GameHandSectionView {
                 let shouldShowSelectionHighlight = isSelected && !isHidden && !isSelectingDiscard
 
                 HandStackCardView(stackCount: stack.count) {
-                    MoveCardIllustrationView(card: card.move)
+                    MoveCardIllustrationView(
+                        card: card.move,
+                        fixedWarpDestination: card.fixedWarpDestination // 手札表示でも固定ワープ先を反映したカードデザインにする
+                    )
                         .matchedGeometryEffect(id: card.id, in: cardAnimationNamespace)
                         .anchorPreference(key: CardPositionPreferenceKey.self, value: .bounds) { [card.id: $0] }
                 }


### PR DESCRIPTION
## Summary
- draw fixed warp cards with a single purple marker at the assigned board coordinate and hide the start marker
- thread fixed warp destinations through hand, next, and animation overlays so every warp card illustration reflects its own target
- extend accessibility copy to announce the fixed warp destination coordinates

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e3766ce558832c976adf18c0a213ec