### PR TITLE
Disable super warp guide highlights

### DIFF
--- a/UI/GameBoardBridgeViewModel.swift
+++ b/UI/GameBoardBridgeViewModel.swift
@@ -251,8 +251,13 @@ final class GameBoardBridgeViewModel: ObservableObject {
             let destinations = moves.map { $0.destination }
             let move = representative.card.move
 
-            if move == .fixedWarp || move == .superWarp {
-                // ワープ系カードは紫枠で視認性を高めるため専用バケットへ分類する
+            if move == .superWarp {
+                // スーパーワープは盤面全域が候補となりガイドが画面を覆ってしまうため、あえて登録しない
+                continue
+            }
+
+            if move == .fixedWarp {
+                // 固定ワープのみ紫枠で視認性を高めるため専用バケットへ分類する
                 computedBuckets.warpDestinations.formUnion(destinations)
                 continue
             }


### PR DESCRIPTION
## Summary
- skip registering super warp moves in the guide highlight buckets so the overlay stays hidden
- leave fixed warp cards using the dedicated warp highlight styling

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e3836dedac832cb9e55baccd416848